### PR TITLE
Redesign TUI layout with viewport-based scrolling (#10)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/viewport"
 	"github.com/dustinlange/agent-minder/internal/db"
 	"github.com/dustinlange/agent-minder/internal/poller"
 )
@@ -50,10 +52,18 @@ type Model struct {
 	height  int
 
 	// State.
-	events       []poller.Event
-	lastPoll     *poller.PollResult
-	pollExpanded bool
-	err          error
+	events   []poller.Event
+	lastPoll *poller.PollResult
+	err      error
+
+	// Viewports for scrollable sections.
+	analysisVP       viewport.Model
+	eventLogVP       viewport.Model
+	analysisExpanded bool // 'e' toggles 3-line vs proportional
+	showInfo         bool // 'i' toggles repos/topics detail
+
+	// Tracked items (refreshed on poll results).
+	trackedItems []db.TrackedItem
 
 	// Spinner for async operations.
 	spinner spinner.Model
@@ -71,6 +81,18 @@ type Model struct {
 	// Onboard mode.
 	onboardInput  textarea.Model
 	onboardStatus string
+}
+
+// safeViewportKeyMap returns a viewport KeyMap that only uses arrow keys and
+// pgup/pgdn, avoiding conflicts with app-level letter keybindings.
+func safeViewportKeyMap() viewport.KeyMap {
+	return viewport.KeyMap{
+		Up:       key.NewBinding(key.WithKeys("up")),
+		Down:     key.NewBinding(key.WithKeys("down")),
+		PageUp:   key.NewBinding(key.WithKeys("pgup")),
+		PageDown: key.NewBinding(key.WithKeys("pgdown")),
+		// HalfPageUp, HalfPageDown, Left, Right left as zero-value (disabled).
+	}
 }
 
 // New creates a new TUI model.
@@ -98,6 +120,16 @@ func New(project *db.Project, store *db.Store, p *poller.Poller) Model {
 	oi.SetHeight(3)
 	oi.SetWidth(80)
 
+	aVP := viewport.New()
+	aVP.KeyMap = safeViewportKeyMap()
+	aVP.SoftWrap = true
+	aVP.FillHeight = true
+
+	eVP := viewport.New()
+	eVP.KeyMap = safeViewportKeyMap()
+	eVP.SoftWrap = true
+	eVP.FillHeight = true
+
 	return Model{
 		project:        project,
 		store:          store,
@@ -108,6 +140,8 @@ func New(project *db.Project, store *db.Store, p *poller.Poller) Model {
 		userMsgInput:   ta,
 		onboardInput:   oi,
 		spinner:        sp,
+		analysisVP:     aVP,
+		eventLogVP:     eVP,
 	}
 }
 
@@ -124,6 +158,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.resizeViewports()
 		return m, nil
 
 	case tea.KeyPressMsg:
@@ -152,7 +187,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if event.PollResult != nil {
 			m.lastPoll = event.PollResult
 			m.polling = false
+			m.trackedItems, _ = m.store.GetTrackedItems(m.project.ID)
 		}
+		m.rebuildEventLogContent()
+		m.rebuildAnalysisContent()
 		return m, listenForEvents(m.poller)
 
 	case broadcastResultMsg:
@@ -161,7 +199,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.broadcastStatus = fmt.Sprintf("Sent to %s", msg.topic)
 		}
-		// Clear status after a delay by returning to normal mode.
 		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
 			return clearBroadcastStatusMsg{}
 		})
@@ -230,10 +267,17 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return nil
 		}
 	case "e":
-		m.pollExpanded = !m.pollExpanded
+		m.analysisExpanded = !m.analysisExpanded
+		m.resizeViewports()
+		return m, nil
+	case "i":
+		m.showInfo = !m.showInfo
+		m.resizeViewports()
 		return m, nil
 	case "t":
 		cycleTheme()
+		m.rebuildAnalysisContent()
+		m.rebuildEventLogContent()
 		return m, nil
 	case "u":
 		m.mode = "usermsg"
@@ -261,6 +305,10 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.onboardInput.SetWidth(m.width - 4)
 		}
 		cmd := m.onboardInput.Focus()
+		return m, cmd
+	case "up", "down", "pgup", "pgdown":
+		var cmd tea.Cmd
+		m.eventLogVP, cmd = m.eventLogVP.Update(msg)
 		return m, cmd
 	}
 	return m, nil
@@ -292,7 +340,6 @@ func (m Model) updateBroadcast(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Delegate to textarea (Enter inserts newline by default).
 	var cmd tea.Cmd
 	m.broadcastInput, cmd = m.broadcastInput.Update(msg)
 	return m, cmd
@@ -324,7 +371,6 @@ func (m Model) updateUserMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Delegate to textarea (Enter inserts newline by default).
 	var cmd tea.Cmd
 	m.userMsgInput, cmd = m.userMsgInput.Update(msg)
 	return m, cmd
@@ -356,227 +402,6 @@ func (m Model) updateOnboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m Model) View() tea.View {
-	if m.width == 0 {
-		return tea.NewView("Loading...")
-	}
-
-	var b strings.Builder
-
-	// Header.
-	status := statusRunningStyle().Render("RUNNING")
-	if m.poller.IsPaused() {
-		status = statusPausedStyle().Render("PAUSED")
-	}
-	b.WriteString(titleStyle().Render(fmt.Sprintf("agent-minder: %s", m.project.Name)))
-	b.WriteString("  ")
-	b.WriteString(status)
-	if m.polling {
-		b.WriteString("  ")
-		b.WriteString(m.spinner.View())
-		b.WriteString(" ")
-		b.WriteString(mutedStyle().Render("polling..."))
-	}
-	b.WriteString("  ")
-	b.WriteString(mutedStyle().Render(fmt.Sprintf("[%s]", currentTheme().Name)))
-	b.WriteString("\n")
-
-	// Goal.
-	goalText := fmt.Sprintf("  %s — %s", m.project.GoalType, m.project.GoalDescription)
-	b.WriteString(mutedStyle().Width(m.width).Render(goalText))
-	b.WriteString("\n\n")
-
-	// Repos section.
-	repos, _ := m.store.GetRepos(m.project.ID)
-	b.WriteString(headerStyle().Render("Repos"))
-	b.WriteString("\n")
-	for _, r := range repos {
-		b.WriteString(textStyle().Render(fmt.Sprintf("  %s (%s)", r.ShortName, r.Path)))
-		b.WriteString("\n")
-	}
-	b.WriteString("\n")
-
-	// Topics.
-	topics, _ := m.store.GetTopics(m.project.ID)
-	if len(topics) > 0 {
-		b.WriteString(headerStyle().Render("Topics"))
-		b.WriteString("\n")
-		for _, t := range topics {
-			b.WriteString(textStyle().Render(fmt.Sprintf("  %s", t.Name)))
-			b.WriteString("\n")
-		}
-		b.WriteString("\n")
-	}
-
-	// Active concerns (capped to avoid pushing controls off screen).
-	concerns, _ := m.store.ActiveConcerns(m.project.ID)
-	if len(concerns) > 0 {
-		maxConcerns := 5
-		b.WriteString(headerStyle().Render(fmt.Sprintf("Active Concerns (%d)", len(concerns))))
-		b.WriteString("\n")
-		shown := concerns
-		if len(shown) > maxConcerns {
-			shown = shown[:maxConcerns]
-		}
-		for _, c := range shown {
-			style := concernInfoStyle().Width(m.width - 2)
-			prefix := "INFO"
-			switch c.Severity {
-			case "warning":
-				style = concernWarningStyle().Width(m.width - 2)
-				prefix = "WARN"
-			case "danger":
-				style = concernDangerStyle().Width(m.width - 2)
-				prefix = "DANGER"
-			}
-			b.WriteString(style.Render(fmt.Sprintf("  [%s] %s", prefix, c.Message)))
-			b.WriteString("\n")
-		}
-		if len(concerns) > maxConcerns {
-			b.WriteString(mutedStyle().Render(fmt.Sprintf("  ... +%d more", len(concerns)-maxConcerns)))
-			b.WriteString("\n")
-		}
-		b.WriteString("\n")
-	}
-
-	// Last poll result.
-	expandHint := "e: expand"
-	if m.pollExpanded {
-		expandHint = "e: collapse"
-	}
-	b.WriteString(headerStyle().Render("Last Poll"))
-	b.WriteString("  ")
-	b.WriteString(mutedStyle().Render(fmt.Sprintf("[%s]", expandHint)))
-	b.WriteString("\n")
-	if m.lastPoll != nil {
-		b.WriteString(mutedStyle().Render(fmt.Sprintf("  %d commits, %d messages (took %s)",
-			m.lastPoll.NewCommits, m.lastPoll.NewMessages, m.lastPoll.Duration.Round(time.Millisecond))))
-		b.WriteString("\n")
-		if m.lastPoll.BusMessageSent != "" {
-			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  >> Bus: %s", m.lastPoll.BusMessageSent)))
-			b.WriteString("\n")
-		}
-		response := m.lastPoll.LLMResponse()
-		if response != "" {
-			if !m.pollExpanded {
-				// Truncate to ~3 lines.
-				lines := strings.Split(response, "\n")
-				if len(lines) > 3 {
-					response = strings.Join(lines[:3], "\n") + "\n  ..."
-				}
-			}
-			b.WriteString(llmResponseStyle().Width(m.width - 2).Render(response))
-			b.WriteString("\n")
-		}
-	} else {
-		b.WriteString(mutedStyle().Render("  Waiting for first poll..."))
-		b.WriteString("\n")
-	}
-	b.WriteString("\n")
-
-	// Event log — dynamically sized to fit remaining terminal height.
-	// Count lines used so far (approximate: count newlines in buffer).
-	linesUsed := strings.Count(b.String(), "\n")
-	bottomLines := 4 // help bar + broadcast bar + padding
-	maxEvents := m.height - linesUsed - bottomLines
-	if maxEvents < 3 {
-		maxEvents = 3
-	}
-	if maxEvents > 10 {
-		maxEvents = 10
-	}
-
-	b.WriteString(headerStyle().Render("Event Log"))
-	b.WriteString("\n")
-	start := 0
-	if len(m.events) > maxEvents {
-		start = len(m.events) - maxEvents
-	}
-	for i := len(m.events) - 1; i >= start; i-- {
-		e := m.events[i]
-		ts := e.Time.Format("15:04:05")
-		b.WriteString(mutedStyle().Render(fmt.Sprintf("  [%s] %s: %s", ts, e.Type, e.Summary)))
-		b.WriteString("\n")
-	}
-	if len(m.events) == 0 {
-		b.WriteString(mutedStyle().Render("  (no events yet)"))
-		b.WriteString("\n")
-	}
-
-	// Bottom bar: input or help.
-	b.WriteString("\n")
-	switch m.mode {
-	case "broadcast":
-		if m.broadcastStatus == "Sending..." {
-			b.WriteString("  ")
-			b.WriteString(m.spinner.View())
-			b.WriteString(" ")
-			b.WriteString(broadcastStyle().Render("Sending broadcast..."))
-		} else if m.broadcastStatus != "" {
-			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.broadcastStatus)))
-		} else {
-			b.WriteString("  ")
-			b.WriteString(m.broadcastInput.View())
-		}
-		b.WriteString("\n")
-		if m.broadcastStatus == "" {
-			b.WriteString(helpStyle().Render("ctrl+d: send • esc: cancel"))
-		}
-		b.WriteString("\n")
-	case "usermsg":
-		if m.userMsgStatus == "Posting..." {
-			b.WriteString("  ")
-			b.WriteString(m.spinner.View())
-			b.WriteString(" ")
-			b.WriteString(userMsgStyle().Render("Posting message..."))
-		} else if m.userMsgStatus != "" {
-			b.WriteString(userMsgStyle().Render(fmt.Sprintf("  %s", m.userMsgStatus)))
-		} else {
-			b.WriteString("  ")
-			b.WriteString(m.userMsgInput.View())
-		}
-		b.WriteString("\n")
-		if m.userMsgStatus == "" {
-			b.WriteString(helpStyle().Render("ctrl+d: send • esc: cancel"))
-		}
-		b.WriteString("\n")
-	case "onboard":
-		if m.onboardStatus != "" && m.onboardStatus != "Generating onboarding message..." {
-			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.onboardStatus)))
-		} else if m.onboardStatus == "Generating onboarding message..." {
-			b.WriteString("  ")
-			b.WriteString(m.spinner.View())
-			b.WriteString(" ")
-			b.WriteString(broadcastStyle().Render("Generating onboarding message..."))
-		} else {
-			b.WriteString(headerStyle().Render("  Onboard — optional guidance for the new agent:"))
-			b.WriteString("\n")
-			b.WriteString("  ")
-			b.WriteString(m.onboardInput.View())
-		}
-		b.WriteString("\n")
-		if m.onboardStatus == "" {
-			b.WriteString(helpStyle().Render("ctrl+d: generate & publish • esc: cancel (leave empty for generic onboarding)"))
-		}
-		b.WriteString("\n")
-	default:
-		if m.broadcastStatus != "" {
-			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.broadcastStatus)))
-			b.WriteString("\n")
-		}
-		if m.userMsgStatus != "" {
-			b.WriteString(userMsgStyle().Render(fmt.Sprintf("  %s", m.userMsgStatus)))
-			b.WriteString("\n")
-		}
-		b.WriteString(renderHelpBar(m.width))
-		b.WriteString("\n")
-	}
-
-	v := tea.NewView(b.String())
-	v.AltScreen = true
-	return v
-}
-
 // listenForEvents returns a command that waits for the next poller event.
 func listenForEvents(p *poller.Poller) tea.Cmd {
 	return func() tea.Msg {
@@ -586,44 +411,6 @@ func listenForEvents(p *poller.Poller) tea.Cmd {
 		}
 		return pollerEventMsg(event)
 	}
-}
-
-// renderHelpBar builds a two-row help bar with styled key hints.
-func renderHelpBar(width int) string {
-	keyStyle := helpKeyStyle()
-	descStyle := helpStyle()
-	sep := descStyle.Render(" • ")
-
-	type hint struct {
-		key  string
-		desc string
-	}
-
-	hints := []hint{
-		{"p", "pause/resume"},
-		{"r", "poll now"},
-		{"e", "expand"},
-		{"u", "user msg"},
-		{"m", "broadcast"},
-		{"o", "onboard"},
-		{"t", "theme"},
-		{"q", "quit"},
-	}
-
-	var row1, row2 strings.Builder
-	for i, h := range hints {
-		entry := keyStyle.Render(h.key) + descStyle.Render(": "+h.desc)
-		target := &row1
-		if i >= 4 {
-			target = &row2
-		}
-		if target.Len() > 0 {
-			target.WriteString(sep)
-		}
-		target.WriteString(entry)
-	}
-
-	return row1.String() + "\n" + row2.String()
 }
 
 // tickEvery returns a command that sends a tick every 5 seconds.

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1,0 +1,465 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// View renders the TUI dashboard with height-budgeted sections.
+func (m Model) View() tea.View {
+	if m.width == 0 {
+		return tea.NewView("Loading...")
+	}
+
+	var b strings.Builder
+
+	// Header (2 lines: title row + goal row).
+	b.WriteString(m.renderHeader())
+	b.WriteString("\n")
+
+	// Info detail (repos/topics) — only when toggled.
+	if m.showInfo {
+		b.WriteString(m.renderInfoDetail())
+		b.WriteString("\n")
+	}
+
+	// Active concerns.
+	concerns := m.renderConcerns()
+	if concerns != "" {
+		b.WriteString(concerns)
+		b.WriteString("\n")
+	}
+
+	// Tracked items strip.
+	tracked := m.renderTrackedStrip()
+	if tracked != "" {
+		b.WriteString(tracked)
+		b.WriteString("\n")
+	}
+
+	// Analysis section.
+	expandHint := "e: expand"
+	if m.analysisExpanded {
+		expandHint = "e: collapse"
+	}
+	b.WriteString(headerStyle().Render("Last Analysis"))
+	b.WriteString("  ")
+	b.WriteString(mutedStyle().Render(fmt.Sprintf("[%s]", expandHint)))
+	if m.lastPoll != nil {
+		b.WriteString("  ")
+		b.WriteString(mutedStyle().Render(m.lastPoll.Duration.Round(time.Millisecond).String()))
+	}
+	b.WriteString("\n")
+	b.WriteString(m.analysisVP.View())
+	b.WriteString("\n\n")
+
+	// Event log section.
+	b.WriteString(headerStyle().Render("Event Log"))
+	scrollHint := ""
+	if !m.eventLogVP.AtTop() || !m.eventLogVP.AtBottom() {
+		pct := m.eventLogVP.ScrollPercent()
+		scrollHint = fmt.Sprintf("  [%.0f%%]", pct*100)
+	}
+	if scrollHint != "" {
+		b.WriteString(mutedStyle().Render(scrollHint))
+	}
+	b.WriteString("\n")
+	b.WriteString(m.eventLogVP.View())
+	b.WriteString("\n")
+
+	// Bottom bar: input or help.
+	b.WriteString(m.renderBottomBar())
+
+	v := tea.NewView(b.String())
+	v.AltScreen = true
+	return v
+}
+
+// renderHeader returns the compact 2-line header with inline repo/topic counts.
+func (m Model) renderHeader() string {
+	var b strings.Builder
+
+	// Line 1: title + status + counts + spinner + theme.
+	status := statusRunningStyle().Render("RUNNING")
+	if m.poller.IsPaused() {
+		status = statusPausedStyle().Render("PAUSED")
+	}
+	b.WriteString(titleStyle().Render(fmt.Sprintf("agent-minder: %s", m.project.Name)))
+	b.WriteString("  ")
+	b.WriteString(status)
+
+	repos, _ := m.store.GetRepos(m.project.ID)
+	topics, _ := m.store.GetTopics(m.project.ID)
+	b.WriteString("  ")
+	b.WriteString(mutedStyle().Render(fmt.Sprintf("%d repos", len(repos))))
+	b.WriteString(mutedStyle().Render(" \u2022 "))
+	b.WriteString(mutedStyle().Render(fmt.Sprintf("%d topics", len(topics))))
+
+	if m.polling {
+		b.WriteString("  ")
+		b.WriteString(m.spinner.View())
+		b.WriteString(" ")
+		b.WriteString(mutedStyle().Render("polling..."))
+	}
+	b.WriteString("  ")
+	b.WriteString(mutedStyle().Render(fmt.Sprintf("[%s]", currentTheme().Name)))
+	b.WriteString("\n")
+
+	// Line 2: goal.
+	goalText := fmt.Sprintf("  %s \u2014 %s", m.project.GoalType, m.project.GoalDescription)
+	b.WriteString(mutedStyle().Width(m.width).Render(goalText))
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+// renderInfoDetail returns the expanded repos/topics listing (shown when showInfo is true).
+func (m Model) renderInfoDetail() string {
+	var b strings.Builder
+
+	repos, _ := m.store.GetRepos(m.project.ID)
+	b.WriteString(headerStyle().Render("Repos"))
+	b.WriteString("\n")
+	for _, r := range repos {
+		b.WriteString(textStyle().Render(fmt.Sprintf("  %s (%s)", r.ShortName, r.Path)))
+		b.WriteString("\n")
+	}
+
+	topics, _ := m.store.GetTopics(m.project.ID)
+	if len(topics) > 0 {
+		b.WriteString(headerStyle().Render("Topics"))
+		b.WriteString("\n")
+		for _, t := range topics {
+			b.WriteString(textStyle().Render(fmt.Sprintf("  %s", t.Name)))
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+// renderConcerns returns wrapped concerns, capped at maxConcernLines total.
+// If the wrapped output exceeds the cap, concerns are truncated to fit.
+func (m Model) renderConcerns() string {
+	concerns, _ := m.store.ActiveConcerns(m.project.ID)
+	if len(concerns) == 0 {
+		return ""
+	}
+
+	const maxConcernLines = 8
+	maxConcerns := 5
+
+	var b strings.Builder
+	b.WriteString(headerStyle().Render(fmt.Sprintf("Active Concerns (%d)", len(concerns))))
+	b.WriteString("\n")
+
+	shown := concerns
+	if len(shown) > maxConcerns {
+		shown = shown[:maxConcerns]
+	}
+
+	// Render each concern with wrapping, tracking total lines used.
+	linesUsed := 0
+	concertsShown := 0
+	for _, c := range shown {
+		prefix := "INFO"
+		style := concernInfoStyle()
+		switch c.Severity {
+		case "warning":
+			style = concernWarningStyle()
+			prefix = "WARN"
+		case "danger":
+			style = concernDangerStyle()
+			prefix = "DANGER"
+		}
+		rendered := style.Width(m.width - 2).Render(fmt.Sprintf("  [%s] %s", prefix, c.Message))
+		lineCount := strings.Count(rendered, "\n") + 1
+
+		if linesUsed+lineCount > maxConcernLines && concertsShown > 0 {
+			remaining := len(concerns) - concertsShown
+			b.WriteString(mutedStyle().Render(fmt.Sprintf("  ... +%d more", remaining)))
+			b.WriteString("\n")
+			return b.String()
+		}
+
+		b.WriteString(rendered)
+		b.WriteString("\n")
+		linesUsed += lineCount
+		concertsShown++
+	}
+
+	if len(concerns) > maxConcerns {
+		b.WriteString(mutedStyle().Render(fmt.Sprintf("  ... +%d more", len(concerns)-maxConcerns)))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// renderTrackedStrip returns a compact one-line tracked items display.
+func (m Model) renderTrackedStrip() string {
+	if len(m.trackedItems) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(headerStyle().Render(fmt.Sprintf("Tracked (%d)", len(m.trackedItems))))
+	b.WriteString("  ")
+
+	for i, item := range m.trackedItems {
+		if i > 0 {
+			b.WriteString("  ")
+		}
+		dot := statusDot(item.LastStatus)
+		b.WriteString(fmt.Sprintf("#%d %s", item.Number, dot))
+	}
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+// rebuildEventLogContent sets the event log viewport content with single-line entries.
+func (m *Model) rebuildEventLogContent() {
+	lines := make([]string, 0, len(m.events))
+	for i := len(m.events) - 1; i >= 0; i-- {
+		e := m.events[i]
+		ts := e.Time.Format("15:04:05")
+		summary := strings.ReplaceAll(e.Summary, "\n", " ")
+		summary = strings.Join(strings.Fields(summary), " ")
+		maxW := m.width - 22
+		if maxW < 20 {
+			maxW = 20
+		}
+		line := fmt.Sprintf("  [%s] %s: %s", ts, e.Type, truncateLine(summary, maxW))
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		lines = []string{"  (no events yet)"}
+	}
+	m.eventLogVP.SetContentLines(lines)
+}
+
+// rebuildAnalysisContent sets the analysis viewport content from the last poll.
+func (m *Model) rebuildAnalysisContent() {
+	if m.lastPoll == nil {
+		m.analysisVP.SetContent(mutedStyle().Render("  Waiting for first poll..."))
+		return
+	}
+	var b strings.Builder
+	b.WriteString(mutedStyle().Render(fmt.Sprintf("  %d commits, %d messages",
+		m.lastPoll.NewCommits, m.lastPoll.NewMessages)))
+	b.WriteString("\n")
+	if m.lastPoll.BusMessageSent != "" {
+		b.WriteString(broadcastStyle().Render(fmt.Sprintf("  >> Bus: %s", m.lastPoll.BusMessageSent)))
+		b.WriteString("\n")
+	}
+	response := m.lastPoll.LLMResponse()
+	if response != "" {
+		b.WriteString(llmResponseStyle().Width(m.width - 2).Render(response))
+	}
+	m.analysisVP.SetContent(b.String())
+}
+
+// resizeViewports computes the height budget and resizes both viewports.
+func (m *Model) resizeViewports() {
+	if m.width == 0 || m.height == 0 {
+		return
+	}
+
+	analysisH, eventLogH := m.computeHeightBudget()
+
+	m.analysisVP.SetWidth(m.width)
+	m.analysisVP.SetHeight(analysisH)
+	m.eventLogVP.SetWidth(m.width)
+	m.eventLogVP.SetHeight(eventLogH)
+}
+
+// computeHeightBudget calculates the height for analysis and event log viewports.
+func (m Model) computeHeightBudget() (analysisH, eventLogH int) {
+	fixed := 2 // header (title + goal)
+	fixed += 1 // blank line after header
+
+	if m.showInfo {
+		repos, _ := m.store.GetRepos(m.project.ID)
+		topics, _ := m.store.GetTopics(m.project.ID)
+		fixed += 1 + len(repos) // "Repos" header + repo lines
+		if len(topics) > 0 {
+			fixed += 1 + len(topics) // "Topics" header + topic lines
+		}
+		fixed += 1 // blank line after info
+	}
+
+	// Count actual rendered concern lines (matches renderConcerns logic).
+	concernContent := m.renderConcerns()
+	if concernContent != "" {
+		fixed += strings.Count(concernContent, "\n")
+		fixed += 1 // blank line after concerns
+	}
+
+	if len(m.trackedItems) > 0 {
+		fixed += 1 // tracked strip line
+		fixed += 1 // blank line after tracked
+	}
+
+	fixed += 1 // analysis header
+	fixed += 1 // event log header
+	fixed += 3 // bottom bar (blank + 2 help rows)
+	fixed += 3 // blank lines (after analysis VP, after event log VP, before bottom bar)
+
+	remaining := m.height - fixed
+	if remaining < 6 {
+		remaining = 6
+	}
+
+	if m.analysisExpanded {
+		analysisH = remaining * 60 / 100
+		eventLogH = remaining - analysisH
+	} else {
+		analysisH = 3
+		eventLogH = remaining - 3
+	}
+
+	if analysisH < 2 {
+		analysisH = 2
+	}
+	if eventLogH < 2 {
+		eventLogH = 2
+	}
+
+	return analysisH, eventLogH
+}
+
+// renderBottomBar renders the input area or help bar depending on mode.
+func (m Model) renderBottomBar() string {
+	var b strings.Builder
+	b.WriteString("\n")
+
+	switch m.mode {
+	case "broadcast":
+		if m.broadcastStatus == "Sending..." {
+			b.WriteString("  ")
+			b.WriteString(m.spinner.View())
+			b.WriteString(" ")
+			b.WriteString(broadcastStyle().Render("Sending broadcast..."))
+		} else if m.broadcastStatus != "" {
+			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.broadcastStatus)))
+		} else {
+			b.WriteString("  ")
+			b.WriteString(m.broadcastInput.View())
+		}
+		b.WriteString("\n")
+		if m.broadcastStatus == "" {
+			b.WriteString(helpStyle().Render("ctrl+d: send \u2022 esc: cancel"))
+		}
+		b.WriteString("\n")
+	case "usermsg":
+		if m.userMsgStatus == "Posting..." {
+			b.WriteString("  ")
+			b.WriteString(m.spinner.View())
+			b.WriteString(" ")
+			b.WriteString(userMsgStyle().Render("Posting message..."))
+		} else if m.userMsgStatus != "" {
+			b.WriteString(userMsgStyle().Render(fmt.Sprintf("  %s", m.userMsgStatus)))
+		} else {
+			b.WriteString("  ")
+			b.WriteString(m.userMsgInput.View())
+		}
+		b.WriteString("\n")
+		if m.userMsgStatus == "" {
+			b.WriteString(helpStyle().Render("ctrl+d: send \u2022 esc: cancel"))
+		}
+		b.WriteString("\n")
+	case "onboard":
+		if m.onboardStatus != "" && m.onboardStatus != "Generating onboarding message..." {
+			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.onboardStatus)))
+		} else if m.onboardStatus == "Generating onboarding message..." {
+			b.WriteString("  ")
+			b.WriteString(m.spinner.View())
+			b.WriteString(" ")
+			b.WriteString(broadcastStyle().Render("Generating onboarding message..."))
+		} else {
+			b.WriteString(headerStyle().Render("  Onboard \u2014 optional guidance for the new agent:"))
+			b.WriteString("\n")
+			b.WriteString("  ")
+			b.WriteString(m.onboardInput.View())
+		}
+		b.WriteString("\n")
+		if m.onboardStatus == "" {
+			b.WriteString(helpStyle().Render("ctrl+d: generate & publish \u2022 esc: cancel (leave empty for generic onboarding)"))
+		}
+		b.WriteString("\n")
+	default:
+		if m.broadcastStatus != "" {
+			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.broadcastStatus)))
+			b.WriteString("\n")
+		}
+		if m.userMsgStatus != "" {
+			b.WriteString(userMsgStyle().Render(fmt.Sprintf("  %s", m.userMsgStatus)))
+			b.WriteString("\n")
+		}
+		b.WriteString(renderHelpBar(m.width))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// renderHelpBar builds a two-row help bar with styled key hints.
+func renderHelpBar(width int) string {
+	keyStyle := helpKeyStyle()
+	descStyle := helpStyle()
+	sep := descStyle.Render(" \u2022 ")
+
+	type hint struct {
+		key  string
+		desc string
+	}
+
+	hints := []hint{
+		{"p", "pause/resume"},
+		{"r", "poll now"},
+		{"e", "expand"},
+		{"u", "user msg"},
+		{"m", "broadcast"},
+		{"o", "onboard"},
+		{"i", "info"},
+		{"t", "theme"},
+		{"q", "quit"},
+	}
+
+	var row1, row2 strings.Builder
+	for idx, h := range hints {
+		entry := keyStyle.Render(h.key) + descStyle.Render(": "+h.desc)
+		target := &row1
+		if idx >= 5 {
+			target = &row2
+		}
+		if target.Len() > 0 {
+			target.WriteString(sep)
+		}
+		target.WriteString(entry)
+	}
+
+	return row1.String() + "\n" + row2.String()
+}
+
+// truncateLine truncates a string to maxWidth characters, adding "..." if truncated.
+func truncateLine(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return s
+	}
+	// Flatten to single line first.
+	s = strings.ReplaceAll(s, "\n", " ")
+	runes := []rune(s)
+	if len(runes) <= maxWidth {
+		return s
+	}
+	if maxWidth <= 3 {
+		return string(runes[:maxWidth])
+	}
+	return string(runes[:maxWidth-3]) + "..."
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -125,3 +125,20 @@ func userMsgStyle() lipgloss.Style {
 func spinnerStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(currentTheme().Secondary)
 }
+
+// statusDot returns a colored status indicator for tracked items.
+func statusDot(status string) string {
+	t := currentTheme()
+	switch status {
+	case "InProg":
+		return lipgloss.NewStyle().Foreground(t.Secondary).Render("\u25cf")
+	case "Blckd":
+		return lipgloss.NewStyle().Foreground(t.Warning).Render("\u25cf")
+	case "Mrgd":
+		return lipgloss.NewStyle().Foreground(t.Success).Render("\u2713")
+	case "Closd":
+		return lipgloss.NewStyle().Foreground(t.Muted).Render("\u2715")
+	default: // Open
+		return lipgloss.NewStyle().Foreground(t.Muted).Render("\u25cb")
+	}
+}


### PR DESCRIPTION
## Summary
- **Fixes #10**: Event log entries truncated to single lines, eliminating overflow that pushed keybinds off screen
- Replaced unbounded string-buffer rendering with height-budgeted viewport sections (bubbletea `viewport` bubble) for analysis and event log — both scroll independently
- Compacted header: repos/topics collapsed to counts, press `i` to expand full detail
- Active concerns wrap naturally but cap at 8 rendered lines
- Added tracked items status strip with color-coded dots per issue status
- Help bar always pinned at bottom

## Test plan
- [x] `go build ./...` and `go test ./...` pass
- [x] `MINDER_DEBUG=1 agent-minder start <project>` — multi-line events render as single lines
- [x] Help bar stays visible at bottom regardless of content length
- [x] `i` toggles repos/topics detail
- [x] `e` toggles analysis expansion (3-line collapsed vs proportional)
- [x] Arrow keys / pgup/pgdn scroll the event log
- [x] `m`, `u`, `o` input modes still work
- [x] `t` theme cycling re-renders correctly
- [x] Tracked items strip renders if project has tracked items

🤖 Generated with [Claude Code](https://claude.com/claude-code)