### PR TITLE
Add workflow to auto-remove in-progress label on close

### DIFF
--- a/.github/workflows/label-cleanup.yml
+++ b/.github/workflows/label-cleanup.yml
@@ -1,0 +1,24 @@
+name: Remove in-progress on close
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  cleanup-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'in-progress';
+            const labels = context.payload.issue.labels.map(l => l.name);
+            if (labels.includes(label)) {
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: context.issue.number,
+                name: label,
+              });
+            }


### PR DESCRIPTION
## Summary
- GitHub Actions workflow that triggers on issue close
- Removes `in-progress` label if present
- Keeps label state clean without manual intervention

## Test plan
- [ ] Close an issue with `in-progress` label, verify label is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)