### PR TITLE
Fix config tests leaking real env vars (#16)

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,7 @@ func setupTestKeyring(t *testing.T) *secrets.MapKeyring {
 func TestGetProviderAPIKey_FromConfig(t *testing.T) {
 	resetViper(t)
 	setupTestKeyring(t)
+	t.Setenv("ANTHROPIC_API_KEY", "")
 	viper.Set("providers.anthropic.api_key", "sk-ant-test123")
 
 	got := GetProviderAPIKey("anthropic")
@@ -138,6 +139,10 @@ func TestSetAndSave(t *testing.T) {
 
 	resetViper(t)
 	setupTestKeyring(t) // re-setup empty keyring after reset
+	// Clear env vars so they don't take precedence over config file values.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
 	viper.SetConfigFile(configPath)
 	if err := viper.ReadInConfig(); err != nil {
 		t.Fatalf("ReadInConfig: %v", err)


### PR DESCRIPTION
## Summary
- `TestSetAndSave` and `TestGetProviderAPIKey_FromConfig` fail when `ANTHROPIC_API_KEY` is set in the environment because env vars take precedence over config file values in `GetProviderAPIKey()`'s lookup order
- Add `t.Setenv("ANTHROPIC_API_KEY", "")` (and `GITHUB_TOKEN`/`GH_TOKEN` for `TestSetAndSave`) to clear env vars before asserting on config-file-only values

Closes #16

## Test plan
- [x] `go test ./internal/config/... -v` — all 20 tests pass with `ANTHROPIC_API_KEY` set in environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)