### PR TITLE
Auto-prune oldest terminal tracked items (#19)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -675,3 +676,108 @@ CREATE TABLE IF NOT EXISTS polls (
 	polled_at       TEXT DEFAULT (datetime('now'))
 );
 `
+
+func TestPruneTrackedItems(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "prunetest", MinderIdentity: "prunetest/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	// Add 10 items: 5 open, 5 closed with staggered timestamps.
+	for i := 1; i <= 5; i++ {
+		item := &TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i, LastStatus: "Open"}
+		if err := store.AddTrackedItem(item); err != nil {
+			t.Fatalf("AddTrackedItem %d: %v", i, err)
+		}
+	}
+	for i := 6; i <= 10; i++ {
+		item := &TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i, LastStatus: "Closd", LastCheckedAt: fmt.Sprintf("2026-01-%02dT00:00:00Z", i)}
+		if err := store.AddTrackedItem(item); err != nil {
+			t.Fatalf("AddTrackedItem %d: %v", i, err)
+		}
+	}
+
+	// At exactly 10, prune should still trigger (>= maxTotal).
+	pruned, err := store.PruneTrackedItems(p.ID, 10, 2)
+	if err != nil {
+		t.Fatalf("PruneTrackedItems: %v", err)
+	}
+	// Should prune enough to get below 10, keeping 2 terminal items.
+	// 5 terminal - 2 keep = 3 removable, excess = 10-10+1 = 1, so prune 1.
+	if pruned != 1 {
+		t.Errorf("pruned = %d, want 1", pruned)
+	}
+
+	items, _ := store.GetTrackedItems(p.ID)
+	if len(items) != 9 {
+		t.Errorf("after prune len = %d, want 9", len(items))
+	}
+
+	// Oldest terminal (#6, checked Jan 6) should be gone.
+	for _, item := range items {
+		if item.Number == 6 {
+			t.Errorf("item #6 should have been pruned")
+		}
+	}
+}
+
+func TestPruneTrackedItems_UnderThreshold(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "pruneskip", MinderIdentity: "pruneskip/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	for i := 1; i <= 5; i++ {
+		item := &TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i, LastStatus: "Closd"}
+		store.AddTrackedItem(item)
+	}
+
+	pruned, err := store.PruneTrackedItems(p.ID, 10, 2)
+	if err != nil {
+		t.Fatalf("PruneTrackedItems: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("pruned = %d, want 0 (under threshold)", pruned)
+	}
+}
+
+func TestPruneTrackedItems_AllOpen(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "pruneopen", MinderIdentity: "pruneopen/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	for i := 1; i <= 10; i++ {
+		item := &TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i, LastStatus: "Open"}
+		store.AddTrackedItem(item)
+	}
+
+	pruned, err := store.PruneTrackedItems(p.ID, 10, 2)
+	if err != nil {
+		t.Fatalf("PruneTrackedItems: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("pruned = %d, want 0 (no terminal items)", pruned)
+	}
+}
+
+func TestPruneTrackedItems_RespectsKeepTerminal(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "prunekeep", MinderIdentity: "prunekeep/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	// 8 open + 2 terminal = 10 total. keepTerminal=2 means 0 removable.
+	for i := 1; i <= 8; i++ {
+		item := &TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i, LastStatus: "Open"}
+		store.AddTrackedItem(item)
+	}
+	for i := 9; i <= 10; i++ {
+		item := &TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i, LastStatus: "Mrgd"}
+		store.AddTrackedItem(item)
+	}
+
+	pruned, err := store.PruneTrackedItems(p.ID, 10, 2)
+	if err != nil {
+		t.Fatalf("PruneTrackedItems: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("pruned = %d, want 0 (only 2 terminal, keepTerminal=2)", pruned)
+	}
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -367,6 +367,48 @@ func (s *Store) UpdateTrackedItem(item *TrackedItem) error {
 	return err
 }
 
+// PruneTrackedItems removes the oldest terminal (closed/merged/not-planned) tracked items
+// when the total count for a project exceeds maxTotal. It keeps at least keepTerminal
+// terminal items for historical context. Returns the number of items pruned.
+func (s *Store) PruneTrackedItems(projectID int64, maxTotal, keepTerminal int) (int, error) {
+	var total int
+	if err := s.db.Get(&total, `SELECT COUNT(*) FROM tracked_items WHERE project_id = ?`, projectID); err != nil {
+		return 0, fmt.Errorf("count tracked items: %w", err)
+	}
+	if total < maxTotal {
+		return 0, nil
+	}
+
+	// Find terminal items ordered oldest first.
+	var terminal []TrackedItem
+	if err := s.db.Select(&terminal, `
+		SELECT * FROM tracked_items
+		WHERE project_id = ? AND last_status IN ('Closd', 'Mrgd', 'NotPl')
+		ORDER BY last_checked_at ASC, created_at ASC
+	`, projectID); err != nil {
+		return 0, fmt.Errorf("select terminal items: %w", err)
+	}
+
+	// How many can we remove? We need to get below maxTotal but keep at least keepTerminal.
+	removable := len(terminal) - keepTerminal
+	if removable <= 0 {
+		return 0, nil
+	}
+	excess := total - maxTotal + 1 // prune enough to get back under the cap
+	if excess > removable {
+		excess = removable
+	}
+
+	pruned := 0
+	for i := 0; i < excess; i++ {
+		if _, err := s.db.Exec(`DELETE FROM tracked_items WHERE id = ?`, terminal[i].ID); err != nil {
+			return pruned, fmt.Errorf("delete tracked item %d: %w", terminal[i].ID, err)
+		}
+		pruned++
+	}
+	return pruned, nil
+}
+
 // LastPoll returns the most recent poll for a project, or nil if none.
 func (s *Store) LastPoll(projectID int64) (*Poll, error) {
 	polls, err := s.RecentPolls(projectID, 1)

--- a/internal/poller/sweep.go
+++ b/internal/poller/sweep.go
@@ -196,6 +196,14 @@ func (p *Poller) sweepTrackedItems(ctx context.Context, items []db.TrackedItem, 
 		}
 	}
 
+	// Auto-prune oldest terminal items when the list is full.
+	pruned, err := p.store.PruneTrackedItems(p.project.ID, 10, 2)
+	if err != nil {
+		p.emit("error", fmt.Sprintf("pruning tracked items: %v", err), nil)
+	} else if pruned > 0 {
+		p.emit("tracked", fmt.Sprintf("Pruned %d resolved tracked items", pruned), nil)
+	}
+
 	return results, trackedSummary.String()
 }
 


### PR DESCRIPTION
## Summary
- After each sweep cycle, automatically prune the oldest closed/merged/not-planned tracked items when total count reaches 10+
- Keeps at least 2 terminal items for historical context so the analyzer has some recent resolution history
- Oldest items (by `last_checked_at`) are pruned first
- TUI event logged when items are pruned

Closes #19

## Test plan
- [x] `TestPruneTrackedItems` — prunes oldest terminal item when at cap (10 items, 5 closed)
- [x] `TestPruneTrackedItems_UnderThreshold` — no pruning when under 10
- [x] `TestPruneTrackedItems_AllOpen` — no pruning when all items are open (no terminal items)
- [x] `TestPruneTrackedItems_RespectsKeepTerminal` — won't prune below the keepTerminal floor (2)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)