### PR TITLE
Auto-pause polling after idle timeout (#18)

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -150,7 +150,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 	autoEnroll := readLine(reader)
 	autoEnrollBool := !strings.HasPrefix(strings.ToLower(autoEnroll), "n")
 
-	// 6. Select LLM provider from configured providers.
+	// 6. Idle auto-pause.
+	idlePauseMin := promptMinutes(reader, "Auto-pause after idle (minutes, 0=disabled)", 240, 0, 1440)
+	idlePauseSec := int(idlePauseMin.Seconds())
+
+	// 7. Select LLM provider from configured providers.
 	llmProvider := "anthropic"
 	configured := config.ConfiguredProviders()
 	if len(configured) == 0 {
@@ -171,7 +175,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// 7. Write to database.
+	// 8. Write to database.
 	project := &db.Project{
 		Name:                projectName,
 		GoalType:            goal.Name,
@@ -179,6 +183,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		RefreshIntervalSec:  int(interval.Seconds()),
 		MessageTTLSec:       int(ttl.Seconds()),
 		AutoEnrollWorktrees: autoEnrollBool,
+		IdlePauseSec:        idlePauseSec,
 		MinderIdentity:      projectName + "/minder",
 		LLMProvider:         llmProvider,
 		LLMModel:            "claude-haiku-4-5",

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -64,6 +64,7 @@ func TestProjectCRUD(t *testing.T) {
 		LLMModel:            "claude-haiku-4-5",
 		LLMSummarizerModel:  "claude-haiku-4-5",
 		LLMAnalyzerModel:    "claude-sonnet-4-6",
+		IdlePauseSec:        14400,
 	}
 
 	if err := store.CreateProject(p); err != nil {
@@ -89,6 +90,12 @@ func TestProjectCRUD(t *testing.T) {
 	}
 	if got.LLMAnalyzerModel != "claude-sonnet-4-6" {
 		t.Errorf("LLMAnalyzerModel = %q, want %q", got.LLMAnalyzerModel, "claude-sonnet-4-6")
+	}
+	if got.IdlePauseSec != 14400 {
+		t.Errorf("IdlePauseSec = %d, want 14400", got.IdlePauseSec)
+	}
+	if got.IdlePauseDuration().Hours() != 4 {
+		t.Errorf("IdlePauseDuration = %v, want 4h", got.IdlePauseDuration())
 	}
 
 	// Update.
@@ -517,6 +524,161 @@ func TestMigrationV3ToV4(t *testing.T) {
 		t.Errorf("ContentHash = %q, want deadbeef", items[0].ContentHash)
 	}
 }
+
+func TestMigrationV4ToV5(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	// Create a v4 database manually.
+	conn, err := openRawV4(dbPath)
+	if err != nil {
+		t.Fatalf("create v4 db: %v", err)
+	}
+
+	// Insert v4 data.
+	_, err = conn.Exec(`INSERT INTO projects (name, goal_type, goal_description, minder_identity, llm_provider, llm_model, llm_summarizer_model, llm_analyzer_model)
+		VALUES ('migtest5', 'feature', 'test goal', 'migtest5/minder', 'anthropic', 'claude-haiku-4-5', 'claude-haiku-4-5', 'claude-sonnet-4-6')`)
+	if err != nil {
+		t.Fatalf("insert v4 project: %v", err)
+	}
+	conn.Close()
+
+	// Re-open with current migration code — should migrate to v5.
+	conn2, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open after v4: %v", err)
+	}
+	defer conn2.Close()
+	store := NewStore(conn2)
+
+	// Check schema version.
+	var version int
+	store.DB().Get(&version, "SELECT version FROM schema_version LIMIT 1")
+	if version != currentVersion {
+		t.Errorf("version = %d, want %d", version, currentVersion)
+	}
+
+	// Check project got idle_pause_sec with default value.
+	proj, err := store.GetProject("migtest5")
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	if proj.IdlePauseSec != 14400 {
+		t.Errorf("IdlePauseSec = %d, want 14400 (default)", proj.IdlePauseSec)
+	}
+
+	// Verify it can be updated.
+	proj.IdlePauseSec = 7200
+	if err := store.UpdateProject(proj); err != nil {
+		t.Fatalf("UpdateProject: %v", err)
+	}
+	proj, _ = store.GetProject("migtest5")
+	if proj.IdlePauseSec != 7200 {
+		t.Errorf("after update IdlePauseSec = %d, want 7200", proj.IdlePauseSec)
+	}
+}
+
+// openRawV4 creates a database with the v4 schema (no idle_pause_sec).
+func openRawV4(path string) (*sqlx.DB, error) {
+	db, err := sqlx.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)")
+	if err != nil {
+		return nil, err
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if _, err := db.Exec(schemaV4_only); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if _, err := db.Exec("INSERT INTO schema_version (version) VALUES (4)"); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// schemaV4_only is the v4 schema without the v5 idle_pause_sec column.
+const schemaV4_only = `
+CREATE TABLE IF NOT EXISTS schema_version (
+	version INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS projects (
+	id                    INTEGER PRIMARY KEY,
+	name                  TEXT UNIQUE NOT NULL,
+	goal_type             TEXT,
+	goal_description      TEXT,
+	refresh_interval_sec  INTEGER DEFAULT 300,
+	message_ttl_sec       INTEGER DEFAULT 172800,
+	auto_enroll_worktrees BOOLEAN DEFAULT 1,
+	minder_identity       TEXT,
+	llm_provider          TEXT DEFAULT 'anthropic',
+	llm_model             TEXT DEFAULT 'claude-haiku-4-5',
+	llm_summarizer_model  TEXT DEFAULT 'claude-haiku-4-5',
+	llm_analyzer_model    TEXT DEFAULT 'claude-sonnet-4-6',
+	created_at            TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS repos (
+	id         INTEGER PRIMARY KEY,
+	project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+	path       TEXT NOT NULL,
+	short_name TEXT NOT NULL,
+	summary    TEXT,
+	UNIQUE(project_id, path)
+);
+CREATE TABLE IF NOT EXISTS worktrees (
+	id      INTEGER PRIMARY KEY,
+	repo_id INTEGER REFERENCES repos(id) ON DELETE CASCADE,
+	path    TEXT NOT NULL,
+	branch  TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS topics (
+	id         INTEGER PRIMARY KEY,
+	project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+	name       TEXT NOT NULL,
+	UNIQUE(project_id, name)
+);
+CREATE TABLE IF NOT EXISTS concerns (
+	id          INTEGER PRIMARY KEY,
+	project_id  INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+	severity    TEXT DEFAULT 'warning',
+	message     TEXT NOT NULL,
+	resolved    BOOLEAN DEFAULT 0,
+	created_at  TEXT DEFAULT (datetime('now')),
+	resolved_at TEXT
+);
+CREATE TABLE IF NOT EXISTS polls (
+	id              INTEGER PRIMARY KEY,
+	project_id      INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+	new_commits     INTEGER DEFAULT 0,
+	new_messages    INTEGER DEFAULT 0,
+	concerns_raised INTEGER DEFAULT 0,
+	llm_response    TEXT,
+	tier1_response  TEXT DEFAULT '',
+	tier2_response  TEXT DEFAULT '',
+	bus_message_sent TEXT DEFAULT '',
+	polled_at       TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS tracked_items (
+	id              INTEGER PRIMARY KEY,
+	project_id      INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+	source          TEXT NOT NULL DEFAULT 'github',
+	owner           TEXT NOT NULL,
+	repo            TEXT NOT NULL,
+	number          INTEGER NOT NULL,
+	item_type       TEXT NOT NULL DEFAULT 'issue',
+	title           TEXT NOT NULL DEFAULT '',
+	state           TEXT NOT NULL DEFAULT 'open',
+	labels          TEXT NOT NULL DEFAULT '',
+	last_status     TEXT NOT NULL DEFAULT 'Open',
+	last_checked_at     TEXT DEFAULT '',
+	content_hash        TEXT DEFAULT '',
+	objective_summary   TEXT DEFAULT '',
+	progress_summary    TEXT DEFAULT '',
+	created_at          TEXT DEFAULT (datetime('now')),
+	UNIQUE(project_id, source, owner, repo, number)
+);
+`
 
 // openRawV3 creates a database with the v3 schema (no v4 columns on tracked_items).
 func openRawV3(path string) (*sqlx.DB, error) {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -20,6 +20,7 @@ type Project struct {
 	LLMModel             string `db:"llm_model"`
 	LLMSummarizerModel   string `db:"llm_summarizer_model"`
 	LLMAnalyzerModel     string `db:"llm_analyzer_model"`
+	IdlePauseSec         int    `db:"idle_pause_sec"`
 	CreatedAt            string `db:"created_at"`
 }
 
@@ -31,6 +32,12 @@ func (p *Project) RefreshInterval() time.Duration {
 // MessageTTL returns the message TTL as a time.Duration.
 func (p *Project) MessageTTL() time.Duration {
 	return time.Duration(p.MessageTTLSec) * time.Second
+}
+
+// IdlePauseDuration returns the idle pause threshold as a time.Duration.
+// Returns 0 if idle auto-pause is disabled.
+func (p *Project) IdlePauseDuration() time.Duration {
+	return time.Duration(p.IdlePauseSec) * time.Second
 }
 
 // Repo represents a monitored git repository.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -28,10 +28,10 @@ func (s *Store) CreateProject(p *Project) error {
 	result, err := s.db.NamedExec(`
 		INSERT INTO projects (name, goal_type, goal_description, refresh_interval_sec,
 			message_ttl_sec, auto_enroll_worktrees, minder_identity, llm_provider, llm_model,
-			llm_summarizer_model, llm_analyzer_model)
+			llm_summarizer_model, llm_analyzer_model, idle_pause_sec)
 		VALUES (:name, :goal_type, :goal_description, :refresh_interval_sec,
 			:message_ttl_sec, :auto_enroll_worktrees, :minder_identity, :llm_provider, :llm_model,
-			:llm_summarizer_model, :llm_analyzer_model)
+			:llm_summarizer_model, :llm_analyzer_model, :idle_pause_sec)
 	`, p)
 	if err != nil {
 		return fmt.Errorf("insert project: %w", err)
@@ -84,7 +84,8 @@ func (s *Store) UpdateProject(p *Project) error {
 			llm_provider = :llm_provider,
 			llm_model = :llm_model,
 			llm_summarizer_model = :llm_summarizer_model,
-			llm_analyzer_model = :llm_analyzer_model
+			llm_analyzer_model = :llm_analyzer_model,
+			idle_pause_sec = :idle_pause_sec
 		WHERE id = :id
 	`, p)
 	return err

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -8,7 +8,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 4
+const currentVersion = 5
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS projects (
 	llm_model             TEXT DEFAULT 'claude-haiku-4-5',
 	llm_summarizer_model  TEXT DEFAULT 'claude-haiku-4-5',
 	llm_analyzer_model    TEXT DEFAULT 'claude-sonnet-4-6',
+	idle_pause_sec        INTEGER DEFAULT 14400,
 	created_at            TEXT DEFAULT (datetime('now'))
 );
 
@@ -151,6 +152,12 @@ func migrate(db *sqlx.DB) error {
 		}
 	}
 
+	if version < 5 {
+		if err := migrateV5(db); err != nil {
+			return fmt.Errorf("apply migration v5: %w", err)
+		}
+	}
+
 	_, err = db.Exec("UPDATE schema_version SET version = ?", currentVersion)
 	return err
 }
@@ -229,6 +236,18 @@ func migrateV4(db *sqlx.DB) error {
 		if _, err := db.Exec(fmt.Sprintf(`UPDATE tracked_items SET %s = '' WHERE %s IS NULL`, col, col)); err != nil {
 			return fmt.Errorf("null-fill %s: %w", col, err)
 		}
+	}
+	return nil
+}
+
+func migrateV5(db *sqlx.DB) error {
+	_, err := db.Exec(`ALTER TABLE projects ADD COLUMN idle_pause_sec INTEGER DEFAULT 14400`)
+	if err != nil {
+		return fmt.Errorf("add idle_pause_sec: %w", err)
+	}
+	// Ensure no NULLs (Go int can't scan NULL).
+	if _, err := db.Exec(`UPDATE projects SET idle_pause_sec = 14400 WHERE idle_pause_sec IS NULL`); err != nil {
+		return fmt.Errorf("null-fill idle_pause_sec: %w", err)
 	}
 	return nil
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -60,6 +60,9 @@ type removeTrackedItemResultMsg struct {
 // clearTrackStatusMsg clears the track status after a delay.
 type clearTrackStatusMsg struct{}
 
+// idleCheckMsg triggers periodic idle timeout checking.
+type idleCheckMsg time.Time
+
 // Model is the root bubbletea model for the dashboard.
 type Model struct {
 	project *db.Project
@@ -102,6 +105,10 @@ type Model struct {
 	// Track mode (add/remove tracked items).
 	trackInput  textinput.Model
 	trackStatus string
+
+	// Auto-pause on idle.
+	lastUserInput time.Time
+	autoPaused    bool
 }
 
 // safeViewportKeyMap returns a viewport KeyMap that only uses arrow keys and
@@ -169,15 +176,20 @@ func New(project *db.Project, store *db.Store, p *poller.Poller) Model {
 		trackInput:     ti,
 		analysisVP:     aVP,
 		eventLogVP:     eVP,
+		lastUserInput:  time.Now(),
 	}
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(
+	cmds := []tea.Cmd{
 		listenForEvents(m.poller),
 		tickEvery(),
 		m.spinner.Tick,
-	)
+	}
+	if m.project.IdlePauseSec > 0 {
+		cmds = append(cmds, idleCheckTick())
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -189,6 +201,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyPressMsg:
+		m.lastUserInput = time.Now()
+
+		// Auto-resume on any keypress if auto-paused.
+		if m.autoPaused {
+			m.autoPaused = false
+			m.poller.Resume()
+			m.events = append(m.events, poller.Event{
+				Time:    time.Now(),
+				Type:    "resumed",
+				Summary: "Resumed (user returned)",
+			})
+			m.rebuildEventLogContent()
+			// Fall through to handle the keypress normally.
+		}
+
 		switch m.mode {
 		case "broadcast":
 			return m.updateBroadcast(msg)
@@ -293,6 +320,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.trackStatus = ""
 		m.mode = "normal"
 		return m, nil
+
+	case idleCheckMsg:
+		threshold := m.project.IdlePauseDuration()
+		if threshold > 0 && !m.autoPaused && !m.poller.IsPaused() && time.Since(m.lastUserInput) >= threshold {
+			m.autoPaused = true
+			m.poller.Pause()
+			idleDur := formatDuration(threshold)
+			m.events = append(m.events, poller.Event{
+				Time:    time.Now(),
+				Type:    "paused",
+				Summary: fmt.Sprintf("Auto-paused after %s of inactivity", idleDur),
+			})
+			m.rebuildEventLogContent()
+		}
+		return m, idleCheckTick()
 
 	case tickMsg:
 		return m, tickEvery()
@@ -541,4 +583,25 @@ func tickEvery() tea.Cmd {
 		time.Sleep(5 * time.Second)
 		return tickMsg(time.Now())
 	}
+}
+
+// idleCheckTick returns a command that checks idle timeout every 60 seconds.
+func idleCheckTick() tea.Cmd {
+	return func() tea.Msg {
+		time.Sleep(60 * time.Second)
+		return idleCheckMsg(time.Now())
+	}
+}
+
+// formatDuration returns a human-readable duration string like "4h" or "30m".
+func formatDuration(d time.Duration) string {
+	if d >= time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		if m > 0 {
+			return fmt.Sprintf("%dh%dm", h, m)
+		}
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dm", int(d.Minutes()))
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -84,7 +84,10 @@ func (m Model) renderHeader() string {
 
 	// Line 1: title + status + counts + spinner + theme.
 	status := statusRunningStyle().Render("RUNNING")
-	if m.poller.IsPaused() {
+	if m.autoPaused {
+		idleDur := formatDuration(time.Since(m.lastUserInput))
+		status = statusPausedStyle().Render(fmt.Sprintf("AUTO-PAUSED (idle %s)", idleDur))
+	} else if m.poller.IsPaused() {
 		status = statusPausedStyle().Render("PAUSED")
 	}
 	b.WriteString(titleStyle().Render(fmt.Sprintf("agent-minder: %s", m.project.Name)))


### PR DESCRIPTION
## Summary
- Automatically pause polling when the TUI has been idle for a configurable period (default: 4 hours), preventing wasted LLM API calls overnight
- Any keypress while auto-paused resumes polling automatically; manual pause (`p` key) is unaffected
- Header shows `AUTO-PAUSED (idle 4h)` visually distinct from manual `PAUSED`

## Changes
- **Schema v5 migration**: adds `idle_pause_sec INTEGER DEFAULT 14400` to projects table
- **TUI**: tracks `lastUserInput` timestamp, 60s idle check tick, auto-resume on any keypress
- **Init wizard**: new prompt for idle timeout (default 240 min, 0 to disable)
- **Tests**: migration v4→v5 test, project CRUD assertions for idle pause

Closes #18

## Test plan
- [x] `go test ./...` passes (all 14 DB tests + full suite)
- [x] Fresh `init` prompts for idle timeout and stores value
- [x] Existing DBs migrate cleanly (v4→v5 with 4h default)
- [x] TUI shows AUTO-PAUSED after configured idle period
- [x] Any keypress resumes from auto-pause
- [x] Manual pause (`p`) is not auto-resumed by keypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)