### PR TITLE
Add PR draft/review state to analyzer context (#37)

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -108,7 +108,9 @@ type TrackedItem struct {
 	Title         string `db:"title"`          // latest title
 	State         string `db:"state"`          // "open", "closed", "merged"
 	Labels        string `db:"labels"`         // comma-separated
-	LastStatus       string `db:"last_status"`        // compact status for TUI: "Open", "InProg", "Closd", "Mrgd", "Blckd"
+	IsDraft      bool   `db:"is_draft"`       // PR only: true if draft
+	ReviewState  string `db:"review_state"`   // PR only: "approved", "changes_requested", "pending", ""
+	LastStatus       string `db:"last_status"`        // compact status for TUI: "Open", "InProg", "Closd", "Mrgd", "Blckd", "Draft", "Appvd", "ChReq"
 	LastCheckedAt    string `db:"last_checked_at"`
 	ContentHash      string `db:"content_hash"`       // SHA-256 of body+comments+state+labels
 	ObjectiveSummary string `db:"objective_summary"`  // Haiku-generated objective summary

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -429,6 +429,8 @@ func (s *Store) UpdateTrackedItem(item *TrackedItem) error {
 			title = :title,
 			state = :state,
 			labels = :labels,
+			is_draft = :is_draft,
+			review_state = :review_state,
 			last_status = :last_status,
 			last_checked_at = :last_checked_at,
 			content_hash = :content_hash,

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -8,7 +8,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 5
+const currentVersion = 6
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -89,6 +89,8 @@ CREATE TABLE IF NOT EXISTS tracked_items (
 	title           TEXT NOT NULL DEFAULT '',
 	state           TEXT NOT NULL DEFAULT 'open',
 	labels          TEXT NOT NULL DEFAULT '',
+	is_draft        BOOLEAN NOT NULL DEFAULT 0,
+	review_state    TEXT NOT NULL DEFAULT '',
 	last_status     TEXT NOT NULL DEFAULT 'Open',
 	last_checked_at     TEXT DEFAULT '',
 	content_hash        TEXT DEFAULT '',
@@ -155,6 +157,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 5 {
 		if err := migrateV5(db); err != nil {
 			return fmt.Errorf("apply migration v5: %w", err)
+		}
+	}
+
+	if version < 6 {
+		if err := migrateV6(db); err != nil {
+			return fmt.Errorf("apply migration v6: %w", err)
 		}
 	}
 
@@ -248,6 +256,19 @@ func migrateV5(db *sqlx.DB) error {
 	// Ensure no NULLs (Go int can't scan NULL).
 	if _, err := db.Exec(`UPDATE projects SET idle_pause_sec = 14400 WHERE idle_pause_sec IS NULL`); err != nil {
 		return fmt.Errorf("null-fill idle_pause_sec: %w", err)
+	}
+	return nil
+}
+
+func migrateV6(db *sqlx.DB) error {
+	stmts := []string{
+		`ALTER TABLE tracked_items ADD COLUMN is_draft BOOLEAN NOT NULL DEFAULT 0`,
+		`ALTER TABLE tracked_items ADD COLUMN review_state TEXT NOT NULL DEFAULT ''`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("%s: %w", stmt, err)
+		}
 	}
 	return nil
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -11,11 +11,13 @@ import (
 
 // ItemStatus holds the fetched status of a GitHub issue or PR.
 type ItemStatus struct {
-	Number   int
-	Title    string
-	State    string // "open", "closed", "merged"
-	Labels   []string
-	ItemType string // "issue" or "pull_request"
+	Number      int
+	Title       string
+	State       string // "open", "closed", "merged"
+	Labels      []string
+	ItemType    string // "issue" or "pull_request"
+	Draft       bool   // PR only: true if draft PR
+	ReviewState string // PR only: "approved", "changes_requested", "pending", or ""
 }
 
 // CompactStatus returns a short TUI-friendly status tag.
@@ -27,6 +29,12 @@ func (s *ItemStatus) CompactStatus() string {
 		return "Closd"
 	case hasLabel(s.Labels, "blocked"):
 		return "Blckd"
+	case s.Draft:
+		return "Draft"
+	case s.ReviewState == "approved":
+		return "Appvd"
+	case s.ReviewState == "changes_requested":
+		return "ChReq"
 	case hasLabel(s.Labels, "in progress"), hasLabel(s.Labels, "in-progress"), hasLabel(s.Labels, "wip"):
 		return "InProg"
 	default:
@@ -65,6 +73,7 @@ func (c *Client) FetchItemWithHint(ctx context.Context, owner, repo string, numb
 				Title:    pr.GetTitle(),
 				ItemType: "pull_request",
 				Labels:   extractLabels(pr.Labels),
+				Draft:    pr.GetDraft(),
 			}
 			if pr.GetMerged() {
 				status.State = "merged"
@@ -94,6 +103,50 @@ func (c *Client) FetchItemWithHint(ctx context.Context, owner, repo string, numb
 		ItemType: "issue",
 		Labels:   extractLabels(issue.Labels),
 	}, nil
+}
+
+// FetchPRReviewState returns the aggregate review state for a pull request.
+// It examines the most recent review from each reviewer and returns:
+// "approved" if at least one approval and no outstanding changes_requested,
+// "changes_requested" if any reviewer has requested changes,
+// "pending" if there are no decisive reviews yet, or "" on error.
+func (c *Client) FetchPRReviewState(ctx context.Context, owner, repo string, number int) string {
+	reviews, _, err := c.gh.PullRequests.ListReviews(ctx, owner, repo, number, &github.ListOptions{PerPage: 30})
+	if err != nil || len(reviews) == 0 {
+		return ""
+	}
+
+	// Keep only the latest review per user.
+	latest := make(map[int64]*github.PullRequestReview)
+	for _, r := range reviews {
+		uid := r.GetUser().GetID()
+		state := r.GetState()
+		// Skip COMMENTED and DISMISSED — they don't represent a decision.
+		if state == "COMMENTED" || state == "DISMISSED" || state == "PENDING" {
+			continue
+		}
+		if existing, ok := latest[uid]; !ok || r.GetSubmittedAt().After(existing.GetSubmittedAt().Time) {
+			latest[uid] = r
+		}
+	}
+
+	if len(latest) == 0 {
+		return "pending"
+	}
+
+	hasApproval := false
+	for _, r := range latest {
+		switch r.GetState() {
+		case "CHANGES_REQUESTED":
+			return "changes_requested"
+		case "APPROVED":
+			hasApproval = true
+		}
+	}
+	if hasApproval {
+		return "approved"
+	}
+	return "pending"
 }
 
 // ItemContent holds the body and recent comments for a GitHub issue or PR.

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -24,6 +24,11 @@ func TestCompactStatus(t *testing.T) {
 		{"in progress", ItemStatus{State: "open", Labels: []string{"in progress"}}, "InProg"},
 		{"in-progress", ItemStatus{State: "open", Labels: []string{"bug", "in-progress"}}, "InProg"},
 		{"wip", ItemStatus{State: "open", Labels: []string{"WIP"}}, "InProg"},
+		{"draft PR", ItemStatus{State: "open", Draft: true}, "Draft"},
+		{"approved PR", ItemStatus{State: "open", ReviewState: "approved"}, "Appvd"},
+		{"changes requested PR", ItemStatus{State: "open", ReviewState: "changes_requested"}, "ChReq"},
+		{"blocked beats draft", ItemStatus{State: "open", Labels: []string{"blocked"}, Draft: true}, "Blckd"},
+		{"draft beats approved", ItemStatus{State: "open", Draft: true, ReviewState: "approved"}, "Draft"},
 		{"merged takes priority", ItemStatus{State: "merged", Labels: []string{"blocked"}}, "Mrgd"},
 		{"closed takes priority over labels", ItemStatus{State: "closed", Labels: []string{"in progress"}}, "Closd"},
 	}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -832,6 +832,7 @@ Rules:
   - Severity levels: "info" (awareness, no action needed), "warning" (potential issue, monitor), "danger" (blocking or critical, needs immediate attention)
   - Keep each concern to 1-2 sentences. Be specific, not exhaustive.
   - Do NOT raise concerns about closed/merged items — they are done.
+  - For PRs: Use draft/review state to assess lifecycle. A draft PR is work-in-progress. "changes_requested" means the author needs to address feedback. "approved" means ready to merge. "pending" means awaiting review.
 
 - "bus_message": ONLY include when there is something genuinely actionable that other agents need to know (e.g., breaking changes, coordination needed, blocking issues). Most polls should NOT produce a bus message. Omit this field if not needed.
 
@@ -870,7 +871,19 @@ func (p *Poller) buildTier2Prompt(gitSummary, busSummary, trackedChanges string,
 	if len(trackedItems) > 0 {
 		b.WriteString("## Tracked Issues/PRs\n")
 		for _, item := range trackedItems {
-			fmt.Fprintf(&b, "- [%s] %s: %s\n", item.LastStatus, item.DisplayRef(), item.Title)
+			typeTag := "issue"
+			if item.ItemType == "pull_request" {
+				typeTag = "PR"
+			}
+			fmt.Fprintf(&b, "- [%s] [%s] %s: %s\n", item.LastStatus, typeTag, item.DisplayRef(), item.Title)
+			if item.ItemType == "pull_request" && item.State == "open" {
+				if item.IsDraft {
+					b.WriteString("  Draft: yes\n")
+				}
+				if item.ReviewState != "" {
+					fmt.Fprintf(&b, "  Review: %s\n", item.ReviewState)
+				}
+			}
 			if item.ObjectiveSummary != "" {
 				fmt.Fprintf(&b, "  Objective: %s\n", item.ObjectiveSummary)
 			}

--- a/internal/poller/sweep.go
+++ b/internal/poller/sweep.go
@@ -35,12 +35,21 @@ type ItemSweepResponse struct {
 // computeContentHash returns a SHA-256 hex digest of the normalized content.
 // Labels are sorted to ensure order-independence.
 // relatedCommits are included so new commits referencing the item invalidate the cache.
-func computeContentHash(state string, labels string, body string, comments []string, relatedCommits []string) string {
+func computeContentHash(state string, labels string, body string, comments []string, relatedCommits []string, isDraft bool, reviewState string) string {
 	h := sha256.New()
 
 	h.Write([]byte("state:"))
 	h.Write([]byte(state))
 	h.Write([]byte("\n"))
+
+	if isDraft {
+		h.Write([]byte("draft:true\n"))
+	}
+	if reviewState != "" {
+		h.Write([]byte("review:"))
+		h.Write([]byte(reviewState))
+		h.Write([]byte("\n"))
+	}
 
 	// Sort labels for order-independence.
 	labelList := strings.Split(labels, ",")
@@ -90,6 +99,14 @@ func buildItemSweepPrompt(item *db.TrackedItem, content *ghpkg.ItemContent, rela
 
 	fmt.Fprintf(&b, "## %s %s/%s#%d: %s\n\n", item.ItemType, item.Owner, item.Repo, item.Number, item.Title)
 	fmt.Fprintf(&b, "**State:** %s\n", item.State)
+	if item.ItemType == "pull_request" {
+		if item.IsDraft {
+			b.WriteString("**Draft:** yes\n")
+		}
+		if item.ReviewState != "" {
+			fmt.Fprintf(&b, "**Review:** %s\n", item.ReviewState)
+		}
+	}
 	if item.Labels != "" {
 		fmt.Fprintf(&b, "**Labels:** %s\n", item.Labels)
 	}
@@ -223,10 +240,19 @@ func (p *Poller) sweepOneItem(ctx context.Context, item *db.TrackedItem, gh *ghp
 	item.Title = status.Title
 	item.State = status.State
 	item.Labels = strings.Join(status.Labels, ",")
-	item.LastStatus = status.CompactStatus()
+	item.IsDraft = status.Draft
 	item.LastCheckedAt = time.Now().UTC().Format(time.RFC3339)
 	item.ItemType = status.ItemType
 
+	// Step 1b: Fetch review state for PRs (one extra API call).
+	if status.ItemType == "pull_request" && status.State == "open" {
+		item.ReviewState = gh.FetchPRReviewState(ctx, item.Owner, item.Repo, item.Number)
+		status.ReviewState = item.ReviewState
+	} else {
+		item.ReviewState = ""
+	}
+
+	item.LastStatus = status.CompactStatus()
 	result.NewStatus = item.LastStatus
 	result.Changed = result.OldStatus != result.NewStatus
 
@@ -262,7 +288,7 @@ func (p *Poller) sweepOneItem(ctx context.Context, item *db.TrackedItem, gh *ghp
 	}
 
 	// Step 3: Compute content hash (includes related commits so new commits invalidate cache).
-	newHash := computeContentHash(item.State, item.Labels, content.Body, content.Comments, commitHashes)
+	newHash := computeContentHash(item.State, item.Labels, content.Body, content.Comments, commitHashes, item.IsDraft, item.ReviewState)
 
 	// Step 4: Hash comparison — only run Haiku if content changed or no cached hash.
 	if newHash != item.ContentHash || item.ContentHash == "" {

--- a/internal/poller/sweep_test.go
+++ b/internal/poller/sweep_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestComputeContentHash_Deterministic(t *testing.T) {
-	h1 := computeContentHash("open", "bug,enhancement", "fix the thing", []string{"comment 1", "comment 2"}, nil)
-	h2 := computeContentHash("open", "bug,enhancement", "fix the thing", []string{"comment 1", "comment 2"}, nil)
+	h1 := computeContentHash("open", "bug,enhancement", "fix the thing", []string{"comment 1", "comment 2"}, nil, false, "")
+	h2 := computeContentHash("open", "bug,enhancement", "fix the thing", []string{"comment 1", "comment 2"}, nil, false, "")
 	if h1 != h2 {
 		t.Error("same input should produce same hash")
 	}
@@ -22,39 +22,49 @@ func TestComputeContentHash_Deterministic(t *testing.T) {
 }
 
 func TestComputeContentHash_LabelOrderIndependent(t *testing.T) {
-	h1 := computeContentHash("open", "bug,enhancement", "body", nil, nil)
-	h2 := computeContentHash("open", "enhancement,bug", "body", nil, nil)
+	h1 := computeContentHash("open", "bug,enhancement", "body", nil, nil, false, "")
+	h2 := computeContentHash("open", "enhancement,bug", "body", nil, nil, false, "")
 	if h1 != h2 {
 		t.Error("label order should not affect hash")
 	}
 }
 
 func TestComputeContentHash_FieldChangeInvalidates(t *testing.T) {
-	base := computeContentHash("open", "bug", "body", []string{"c1"}, nil)
+	base := computeContentHash("open", "bug", "body", []string{"c1"}, nil, false, "")
 
 	// Change state.
-	if computeContentHash("closed", "bug", "body", []string{"c1"}, nil) == base {
+	if computeContentHash("closed", "bug", "body", []string{"c1"}, nil, false, "") == base {
 		t.Error("state change should invalidate hash")
 	}
 
 	// Change labels.
-	if computeContentHash("open", "bug,wip", "body", []string{"c1"}, nil) == base {
+	if computeContentHash("open", "bug,wip", "body", []string{"c1"}, nil, false, "") == base {
 		t.Error("label change should invalidate hash")
 	}
 
 	// Change body.
-	if computeContentHash("open", "bug", "different body", []string{"c1"}, nil) == base {
+	if computeContentHash("open", "bug", "different body", []string{"c1"}, nil, false, "") == base {
 		t.Error("body change should invalidate hash")
 	}
 
 	// Change comments.
-	if computeContentHash("open", "bug", "body", []string{"c1", "c2"}, nil) == base {
+	if computeContentHash("open", "bug", "body", []string{"c1", "c2"}, nil, false, "") == base {
 		t.Error("comment change should invalidate hash")
 	}
 
 	// Change related commits.
-	if computeContentHash("open", "bug", "body", []string{"c1"}, []string{"abc123:fix thing"}) == base {
+	if computeContentHash("open", "bug", "body", []string{"c1"}, []string{"abc123:fix thing"}, false, "") == base {
 		t.Error("commit change should invalidate hash")
+	}
+
+	// Change draft status.
+	if computeContentHash("open", "bug", "body", []string{"c1"}, nil, true, "") == base {
+		t.Error("draft change should invalidate hash")
+	}
+
+	// Change review state.
+	if computeContentHash("open", "bug", "body", []string{"c1"}, nil, false, "approved") == base {
+		t.Error("review state change should invalidate hash")
 	}
 }
 
@@ -171,6 +181,36 @@ func TestBuildItemSweepPrompt_WithRelatedCommits(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "Add content hashing (#42)") {
 		t.Error("prompt should contain commit subject")
+	}
+}
+
+func TestBuildItemSweepPrompt_PRMetadata(t *testing.T) {
+	item := &db.TrackedItem{
+		Owner:       "octocat",
+		Repo:        "hello-world",
+		Number:      10,
+		ItemType:    "pull_request",
+		Title:       "Add feature",
+		State:       "open",
+		IsDraft:     true,
+		ReviewState: "changes_requested",
+	}
+	content := &ghpkg.ItemContent{Body: "New feature"}
+
+	prompt := buildItemSweepPrompt(item, content, nil)
+
+	if !strings.Contains(prompt, "Draft:** yes") {
+		t.Error("prompt should contain draft status for draft PR")
+	}
+	if !strings.Contains(prompt, "Review:** changes_requested") {
+		t.Error("prompt should contain review state for PR")
+	}
+
+	// Non-PR should not have draft/review.
+	item.ItemType = "issue"
+	prompt = buildItemSweepPrompt(item, content, nil)
+	if strings.Contains(prompt, "Draft:") {
+		t.Error("issue prompt should not contain draft status")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Tier 2 analyzer now sees PR lifecycle: draft status, review state (approved/changes_requested/pending)
- New `FetchPRReviewState()` GitHub API call per open PR (aggregates per-reviewer reviews, no new LLM calls)
- Tier 2 prompt shows `[PR]` vs `[issue]` type tags with draft/review metadata; system prompt updated with PR lifecycle guidance
- Schema v6 migration adds `is_draft` + `review_state` columns; content hash invalidates on changes
- New CompactStatus values: `Draft`, `Appvd`, `ChReq`

Closes #37

## Test plan
- [x] All 15 packages pass (`go test ./...`)
- [x] New CompactStatus tests for draft, approved, changes_requested, priority ordering
- [x] Content hash invalidation tests for draft/review state changes
- [x] PR metadata included in sweep prompt test
- [x] Manual: run minder with tracked PRs, verify tier 2 prompt shows PR type + review state

🤖 Generated with [Claude Code](https://claude.com/claude-code)