### PR TITLE
Add quick cleanup for done tracked items (#42)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1079,3 +1079,53 @@ func TestPruneTrackedItems_RespectsKeepTerminal(t *testing.T) {
 		t.Errorf("pruned = %d, want 0 (only 2 terminal, keepTerminal=2)", pruned)
 	}
 }
+
+func TestRemoveTerminalTrackedItems(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "cleanuptest", MinderIdentity: "cleanuptest/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	// Add 3 open, 2 closed, 1 merged, 1 not-planned.
+	for i := 1; i <= 3; i++ {
+		store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i, LastStatus: "Open"})
+	}
+	store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 4, LastStatus: "Closd"})
+	store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 5, LastStatus: "Mrgd"})
+	store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 6, LastStatus: "Closd"})
+	store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 7, LastStatus: "NotPl"})
+
+	// Count terminal items.
+	count, err := store.CountTerminalTrackedItems(p.ID)
+	if err != nil {
+		t.Fatalf("CountTerminalTrackedItems: %v", err)
+	}
+	if count != 4 {
+		t.Errorf("count = %d, want 4", count)
+	}
+
+	// Remove terminal items.
+	removed, err := store.RemoveTerminalTrackedItems(p.ID)
+	if err != nil {
+		t.Fatalf("RemoveTerminalTrackedItems: %v", err)
+	}
+	if removed != 4 {
+		t.Errorf("removed = %d, want 4", removed)
+	}
+
+	// Verify only open items remain.
+	items, _ := store.GetTrackedItems(p.ID)
+	if len(items) != 3 {
+		t.Fatalf("remaining = %d, want 3", len(items))
+	}
+	for _, item := range items {
+		if item.LastStatus != "Open" {
+			t.Errorf("expected Open, got %s for #%d", item.LastStatus, item.Number)
+		}
+	}
+
+	// Count should now be 0.
+	count, _ = store.CountTerminalTrackedItems(p.ID)
+	if count != 0 {
+		t.Errorf("count after cleanup = %d, want 0", count)
+	}
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -483,6 +483,30 @@ func (s *Store) PruneTrackedItems(projectID int64, maxTotal, keepTerminal int) (
 	return pruned, nil
 }
 
+// RemoveTerminalTrackedItems deletes all tracked items with terminal status
+// (Closd, Mrgd, NotPl) for a project. Returns the number of items removed.
+func (s *Store) RemoveTerminalTrackedItems(projectID int64) (int, error) {
+	result, err := s.db.Exec(`
+		DELETE FROM tracked_items
+		WHERE project_id = ? AND last_status IN ('Closd', 'Mrgd', 'NotPl')
+	`, projectID)
+	if err != nil {
+		return 0, fmt.Errorf("remove terminal tracked items: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}
+
+// CountTerminalTrackedItems returns the count of tracked items with terminal status.
+func (s *Store) CountTerminalTrackedItems(projectID int64) (int, error) {
+	var count int
+	err := s.db.Get(&count, `
+		SELECT COUNT(*) FROM tracked_items
+		WHERE project_id = ? AND last_status IN ('Closd', 'Mrgd', 'NotPl')
+	`, projectID)
+	return count, err
+}
+
 // LastPoll returns the most recent poll for a project, or nil if none.
 func (s *Store) LastPoll(projectID int64) (*Poll, error) {
 	polls, err := s.RecentPolls(projectID, 1)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -59,6 +59,12 @@ type bulkUntrackResultMsg struct {
 	errors  []string
 }
 
+// cleanupResultMsg is sent when cleanup of terminal items completes.
+type cleanupResultMsg struct {
+	removed int
+	err     error
+}
+
 // trackFormRow holds one row of the multi-repo track/untrack form.
 type trackFormRow struct {
 	owner, repo, ownerRepo string
@@ -70,9 +76,10 @@ type trackFormRow struct {
 type trackStep int
 
 const (
-	trackStepInput    trackStep = iota // entering issue numbers
-	trackStepFetching                  // fetching item details from GitHub
-	trackStepPreview                   // showing items for confirmation
+	trackStepInput          trackStep = iota // entering issue numbers
+	trackStepFetching                       // fetching item details from GitHub
+	trackStepPreview                        // showing items for confirmation
+	trackStepCleanupConfirm                 // confirming cleanup of terminal items
 )
 
 // trackPreviewItem holds resolved item info for the confirmation preview.
@@ -144,6 +151,7 @@ type Model struct {
 	trackError        bool
 	trackStep         trackStep
 	trackPreviewItems []trackPreviewItem
+	trackCleanupCount int // number of terminal items pending cleanup
 
 	// Filter mode (bulk add tracked items).
 	filterState  *filterState
@@ -379,12 +387,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		return m, nil
 
+	case cleanupResultMsg:
+		m.trackedItems, _ = m.store.GetTrackedItems(m.project.ID)
+		if msg.err != nil {
+			m.trackError = true
+			m.trackStatus = fmt.Sprintf("Cleanup failed: %v", msg.err)
+		} else {
+			m.trackStatus = fmt.Sprintf("Cleaned up %d done items", msg.removed)
+		}
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearTrackStatusMsg{}
+		})
+
 	case clearTrackStatusMsg:
 		m.trackStatus = ""
 		m.trackError = false
 		m.trackRows = nil
 		m.trackStep = trackStepInput
 		m.trackPreviewItems = nil
+		m.trackCleanupCount = 0
 		m.mode = "normal"
 		m.resizeViewports()
 		return m, nil
@@ -691,6 +712,32 @@ func (m Model) updateTrack(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Cleanup confirm step: y to proceed, n/esc to go back.
+	if m.trackStep == trackStepCleanupConfirm {
+		switch msg.String() {
+		case "y":
+			store := m.store
+			projectID := m.project.ID
+			m.trackStep = trackStepFetching
+			m.trackStatus = fmt.Sprintf("Cleaning up %d items...", m.trackCleanupCount)
+			return m, tea.Batch(m.spinner.Tick, func() tea.Msg {
+				removed, err := store.RemoveTerminalTrackedItems(projectID)
+				return cleanupResultMsg{removed: removed, err: err}
+			})
+		case "n", "esc":
+			m.trackStep = trackStepInput
+			m.trackCleanupCount = 0
+			if len(m.trackRows) > 0 {
+				cmd := m.trackRows[m.trackFocus].input.Focus()
+				m.resizeViewports()
+				return m, cmd
+			}
+			m.resizeViewports()
+			return m, nil
+		}
+		return m, nil
+	}
+
 	// Fetching step: only allow esc.
 	if m.trackStep == trackStepFetching {
 		if msg.String() == "esc" {
@@ -732,6 +779,24 @@ func (m Model) updateTrack(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "enter":
 		return m.submitTrackForm()
+	case "c":
+		if m.mode == "untrack" {
+			count, err := m.store.CountTerminalTrackedItems(m.project.ID)
+			if err != nil || count == 0 {
+				m.trackStatus = "No done items to clean up"
+				m.trackError = false
+				return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+					return clearTrackStatusMsg{}
+				})
+			}
+			for i := range m.trackRows {
+				m.trackRows[i].input.Blur()
+			}
+			m.trackCleanupCount = count
+			m.trackStep = trackStepCleanupConfirm
+			m.resizeViewports()
+			return m, nil
+		}
 	}
 
 	var cmd tea.Cmd

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -578,7 +578,12 @@ func (m Model) renderBottomBar() string {
 		}
 		b.WriteString("\n")
 	case "track", "untrack":
-		if m.trackStep == trackStepPreview {
+		if m.trackStep == trackStepCleanupConfirm {
+			b.WriteString(headerStyle().Render(fmt.Sprintf("  Clean up %d done items? (y/n)", m.trackCleanupCount)))
+			b.WriteString("\n")
+			b.WriteString(helpStyle().Render("y: confirm \u2022 n/esc: cancel"))
+			b.WriteString("\n")
+		} else if m.trackStep == trackStepPreview {
 			// Preview step: help bar only (preview renders in main content area).
 			action := "track"
 			if m.mode == "untrack" {
@@ -612,6 +617,9 @@ func (m Model) renderBottomBar() string {
 				b.WriteString("\n")
 			}
 			help := "up/down: navigate \u2022 enter: submit \u2022 esc: cancel"
+			if m.mode == "untrack" {
+				help += " \u2022 c: clean up done"
+			}
 			b.WriteString(helpStyle().Render(help))
 			b.WriteString("\n")
 		}


### PR DESCRIPTION
## Summary
- Adds `c` key in untrack mode (I) to bulk-remove all merged/closed/not-planned tracked items
- Shows confirmation prompt with count before removing (y/n)
- Adds `RemoveTerminalTrackedItems` and `CountTerminalTrackedItems` DB methods with test coverage

## Test plan
- [x] `go test ./...` passes
- [x] New `TestRemoveTerminalTrackedItems` test covers count + remove + verify
- [x] Manual: press I, then c — should show "Clean up N done items? (y/n)"
- [x] Manual: press y — items removed, status shown; press n — returns to input

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)