### PR TITLE
Fix startup UI: show spinner and keep controls visible

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -209,6 +209,7 @@ func (p *Poller) IsPaused() bool {
 
 // PollNow triggers an immediate poll cycle.
 func (p *Poller) PollNow(ctx context.Context) {
+	p.emit("polling", "Polling...", nil)
 	result, err := p.doPoll(ctx)
 	if err != nil {
 		p.emit("error", err.Error(), nil)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -222,6 +222,7 @@ func New(project *db.Project, store *db.Store, p *poller.Poller) Model {
 		userMsgInput:   ta,
 		onboardInput:   oi,
 		spinner:    sp,
+		polling:    true, // initial poll starts immediately
 		analysisVP: aVP,
 		eventLogVP:     eVP,
 		lastUserInput:  time.Now(),
@@ -290,6 +291,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.events) > 50 {
 			m.events = m.events[len(m.events)-50:]
 		}
+		if event.Type == "polling" {
+			m.polling = true
+		}
 		if event.PollResult != nil {
 			m.lastPoll = event.PollResult
 			m.polling = false
@@ -298,6 +302,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.rebuildEventLogContent()
 		m.rebuildAnalysisContent()
+		m.resizeViewports()
 		return m, listenForEvents(m.poller)
 
 	case broadcastResultMsg:
@@ -481,7 +486,6 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "r":
-		m.polling = true
 		p := m.poller
 		return m, func() tea.Msg {
 			p.PollNow(context.Background())


### PR DESCRIPTION
## Summary
- Emit a `"polling"` event from `PollNow()` so the TUI shows a spinner during the initial automatic poll (not just manual `r` presses)
- Set `polling: true` on model init since the poller fires immediately on startup
- Call `resizeViewports()` when poller events arrive so the height budget recalculates and controls stay visible

Fixes #45

## Test plan
- [x] Start the app — spinner and "polling..." should appear immediately
- [x] Bottom control bar (p/r/m/q/?) should be visible before first poll completes
- [x] After first poll completes, spinner stops and analysis renders normally
- [x] Manual poll (`r`) still shows spinner correctly
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)