### PR TITLE
Filter mode: selectable choices for labels, milestones, assignees

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -259,6 +259,88 @@ func (c *Client) SearchIssues(ctx context.Context, owner, repo string, filterTyp
 	}, nil
 }
 
+// RepoChoice represents a selectable option fetched from a GitHub repo.
+type RepoChoice struct {
+	Value       string // The value to use in the filter (label name, milestone title, username)
+	Description string // Optional extra info (e.g., milestone due date)
+}
+
+// ListLabels returns all labels for a repo.
+func (c *Client) ListLabels(ctx context.Context, owner, repo string) ([]RepoChoice, error) {
+	var all []RepoChoice
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		labels, resp, err := c.gh.Issues.ListLabels(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list labels: %w", err)
+		}
+		for _, l := range labels {
+			all = append(all, RepoChoice{
+				Value:       l.GetName(),
+				Description: l.GetDescription(),
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return all, nil
+}
+
+// ListMilestones returns open milestones for a repo.
+func (c *Client) ListMilestones(ctx context.Context, owner, repo string) ([]RepoChoice, error) {
+	var all []RepoChoice
+	opts := &github.MilestoneListOptions{
+		State:       "open",
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	for {
+		milestones, resp, err := c.gh.Issues.ListMilestones(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list milestones: %w", err)
+		}
+		for _, ms := range milestones {
+			desc := ""
+			if ms.DueOn != nil {
+				desc = "due " + ms.GetDueOn().Format("2006-01-02")
+			}
+			all = append(all, RepoChoice{
+				Value:       ms.GetTitle(),
+				Description: desc,
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return all, nil
+}
+
+// ListAssignees returns available assignees for a repo.
+func (c *Client) ListAssignees(ctx context.Context, owner, repo string) ([]RepoChoice, error) {
+	var all []RepoChoice
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		users, resp, err := c.gh.Issues.ListAssignees(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list assignees: %w", err)
+		}
+		for _, u := range users {
+			all = append(all, RepoChoice{
+				Value:       u.GetLogin(),
+				Description: u.GetName(),
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return all, nil
+}
+
 func extractLabels(labels []*github.Label) []string {
 	out := make([]string, 0, len(labels))
 	for _, l := range labels {

--- a/internal/poller/tracked.go
+++ b/internal/poller/tracked.go
@@ -52,6 +52,26 @@ func (p *Poller) SearchGitHubIssues(ctx context.Context, owner, repo string, fil
 	return gh.SearchIssues(ctx, owner, repo, filterType, filterValue)
 }
 
+// FetchFilterChoices returns available choices for a filter type from GitHub.
+func (p *Poller) FetchFilterChoices(ctx context.Context, owner, repo string, filterType ghpkg.FilterType) ([]ghpkg.RepoChoice, error) {
+	token := config.GetIntegrationToken("github")
+	if token == "" {
+		return nil, fmt.Errorf("no GitHub token configured")
+	}
+	gh := ghpkg.NewClient(token)
+
+	switch filterType {
+	case ghpkg.FilterLabel:
+		return gh.ListLabels(ctx, owner, repo)
+	case ghpkg.FilterMilestone:
+		return gh.ListMilestones(ctx, owner, repo)
+	case ghpkg.FilterAssignee:
+		return gh.ListAssignees(ctx, owner, repo)
+	default:
+		return nil, nil
+	}
+}
+
 // BulkAddTrackedItems converts ItemStatus results to TrackedItems and bulk-inserts them.
 // Returns the number of items actually added.
 func (p *Poller) BulkAddTrackedItems(ctx context.Context, items []ghpkg.ItemStatus, owner, repo string) (int, error) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -415,6 +415,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		return m, nil
 
+	case filterChoicesMsg:
+		if m.filterState != nil {
+			if msg.err != nil || len(msg.choices) == 0 {
+				// No choices available or error — fall back to text input.
+				m.filterState.step = filterStepInputValue
+				switch m.filterState.filterType {
+				case ghpkg.FilterLabel:
+					m.filterState.input.Placeholder = "label name..."
+				case ghpkg.FilterMilestone:
+					m.filterState.input.Placeholder = "milestone title..."
+				case ghpkg.FilterAssignee:
+					m.filterState.input.Placeholder = "username..."
+				}
+				return m, m.filterState.input.Focus()
+			}
+			m.filterState.choices = msg.choices
+			m.filterState.choiceIdx = 0
+			m.filterState.step = filterStepSelectChoice
+		}
+		return m, nil
+
 	case filterSearchResultMsg:
 		if m.filterState != nil {
 			if msg.err != nil {

--- a/internal/tui/filter.go
+++ b/internal/tui/filter.go
@@ -17,6 +17,8 @@ type filterStep int
 const (
 	filterStepSelectRepo filterStep = iota
 	filterStepSelectType
+	filterStepFetchingChoices
+	filterStepSelectChoice
 	filterStepInputValue
 	filterStepFetching
 	filterStepPreview
@@ -26,6 +28,12 @@ const (
 // filterSearchResultMsg is sent when a filter search completes.
 type filterSearchResultMsg struct {
 	results *ghpkg.SearchResult
+	err     error
+}
+
+// filterChoicesMsg is sent when available choices for a filter type are fetched.
+type filterChoicesMsg struct {
+	choices []ghpkg.RepoChoice
 	err     error
 }
 
@@ -44,6 +52,8 @@ type filterState struct {
 	filterType   ghpkg.FilterType
 	filterValue  string
 	results      *ghpkg.SearchResult
+	choices      []ghpkg.RepoChoice // available choices for the selected filter type
+	choiceIdx    int                // currently highlighted choice
 	input        textinput.Model
 	err          error
 	hasExisting  bool // true if project already has tracked items
@@ -86,6 +96,8 @@ func (m Model) updateFilter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.updateFilterSelectRepo(msg)
 	case filterStepSelectType:
 		return m.updateFilterSelectType(msg)
+	case filterStepSelectChoice:
+		return m.updateFilterSelectChoice(msg)
 	case filterStepInputValue:
 		return m.updateFilterInputValue(msg)
 	case filterStepPreview:
@@ -134,17 +146,12 @@ func (m Model) updateFilterSelectType(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	case "l":
 		fs.filterType = ghpkg.FilterLabel
-		fs.step = filterStepInputValue
-		fs.input.Placeholder = "label name..."
-		cmd := fs.input.Focus()
-		return m, cmd
+		return m.startFetchChoices()
 	case "m":
 		fs.filterType = ghpkg.FilterMilestone
-		fs.step = filterStepInputValue
-		fs.input.Placeholder = "milestone title..."
-		cmd := fs.input.Focus()
-		return m, cmd
+		return m.startFetchChoices()
 	case "p":
+		// Projects are org-level, no list API — go straight to input.
 		fs.filterType = ghpkg.FilterProject
 		fs.step = filterStepInputValue
 		fs.input.Placeholder = "org/project-number..."
@@ -152,8 +159,77 @@ func (m Model) updateFilterSelectType(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		return m, cmd
 	case "a":
 		fs.filterType = ghpkg.FilterAssignee
+		return m.startFetchChoices()
+	}
+	return m, nil
+}
+
+// startFetchChoices kicks off the async fetch of available choices for the selected filter type.
+func (m Model) startFetchChoices() (tea.Model, tea.Cmd) {
+	fs := m.filterState
+	fs.step = filterStepFetchingChoices
+	fs.choices = nil
+	fs.choiceIdx = 0
+	fs.err = nil
+
+	p := m.poller
+	owner := fs.selectedRepo.Owner
+	repo := fs.selectedRepo.Repo
+	ft := fs.filterType
+
+	return m, func() tea.Msg {
+		choices, err := p.FetchFilterChoices(context.Background(), owner, repo, ft)
+		return filterChoicesMsg{choices: choices, err: err}
+	}
+}
+
+func (m Model) updateFilterSelectChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	fs := m.filterState
+	switch msg.String() {
+	case "esc":
+		fs.step = filterStepSelectType
+		fs.choices = nil
+		return m, nil
+	case "up", "k":
+		if fs.choiceIdx > 0 {
+			fs.choiceIdx--
+		}
+		return m, nil
+	case "down", "j":
+		// Last entry is the "type custom" option, so total count = len(choices) + 1
+		max := len(fs.choices)
+		if fs.choiceIdx < max {
+			fs.choiceIdx++
+		}
+		return m, nil
+	case "enter":
+		if fs.choiceIdx < len(fs.choices) {
+			// Selected an existing choice — use it directly.
+			fs.filterValue = fs.choices[fs.choiceIdx].Value
+			fs.step = filterStepFetching
+			fs.err = nil
+
+			p := m.poller
+			owner := fs.selectedRepo.Owner
+			repo := fs.selectedRepo.Repo
+			ft := fs.filterType
+			fv := fs.filterValue
+
+			return m, func() tea.Msg {
+				result, err := p.SearchGitHubIssues(context.Background(), owner, repo, ft, fv)
+				return filterSearchResultMsg{results: result, err: err}
+			}
+		}
+		// "Type custom value" option selected — go to text input.
 		fs.step = filterStepInputValue
-		fs.input.Placeholder = "username..."
+		switch fs.filterType {
+		case ghpkg.FilterLabel:
+			fs.input.Placeholder = "label name..."
+		case ghpkg.FilterMilestone:
+			fs.input.Placeholder = "milestone title..."
+		case ghpkg.FilterAssignee:
+			fs.input.Placeholder = "username..."
+		}
 		cmd := fs.input.Focus()
 		return m, cmd
 	}
@@ -164,7 +240,12 @@ func (m Model) updateFilterInputValue(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 	fs := m.filterState
 	switch msg.String() {
 	case "esc":
-		fs.step = filterStepSelectType
+		if len(fs.choices) > 0 {
+			// Go back to the choice list if we came from there.
+			fs.step = filterStepSelectChoice
+		} else {
+			fs.step = filterStepSelectType
+		}
 		fs.input.Blur()
 		fs.input.Reset()
 		return m, nil
@@ -311,6 +392,51 @@ func (m Model) renderFilterView() string {
 		b.WriteString(textStyle().Render("    [p] project"))
 		b.WriteString("\n")
 		b.WriteString(textStyle().Render("    [a] assignee"))
+		b.WriteString("\n")
+
+	case filterStepFetchingChoices:
+		b.WriteString(textStyle().Render(fmt.Sprintf("  Repo: %s/%s  Filter: %s",
+			fs.selectedRepo.Owner, fs.selectedRepo.Repo, fs.filterType)))
+		b.WriteString("\n\n")
+		b.WriteString("  ")
+		b.WriteString(m.spinner.View())
+		b.WriteString(" ")
+		b.WriteString(mutedStyle().Render("Loading available options..."))
+		b.WriteString("\n")
+
+	case filterStepSelectChoice:
+		b.WriteString(textStyle().Render(fmt.Sprintf("  Repo: %s/%s  Filter: %s",
+			fs.selectedRepo.Owner, fs.selectedRepo.Repo, fs.filterType)))
+		b.WriteString("\n\n")
+		b.WriteString(textStyle().Render("  Select a value:"))
+		b.WriteString("\n")
+		for i, c := range fs.choices {
+			prefix := "  "
+			if i == fs.choiceIdx {
+				prefix = "> "
+			}
+			entry := fmt.Sprintf("  %s%s", prefix, c.Value)
+			if c.Description != "" {
+				entry += mutedStyle().Render(fmt.Sprintf(" (%s)", c.Description))
+			}
+			if i == fs.choiceIdx {
+				b.WriteString(headerStyle().Render(entry))
+			} else {
+				b.WriteString(textStyle().Render(entry))
+			}
+			b.WriteString("\n")
+		}
+		// "Type custom" option at the end.
+		customPrefix := "  "
+		if fs.choiceIdx == len(fs.choices) {
+			customPrefix = "> "
+		}
+		customEntry := fmt.Sprintf("  %s✎ type custom value...", customPrefix)
+		if fs.choiceIdx == len(fs.choices) {
+			b.WriteString(headerStyle().Render(customEntry))
+		} else {
+			b.WriteString(mutedStyle().Render(customEntry))
+		}
 		b.WriteString("\n")
 
 	case filterStepInputValue:


### PR DESCRIPTION
## Summary

- When filtering issues by label, milestone, or assignee (`f` → `l`/`m`/`a`), the TUI now fetches available options from the GitHub API and presents them as a navigable list
- Users can pick from the list or select "type custom value..." to enter manually
- Falls back gracefully to text input if the fetch fails or returns no results
- Project filter (`p`) retains manual input since there's no list API

Closes #47

## Test plan

- [ ] Press `f` → select repo → press `l` → verify labels load and display as selectable list
- [ ] Navigate with `j`/`k` or arrows, press `enter` to select a label and trigger search
- [ ] Select "type custom value..." option and verify text input works
- [ ] Press `m` → verify milestones load with due dates shown
- [ ] Press `a` → verify assignees load with display names
- [ ] Press `p` → verify it goes straight to text input (no choices fetch)
- [ ] Press `esc` from choice list → returns to filter type selection
- [ ] Press `esc` from text input (after coming from choice list) → returns to choice list
- [ ] Test with a repo that has no labels → should fall back to text input

🤖 Generated with [Claude Code](https://claude.com/claude-code)