### PR TITLE
Fix milestone filter 422 error and wrap long error messages

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -263,6 +263,7 @@ func (c *Client) SearchIssues(ctx context.Context, owner, repo string, filterTyp
 type RepoChoice struct {
 	Value       string // The value to use in the filter (label name, milestone title, username)
 	Description string // Optional extra info (e.g., milestone due date)
+	ID          int    // Numeric ID (e.g., milestone number) for API calls that need it
 }
 
 // ListLabels returns all labels for a repo.
@@ -308,6 +309,7 @@ func (c *Client) ListMilestones(ctx context.Context, owner, repo string) ([]Repo
 			all = append(all, RepoChoice{
 				Value:       ms.GetTitle(),
 				Description: desc,
+				ID:          ms.GetNumber(),
 			})
 		}
 		if resp.NextPage == 0 {
@@ -339,6 +341,44 @@ func (c *Client) ListAssignees(ctx context.Context, owner, repo string) ([]RepoC
 		opts.Page = resp.NextPage
 	}
 	return all, nil
+}
+
+// ListIssuesByMilestone returns open issues for a specific milestone number.
+// Uses the Issues list API instead of the Search API to avoid query syntax issues
+// with special characters in milestone titles.
+func (c *Client) ListIssuesByMilestone(ctx context.Context, owner, repo string, milestoneNumber int) (*SearchResult, error) {
+	var allItems []ItemStatus
+	opts := &github.IssueListByRepoOptions{
+		Milestone: fmt.Sprintf("%d", milestoneNumber),
+		State:     "open",
+		ListOptions: github.ListOptions{
+			PerPage: 21,
+		},
+	}
+
+	issues, _, err := c.gh.Issues.ListByRepo(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list issues by milestone: %w", err)
+	}
+
+	for _, issue := range issues {
+		// Skip pull requests (Issues API returns PRs too).
+		if issue.PullRequestLinks != nil {
+			continue
+		}
+		allItems = append(allItems, ItemStatus{
+			Number:   issue.GetNumber(),
+			Title:    issue.GetTitle(),
+			State:    issue.GetState(),
+			Labels:   extractLabels(issue.Labels),
+			ItemType: "issue",
+		})
+	}
+
+	return &SearchResult{
+		Items:      allItems,
+		TotalCount: len(allItems),
+	}, nil
 }
 
 func extractLabels(labels []*github.Label) []string {

--- a/internal/poller/tracked.go
+++ b/internal/poller/tracked.go
@@ -72,6 +72,16 @@ func (p *Poller) FetchFilterChoices(ctx context.Context, owner, repo string, fil
 	}
 }
 
+// SearchIssuesByMilestone searches for issues using a milestone number via the Issues API.
+func (p *Poller) SearchIssuesByMilestone(ctx context.Context, owner, repo string, milestoneNumber int) (*ghpkg.SearchResult, error) {
+	token := config.GetIntegrationToken("github")
+	if token == "" {
+		return nil, fmt.Errorf("no GitHub token configured")
+	}
+	gh := ghpkg.NewClient(token)
+	return gh.ListIssuesByMilestone(ctx, owner, repo, milestoneNumber)
+}
+
 // BulkAddTrackedItems converts ItemStatus results to TrackedItems and bulk-inserts them.
 // Returns the number of items actually added.
 func (p *Poller) BulkAddTrackedItems(ctx context.Context, items []ghpkg.ItemStatus, owner, repo string) (int, error) {

--- a/internal/tui/filter.go
+++ b/internal/tui/filter.go
@@ -205,7 +205,8 @@ func (m Model) updateFilterSelectChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 	case "enter":
 		if fs.choiceIdx < len(fs.choices) {
 			// Selected an existing choice — use it directly.
-			fs.filterValue = fs.choices[fs.choiceIdx].Value
+			choice := fs.choices[fs.choiceIdx]
+			fs.filterValue = choice.Value
 			fs.step = filterStepFetching
 			fs.err = nil
 
@@ -214,9 +215,18 @@ func (m Model) updateFilterSelectChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 			repo := fs.selectedRepo.Repo
 			ft := fs.filterType
 			fv := fs.filterValue
+			choiceID := choice.ID
 
 			return m, func() tea.Msg {
-				result, err := p.SearchGitHubIssues(context.Background(), owner, repo, ft, fv)
+				var result *ghpkg.SearchResult
+				var err error
+				if ft == ghpkg.FilterMilestone && choiceID > 0 {
+					// Use Issues API with milestone number to avoid search query
+					// syntax issues with special characters in milestone titles.
+					result, err = p.SearchIssuesByMilestone(context.Background(), owner, repo, choiceID)
+				} else {
+					result, err = p.SearchGitHubIssues(context.Background(), owner, repo, ft, fv)
+				}
 				return filterSearchResultMsg{results: result, err: err}
 			}
 		}
@@ -462,7 +472,12 @@ func (m Model) renderFilterView() string {
 		b.WriteString("\n\n")
 
 		if fs.err != nil {
-			b.WriteString(errorStyle().Render(fmt.Sprintf("  Error: %v", fs.err)))
+			errMsg := fmt.Sprintf("  Error: %v", fs.err)
+			maxW := m.width - 4
+			if maxW > 20 {
+				errMsg = wrapText(errMsg, maxW)
+			}
+			b.WriteString(errorStyle().Render(errMsg))
 			b.WriteString("\n")
 		} else if fs.results == nil || len(fs.results.Items) == 0 {
 			b.WriteString(mutedStyle().Render("  No matching issues found."))
@@ -503,5 +518,29 @@ func (m Model) renderFilterView() string {
 		b.WriteString("\n")
 	}
 
+	return b.String()
+}
+
+// wrapText wraps a string to the given width, breaking on spaces.
+func wrapText(s string, width int) string {
+	if len(s) <= width {
+		return s
+	}
+	var b strings.Builder
+	line := ""
+	for _, word := range strings.Fields(s) {
+		if line == "" {
+			line = word
+		} else if len(line)+1+len(word) > width {
+			b.WriteString(line)
+			b.WriteString("\n  ")
+			line = word
+		} else {
+			line += " " + word
+		}
+	}
+	if line != "" {
+		b.WriteString(line)
+	}
 	return b.String()
 }


### PR DESCRIPTION
## Summary

- Milestone titles with special characters (e.g., `@` in `"Beta @ The Gym"`) cause 422 errors from GitHub's Search API
- When a milestone is selected from the choice list, now uses the Issues list API with milestone number instead of the Search API, avoiding query syntax issues entirely
- Long error messages now wrap to terminal width instead of running off-screen

Closes #47

## Test plan

- [ ] Select a milestone with special characters (`@`, `"`, etc.) from the choice list — should return results without error
- [ ] Trigger a search error and verify the message wraps within the terminal width
- [ ] Verify normal milestone selection (no special chars) still works
- [ ] Verify label and assignee filters are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)