### PR TITLE
Add update option to filter conflict step

### DIFF
--- a/internal/poller/tracked.go
+++ b/internal/poller/tracked.go
@@ -122,6 +122,24 @@ func (p *Poller) ClearAndBulkAddTrackedItems(ctx context.Context, items []ghpkg.
 	return p.BulkAddTrackedItems(ctx, items, owner, repo)
 }
 
+// UpdateTrackedItems removes terminal (closed/merged/not-planned) items and adds new ones.
+// Returns (added, removed, error).
+func (p *Poller) UpdateTrackedItems(ctx context.Context, items []ghpkg.ItemStatus, owner, repo string) (int, int, error) {
+	removed, err := p.store.RemoveTerminalTrackedItems(p.project.ID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("remove terminal items: %w", err)
+	}
+	if removed > 0 {
+		p.emit("tracked", fmt.Sprintf("Removed %d closed/merged items", removed), nil)
+	}
+
+	added, err := p.BulkAddTrackedItems(ctx, items, owner, repo)
+	if err != nil {
+		return 0, removed, err
+	}
+	return added, removed, nil
+}
+
 // DefaultOwnerRepo derives a default owner/repo from the project's enrolled repos.
 // It looks for GitHub remote URLs and returns the first match.
 func (p *Poller) DefaultOwnerRepo() (owner, repo string) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -461,6 +461,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return clearFilterStatusMsg{}
 		})
 
+	case bulkUpdateResultMsg:
+		if msg.err != nil {
+			m.filterStatus = fmt.Sprintf("Error: %v", msg.err)
+		} else {
+			m.filterStatus = fmt.Sprintf("Updated: +%d new, -%d closed", msg.added, msg.removed)
+			m.trackedItems, _ = m.store.GetTrackedItems(m.project.ID)
+		}
+		m.filterState = nil
+		m.mode = "normal"
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearFilterStatusMsg{}
+		})
+
 	case clearFilterStatusMsg:
 		m.filterStatus = ""
 		return m, nil

--- a/internal/tui/filter.go
+++ b/internal/tui/filter.go
@@ -43,6 +43,13 @@ type bulkAddResultMsg struct {
 	err   error
 }
 
+// bulkUpdateResultMsg is sent when an update (add new + remove terminal) completes.
+type bulkUpdateResultMsg struct {
+	added   int
+	removed int
+	err     error
+}
+
 // filterState holds all state for the filter flow.
 type filterState struct {
 	step         filterStep
@@ -335,6 +342,13 @@ func (m Model) updateFilterConflict(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			items = items[:20]
 		}
 		return m.startBulkAdd(items, true)
+	case "u":
+		// Update: add new items and remove closed/merged/not-planned.
+		items := fs.results.Items
+		if len(items) > 20 {
+			items = items[:20]
+		}
+		return m.startBulkUpdate(items)
 	}
 	return m, nil
 }
@@ -357,6 +371,21 @@ func (m Model) startBulkAdd(items []ghpkg.ItemStatus, clearFirst bool) (tea.Mode
 			added, err = p.BulkAddTrackedItems(context.Background(), items, owner, repo)
 		}
 		return bulkAddResultMsg{added: added, err: err}
+	}
+}
+
+// startBulkUpdate kicks off the async update operation: removes terminal items then adds new ones.
+func (m Model) startBulkUpdate(items []ghpkg.ItemStatus) (tea.Model, tea.Cmd) {
+	fs := m.filterState
+	fs.step = filterStepFetching // reuse fetching step for spinner
+
+	p := m.poller
+	owner := fs.selectedRepo.Owner
+	repo := fs.selectedRepo.Repo
+
+	return m, func() tea.Msg {
+		added, removed, err := p.UpdateTrackedItems(context.Background(), items, owner, repo)
+		return bulkUpdateResultMsg{added: added, removed: removed, err: err}
 	}
 }
 
@@ -510,6 +539,8 @@ func (m Model) renderFilterView() string {
 	case filterStepConflict:
 		b.WriteString(textStyle().Render(fmt.Sprintf("  %d existing tracked items found.", len(m.trackedItems))))
 		b.WriteString("\n\n")
+		b.WriteString(textStyle().Render("  [u] update (add new, remove closed/merged)"))
+		b.WriteString("\n")
 		b.WriteString(textStyle().Render("  [a] append to existing"))
 		b.WriteString("\n")
 		b.WriteString(textStyle().Render("  [c] clear and replace"))


### PR DESCRIPTION
## Summary
- Adds `[u] update` option when re-running a filter with existing tracked items (#47)
- Update removes closed/merged/not-planned items, adds new matching issues, and preserves all tracking state (summaries, progress) on existing open items
- New `Poller.UpdateTrackedItems()` method uses existing `RemoveTerminalTrackedItems` + `BulkAddTrackedItems` (INSERT OR IGNORE for dedup)

## Test plan
- [ ] Run `(f)` filter on a milestone/label with existing tracked items — verify `[u] update` option appears
- [ ] Select `[u]` — verify closed/merged items are removed and new items are added
- [ ] Verify existing open items retain their objective/progress summaries
- [ ] Verify status bar shows `Updated: +N new, -N closed` message
- [ ] Run `go test ./...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)