### PR TITLE
Fix event log readability on light terminals

### DIFF
--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 )
 
 // View renders the TUI dashboard with height-budgeted sections.
@@ -371,7 +372,19 @@ func (m *Model) rebuildEventLogContent() {
 		if maxW < 20 {
 			maxW = 20
 		}
-		line := fmt.Sprintf("  [%s] %s: %s", ts, e.Type, truncateLine(summary, maxW))
+		summary = truncateLine(summary, maxW)
+		var style lipgloss.Style
+		switch e.Type {
+		case "user":
+			style = userMsgStyle()
+		case "broadcast":
+			style = broadcastStyle()
+		case "error":
+			style = errorStyle()
+		default:
+			style = mutedStyle()
+		}
+		line := fmt.Sprintf("  %s %s", mutedStyle().Render(fmt.Sprintf("[%s]", ts)), style.Render(fmt.Sprintf("%s: %s", e.Type, summary)))
 		lines = append(lines, line)
 	}
 	if len(lines) == 0 {


### PR DESCRIPTION
## Summary
- Color-codes event log entries by type: user (green), broadcast (cyan/italic), error (red), default (muted)
- Timestamps remain muted for visual separation from the styled content
- Fixes poor contrast that made `(u)` and `(m)` entries unreadable on light-themed terminals

Closes #54

## Test plan
- [ ] Run with light terminal theme, send user message (`u`) and broadcast (`m`), verify entries are legible
- [ ] Run with dark terminal theme, verify no regression in readability
- [ ] Cycle themes with `t` and verify all event types remain readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)