### PR TITLE
Fix textarea readability on light terminals

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -212,7 +212,7 @@ func New(project *db.Project, store *db.Store, p *poller.Poller) Model {
 	eVP.SoftWrap = true
 	eVP.FillHeight = true
 
-	return Model{
+	m := Model{
 		project:        project,
 		store:          store,
 		poller:         p,
@@ -227,6 +227,21 @@ func New(project *db.Project, store *db.Store, p *poller.Poller) Model {
 		eventLogVP:     eVP,
 		lastUserInput:  time.Now(),
 	}
+	m.applyTextareaTheme()
+	return m
+}
+
+// applyTextareaTheme sets textarea styles to match the current theme.
+func (m *Model) applyTextareaTheme() {
+	var s textarea.Styles
+	if currentTheme().Name == "light" {
+		s = textarea.DefaultLightStyles()
+	} else {
+		s = textarea.DefaultDarkStyles()
+	}
+	m.broadcastInput.SetStyles(s)
+	m.userMsgInput.SetStyles(s)
+	m.onboardInput.SetStyles(s)
 }
 
 func (m Model) Init() tea.Cmd {
@@ -597,6 +612,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "t":
 		cycleTheme()
+		m.applyTextareaTheme()
 		m.rebuildAnalysisContent()
 		m.rebuildEventLogContent()
 		return m, nil


### PR DESCRIPTION
## Summary
- Textarea inputs (user msg, broadcast, onboard) defaulted to dark styles, making text invisible on light terminals
- Added `applyTextareaTheme()` that switches between `textarea.DefaultLightStyles()` and `textarea.DefaultDarkStyles()` based on the active theme
- Called at init and on theme cycle (`t` key)

Closes #54

## Test plan
- [ ] Light terminal: press `u`, `m`, or `o` — textarea text should be readable
- [ ] Dark terminal: same inputs should still look correct
- [ ] Cycle themes with `t` while a textarea is open — styles should update

🤖 Generated with [Claude Code](https://claude.com/claude-code)