### PR TITLE
Archive completed tracked items for analyzer progress context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,15 +49,17 @@ Bubbletea v2 dashboard. Key bindings: `p` pause, `r` poll now, `e` expand, `u` u
 - Broadcast mode: `m` opens textarea, ctrl+d sends through tier 2 LLM → publishes to bus
 - Onboard mode: `o` opens textarea for optional guidance, ctrl+d generates onboarding message via tier 2 LLM → publishes to `<project>/onboarding` with replace semantics
 
-### DB schema (internal/db) — currently v2
+### DB schema (internal/db) — currently v7
 
 **projects**: name, goal_type, goal_description, refresh_interval_sec, message_ttl_sec, auto_enroll_worktrees, minder_identity, llm_provider, llm_model, llm_summarizer_model, llm_analyzer_model
 
 **polls**: project_id, new_commits, new_messages, concerns_raised, llm_response (legacy), tier1_response, tier2_response, bus_message_sent, polled_at
 
+**completed_items**: project_id, source, owner, repo, number, item_type, title, final_status, summary, completed_at — archived from tracked_items when they reach terminal state (only if progress_summary was non-empty)
+
 **Also**: repos, worktrees, topics, concerns (see `schema.go` for full DDL)
 
-Migration v1→v2 adds `llm_summarizer_model`/`llm_analyzer_model` to projects and `tier1_response`/`tier2_response`/`bus_message_sent` to polls, copies existing data into new columns.
+Migrations: v1→v2 (two-tier LLM columns), v3 (tracked_items), v4 (content hash + summaries), v5 (idle_pause_sec), v6 (is_draft + review_state), v7 (completed_items).
 
 `Poll.LLMResponse()` accessor returns tier2 > tier1 > raw (backward compat).
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1129,3 +1129,172 @@ func TestRemoveTerminalTrackedItems(t *testing.T) {
 		t.Errorf("count after cleanup = %d, want 0", count)
 	}
 }
+
+func TestArchiveTrackedItem(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "archivetest", MinderIdentity: "archivetest/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	// Item with progress summary should be archived.
+	item := &TrackedItem{
+		ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 1,
+		ItemType: "pull_request", Title: "Add auth", LastStatus: "Mrgd",
+		ObjectiveSummary: "Implement OAuth2 flow",
+		ProgressSummary:  "OAuth2 flow implemented and merged",
+	}
+	store.AddTrackedItem(item)
+
+	err := store.ArchiveTrackedItem(item)
+	if err != nil {
+		t.Fatalf("ArchiveTrackedItem: %v", err)
+	}
+
+	completed, err := store.RecentCompletedItems(p.ID, 3600)
+	if err != nil {
+		t.Fatalf("RecentCompletedItems: %v", err)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("completed count = %d, want 1", len(completed))
+	}
+	if completed[0].FinalStatus != "Mrgd" {
+		t.Errorf("final_status = %q, want Mrgd", completed[0].FinalStatus)
+	}
+	if completed[0].Summary != "Implement OAuth2 flow — OAuth2 flow implemented and merged" {
+		t.Errorf("summary = %q, want combined objective + progress", completed[0].Summary)
+	}
+}
+
+func TestArchiveTrackedItem_SkipsNoProgress(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "archiveskip", MinderIdentity: "archiveskip/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	// Item with no progress summary should NOT be archived.
+	item := &TrackedItem{
+		ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 2,
+		ItemType: "issue", Title: "Accidental add", LastStatus: "Closd",
+		ProgressSummary: "",
+	}
+	store.AddTrackedItem(item)
+
+	err := store.ArchiveTrackedItem(item)
+	if err != nil {
+		t.Fatalf("ArchiveTrackedItem: %v", err)
+	}
+
+	completed, _ := store.RecentCompletedItems(p.ID, 3600)
+	if len(completed) != 0 {
+		t.Errorf("completed count = %d, want 0 (no progress summary)", len(completed))
+	}
+}
+
+func TestArchiveTerminalTrackedItems(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "archiveterminal", MinderIdentity: "archiveterminal/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	// 2 open, 2 terminal (1 with progress, 1 without).
+	store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 1, LastStatus: "Open"})
+	store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 2, LastStatus: "Open"})
+	item3 := &TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 3, LastStatus: "Mrgd"}
+	store.AddTrackedItem(item3)
+	item3.ProgressSummary = "Feature shipped"
+	store.UpdateTrackedItem(item3)
+	store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: 4, LastStatus: "Closd"}) // no progress
+
+	removed, err := store.ArchiveTerminalTrackedItems(p.ID)
+	if err != nil {
+		t.Fatalf("ArchiveTerminalTrackedItems: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("removed = %d, want 2", removed)
+	}
+
+	// Only open items should remain.
+	items, _ := store.GetTrackedItems(p.ID)
+	if len(items) != 2 {
+		t.Errorf("remaining tracked = %d, want 2", len(items))
+	}
+
+	// Only 1 should be archived (the one with progress).
+	completed, _ := store.RecentCompletedItems(p.ID, 3600)
+	if len(completed) != 1 {
+		t.Errorf("completed count = %d, want 1", len(completed))
+	}
+	if len(completed) > 0 && completed[0].Number != 3 {
+		t.Errorf("archived item number = %d, want 3", completed[0].Number)
+	}
+}
+
+func TestPruneCompletedItems(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "prunecompleted", MinderIdentity: "prunecompleted/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	// Insert a completed item with an old timestamp.
+	store.db.Exec(`
+		INSERT INTO completed_items (project_id, source, owner, repo, number, item_type, title, final_status, summary, completed_at)
+		VALUES (?, 'github', 'org', 'repo', 1, 'issue', 'Old item', 'Closd', 'Done long ago', datetime('now', '-30 days'))
+	`, p.ID)
+
+	// Insert a recent one.
+	store.db.Exec(`
+		INSERT INTO completed_items (project_id, source, owner, repo, number, item_type, title, final_status, summary, completed_at)
+		VALUES (?, 'github', 'org', 'repo', 2, 'issue', 'Recent item', 'Mrgd', 'Just done', datetime('now'))
+	`, p.ID)
+
+	// Prune items older than 14 days.
+	pruned, err := store.PruneCompletedItems(p.ID, 14*24*3600)
+	if err != nil {
+		t.Fatalf("PruneCompletedItems: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("pruned = %d, want 1", pruned)
+	}
+
+	// Only the recent item should remain.
+	remaining, _ := store.RecentCompletedItems(p.ID, 30*24*3600)
+	if len(remaining) != 1 {
+		t.Fatalf("remaining = %d, want 1", len(remaining))
+	}
+	if remaining[0].Number != 2 {
+		t.Errorf("remaining item number = %d, want 2", remaining[0].Number)
+	}
+}
+
+func TestPruneTrackedItems_ArchivesBeforeDelete(t *testing.T) {
+	store := openTestDB(t)
+	p := &Project{Name: "prunearchive", MinderIdentity: "prunearchive/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	store.CreateProject(p)
+
+	// 5 open + 5 terminal (with progress summaries).
+	for i := 1; i <= 5; i++ {
+		store.AddTrackedItem(&TrackedItem{ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i, LastStatus: "Open"})
+	}
+	for i := 6; i <= 10; i++ {
+		item := &TrackedItem{
+			ProjectID: p.ID, Source: "github", Owner: "org", Repo: "repo", Number: i,
+			LastStatus: "Closd", LastCheckedAt: fmt.Sprintf("2026-01-%02dT00:00:00Z", i),
+		}
+		store.AddTrackedItem(item)
+		item.ProgressSummary = fmt.Sprintf("Work done on item %d", i)
+		store.UpdateTrackedItem(item)
+	}
+
+	pruned, err := store.PruneTrackedItems(p.ID, 10, 2)
+	if err != nil {
+		t.Fatalf("PruneTrackedItems: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("pruned = %d, want 1", pruned)
+	}
+
+	// The pruned item (#6, oldest) should now be in completed_items.
+	completed, _ := store.RecentCompletedItems(p.ID, 3600)
+	if len(completed) != 1 {
+		t.Fatalf("completed count = %d, want 1", len(completed))
+	}
+	if completed[0].Number != 6 {
+		t.Errorf("archived item number = %d, want 6", completed[0].Number)
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -123,6 +123,27 @@ func (t *TrackedItem) DisplayRef() string {
 	return fmt.Sprintf("%s/%s#%d", t.Owner, t.Repo, t.Number)
 }
 
+// CompletedItem represents a tracked item that reached terminal state and was archived
+// before being pruned. Only items with a progress summary are archived.
+type CompletedItem struct {
+	ID          int64  `db:"id"`
+	ProjectID   int64  `db:"project_id"`
+	Source      string `db:"source"`
+	Owner       string `db:"owner"`
+	Repo        string `db:"repo"`
+	Number      int    `db:"number"`
+	ItemType    string `db:"item_type"`
+	Title       string `db:"title"`
+	FinalStatus string `db:"final_status"` // "Closd", "Mrgd", "NotPl"
+	Summary     string `db:"summary"`      // snapshot of objective + progress
+	CompletedAt string `db:"completed_at"`
+}
+
+// DisplayRef returns a compact reference like "owner/repo#123".
+func (c *CompletedItem) DisplayRef() string {
+	return fmt.Sprintf("%s/%s#%d", c.Owner, c.Repo, c.Number)
+}
+
 // LLMResponse returns the best available response: tier 2 if present, else tier 1, else raw.
 func (p *Poll) LLMResponse() string {
 	if p.Tier2Response != "" {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -475,6 +475,9 @@ func (s *Store) PruneTrackedItems(projectID int64, maxTotal, keepTerminal int) (
 
 	pruned := 0
 	for i := 0; i < excess; i++ {
+		if err := s.ArchiveTrackedItem(&terminal[i]); err != nil {
+			return pruned, fmt.Errorf("archive tracked item %d: %w", terminal[i].ID, err)
+		}
 		if _, err := s.db.Exec(`DELETE FROM tracked_items WHERE id = ?`, terminal[i].ID); err != nil {
 			return pruned, fmt.Errorf("delete tracked item %d: %w", terminal[i].ID, err)
 		}
@@ -505,6 +508,88 @@ func (s *Store) CountTerminalTrackedItems(projectID int64) (int, error) {
 		WHERE project_id = ? AND last_status IN ('Closd', 'Mrgd', 'NotPl')
 	`, projectID)
 	return count, err
+}
+
+// --- Completed Items ---
+
+// ArchiveTrackedItem copies a terminal tracked item to the completed_items table.
+// Only archives items that have a non-empty progress summary (i.e., real work was done).
+// Builds a combined summary from the objective and progress summaries.
+func (s *Store) ArchiveTrackedItem(item *TrackedItem) error {
+	if item.ProgressSummary == "" {
+		return nil // skip items with no progress signal
+	}
+
+	summary := item.ProgressSummary
+	if item.ObjectiveSummary != "" {
+		summary = item.ObjectiveSummary + " — " + item.ProgressSummary
+	}
+
+	_, err := s.db.Exec(`
+		INSERT INTO completed_items (project_id, source, owner, repo, number, item_type, title, final_status, summary)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, item.ProjectID, item.Source, item.Owner, item.Repo, item.Number,
+		item.ItemType, item.Title, item.LastStatus, summary)
+	if err != nil {
+		return fmt.Errorf("archive tracked item %s/%s#%d: %w", item.Owner, item.Repo, item.Number, err)
+	}
+	return nil
+}
+
+// ArchiveTerminalTrackedItems archives all terminal tracked items (that have progress summaries)
+// and then deletes them. Returns the number removed.
+func (s *Store) ArchiveTerminalTrackedItems(projectID int64) (int, error) {
+	// Fetch terminal items first.
+	var terminal []TrackedItem
+	if err := s.db.Select(&terminal, `
+		SELECT * FROM tracked_items
+		WHERE project_id = ? AND last_status IN ('Closd', 'Mrgd', 'NotPl')
+	`, projectID); err != nil {
+		return 0, fmt.Errorf("select terminal items: %w", err)
+	}
+
+	for i := range terminal {
+		if err := s.ArchiveTrackedItem(&terminal[i]); err != nil {
+			return 0, err
+		}
+	}
+
+	result, err := s.db.Exec(`
+		DELETE FROM tracked_items
+		WHERE project_id = ? AND last_status IN ('Closd', 'Mrgd', 'NotPl')
+	`, projectID)
+	if err != nil {
+		return 0, fmt.Errorf("remove terminal tracked items: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}
+
+// RecentCompletedItems returns completed items for a project within maxAge.
+func (s *Store) RecentCompletedItems(projectID int64, maxAge int) ([]CompletedItem, error) {
+	var items []CompletedItem
+	if err := s.db.Select(&items, `
+		SELECT * FROM completed_items
+		WHERE project_id = ? AND completed_at > datetime('now', ? || ' seconds')
+		ORDER BY completed_at DESC
+	`, projectID, fmt.Sprintf("-%d", maxAge)); err != nil {
+		return nil, fmt.Errorf("recent completed items: %w", err)
+	}
+	return items, nil
+}
+
+// PruneCompletedItems removes completed items older than maxAgeSec.
+// Returns the number of items pruned.
+func (s *Store) PruneCompletedItems(projectID int64, maxAgeSec int) (int, error) {
+	result, err := s.db.Exec(`
+		DELETE FROM completed_items
+		WHERE project_id = ? AND completed_at <= datetime('now', ? || ' seconds')
+	`, projectID, fmt.Sprintf("-%d", maxAgeSec))
+	if err != nil {
+		return 0, fmt.Errorf("prune completed items: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
 }
 
 // LastPoll returns the most recent poll for a project, or nil if none.

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -8,7 +8,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 6
+const currentVersion = 7
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -99,6 +99,20 @@ CREATE TABLE IF NOT EXISTS tracked_items (
 	created_at          TEXT DEFAULT (datetime('now')),
 	UNIQUE(project_id, source, owner, repo, number)
 );
+
+CREATE TABLE IF NOT EXISTS completed_items (
+	id           INTEGER PRIMARY KEY,
+	project_id   INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+	source       TEXT NOT NULL DEFAULT 'github',
+	owner        TEXT NOT NULL,
+	repo         TEXT NOT NULL,
+	number       INTEGER NOT NULL,
+	item_type    TEXT NOT NULL DEFAULT 'issue',
+	title        TEXT NOT NULL DEFAULT '',
+	final_status TEXT NOT NULL DEFAULT 'Closd',
+	summary      TEXT NOT NULL DEFAULT '',
+	completed_at TEXT DEFAULT (datetime('now'))
+);
 `
 
 // Open opens (or creates) the agent-minder SQLite database and runs migrations,
@@ -163,6 +177,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 6 {
 		if err := migrateV6(db); err != nil {
 			return fmt.Errorf("apply migration v6: %w", err)
+		}
+	}
+
+	if version < 7 {
+		if err := migrateV7(db); err != nil {
+			return fmt.Errorf("apply migration v7: %w", err)
 		}
 	}
 
@@ -269,6 +289,28 @@ func migrateV6(db *sqlx.DB) error {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("%s: %w", stmt, err)
 		}
+	}
+	return nil
+}
+
+func migrateV7(db *sqlx.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS completed_items (
+			id           INTEGER PRIMARY KEY,
+			project_id   INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			source       TEXT NOT NULL DEFAULT 'github',
+			owner        TEXT NOT NULL,
+			repo         TEXT NOT NULL,
+			number       INTEGER NOT NULL,
+			item_type    TEXT NOT NULL DEFAULT 'issue',
+			title        TEXT NOT NULL DEFAULT '',
+			final_status TEXT NOT NULL DEFAULT 'Closd',
+			summary      TEXT NOT NULL DEFAULT '',
+			completed_at TEXT DEFAULT (datetime('now'))
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create completed_items table: %w", err)
 	}
 	return nil
 }

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -783,7 +783,17 @@ func (p *Poller) doPoll(ctx context.Context) (*PollResult, error) {
 		tier2Model = "claude-opus-4-6"
 	}
 
-	tier2Prompt := p.buildTier2Prompt(gitTier1, busTier1, trackedChanges, prStatusSection, concerns, trackedItems)
+	// Fetch recently completed items for progress context.
+	ttl := p.project.MessageTTLSec
+	if ttl <= 0 {
+		ttl = 14 * 24 * 3600
+	}
+	completedItems, err := p.store.RecentCompletedItems(p.project.ID, ttl)
+	if err != nil {
+		p.emit("error", fmt.Sprintf("fetching completed items: %v", err), nil)
+	}
+
+	tier2Prompt := p.buildTier2Prompt(gitTier1, busTier1, trackedChanges, prStatusSection, concerns, trackedItems, completedItems)
 	debugLog("llm call", "stage", "tier2", "step", "input", "component", "analyzer", "model", tier2Model, "system_prompt", tier2SystemPrompt(p.project.Name), "user_prompt", tier2Prompt)
 
 	tier2Resp, err := p.provider.Complete(ctx, &llm.Request{
@@ -972,6 +982,7 @@ Rules:
   - Severity levels: "info" (awareness, no action needed), "warning" (potential issue, monitor), "danger" (blocking or critical, needs immediate attention)
   - Keep each concern to 1-2 sentences. Be specific, not exhaustive.
   - Do NOT raise concerns about closed/merged items — they are done.
+  - A "Recently Completed Work" section may be present showing items that were previously tracked and have since been completed. Use this as evidence of forward progress — do NOT flag lack of progress if completed items show recent work.
   - For PRs: Use draft/review state to assess lifecycle. A draft PR is work-in-progress. "changes_requested" means the author needs to address feedback. "approved" means ready to merge. "pending" means awaiting review.
 
 - "bus_message": ONLY include when there is something genuinely actionable that other agents need to know (e.g., breaking changes, coordination needed, blocking issues). Most polls should NOT produce a bus message. Omit this field if not needed.
@@ -990,7 +1001,7 @@ Evidence standards:
 Keep analysis concise and focused on cross-repo coordination.`, projectName, projectName)
 }
 
-func (p *Poller) buildTier2Prompt(gitSummary, busSummary, trackedChanges, prStatus string, concerns []db.Concern, trackedItems []db.TrackedItem) string {
+func (p *Poller) buildTier2Prompt(gitSummary, busSummary, trackedChanges, prStatus string, concerns []db.Concern, trackedItems []db.TrackedItem, completedItems []db.CompletedItem) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "## Project Context\n")
@@ -1033,6 +1044,22 @@ func (p *Poller) buildTier2Prompt(gitSummary, busSummary, trackedChanges, prStat
 			}
 			if item.ProgressSummary != "" {
 				fmt.Fprintf(&b, "  Progress: %s\n", item.ProgressSummary)
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	if len(completedItems) > 0 {
+		b.WriteString("## Recently Completed Work\n")
+		b.WriteString("These items were previously tracked and have been completed. They provide context on recent progress.\n")
+		for _, ci := range completedItems {
+			typeTag := "issue"
+			if ci.ItemType == "pull_request" {
+				typeTag = "PR"
+			}
+			fmt.Fprintf(&b, "- [%s] [%s] %s: %s\n", ci.FinalStatus, typeTag, ci.DisplayRef(), ci.Title)
+			if ci.Summary != "" {
+				fmt.Fprintf(&b, "  %s\n", ci.Summary)
 			}
 		}
 		b.WriteString("\n")

--- a/internal/poller/sweep.go
+++ b/internal/poller/sweep.go
@@ -213,12 +213,24 @@ func (p *Poller) sweepTrackedItems(ctx context.Context, items []db.TrackedItem, 
 		}
 	}
 
-	// Auto-prune oldest terminal items when the list is full.
+	// Auto-prune oldest terminal items when the list is full (archives before deleting).
 	pruned, err := p.store.PruneTrackedItems(p.project.ID, 10, 2)
 	if err != nil {
 		p.emit("error", fmt.Sprintf("pruning tracked items: %v", err), nil)
 	} else if pruned > 0 {
-		p.emit("tracked", fmt.Sprintf("Pruned %d resolved tracked items", pruned), nil)
+		p.emit("tracked", fmt.Sprintf("Archived and pruned %d resolved tracked items", pruned), nil)
+	}
+
+	// Prune old completed items beyond the TTL (default 14 days).
+	ttl := p.project.MessageTTLSec
+	if ttl <= 0 {
+		ttl = 14 * 24 * 3600 // 14 days default
+	}
+	prunedCompleted, err := p.store.PruneCompletedItems(p.project.ID, ttl)
+	if err != nil {
+		p.emit("error", fmt.Sprintf("pruning completed items: %v", err), nil)
+	} else if prunedCompleted > 0 {
+		p.emit("tracked", fmt.Sprintf("Pruned %d expired completed items", prunedCompleted), nil)
 	}
 
 	return results, trackedSummary.String()

--- a/internal/poller/tracked.go
+++ b/internal/poller/tracked.go
@@ -125,12 +125,12 @@ func (p *Poller) ClearAndBulkAddTrackedItems(ctx context.Context, items []ghpkg.
 // UpdateTrackedItems removes terminal (closed/merged/not-planned) items and adds new ones.
 // Returns (added, removed, error).
 func (p *Poller) UpdateTrackedItems(ctx context.Context, items []ghpkg.ItemStatus, owner, repo string) (int, int, error) {
-	removed, err := p.store.RemoveTerminalTrackedItems(p.project.ID)
+	removed, err := p.store.ArchiveTerminalTrackedItems(p.project.ID)
 	if err != nil {
-		return 0, 0, fmt.Errorf("remove terminal items: %w", err)
+		return 0, 0, fmt.Errorf("archive+remove terminal items: %w", err)
 	}
 	if removed > 0 {
-		p.emit("tracked", fmt.Sprintf("Removed %d closed/merged items", removed), nil)
+		p.emit("tracked", fmt.Sprintf("Archived and removed %d closed/merged items", removed), nil)
 	}
 
 	added, err := p.BulkAddTrackedItems(ctx, items, owner, repo)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -775,7 +775,7 @@ func (m Model) updateTrack(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.trackStep = trackStepFetching
 			m.trackStatus = fmt.Sprintf("Cleaning up %d items...", m.trackCleanupCount)
 			return m, tea.Batch(m.spinner.Tick, func() tea.Msg {
-				removed, err := store.RemoveTerminalTrackedItems(projectID)
+				removed, err := store.ArchiveTerminalTrackedItems(projectID)
 				return cleanupResultMsg{removed: removed, err: err}
 			})
 		case "n", "esc":


### PR DESCRIPTION
## Summary
- Adds `completed_items` table (schema v7) to archive tracked items when they reach terminal state, but only if they had a non-empty progress summary (filtering out accidental adds or items that never saw real work)
- All three deletion paths (auto-prune in sweep, `UpdateTrackedItems`, TUI cleanup) now archive before deleting via `ArchiveTrackedItem` / `ArchiveTerminalTrackedItems`
- Tier 2 analyzer prompt includes a new "Recently Completed Work" section so the analyzer sees a trail of completed work and won't raise false concerns about lack of progress when items are cleaned up
- Completed items are pruned after the project's `message_ttl_sec` (default 14 days)

## Test plan
- [x] `TestArchiveTrackedItem` — item with progress summary is archived with combined objective + progress
- [x] `TestArchiveTrackedItem_SkipsNoProgress` — item without progress summary is silently skipped
- [x] `TestArchiveTerminalTrackedItems` — archives terminal items with progress, deletes all terminal, leaves open items
- [x] `TestPruneCompletedItems` — TTL-based pruning removes old items, keeps recent
- [x] `TestPruneTrackedItems_ArchivesBeforeDelete` — auto-prune path archives before deleting
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)