### PR TITLE
Add clickable GitHub links to tracked items in TUI

### DIFF
--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -241,6 +241,8 @@ func (m Model) renderTrackedStrip() string {
 		entry := fmt.Sprintf("#%d[%s]", item.Number, item.LastStatus)
 		dot := statusDot(item.LastStatus)
 		entryLen := len(entry) + 2 // +2 for dot + space
+		// Build GitHub URL for OSC 8 hyperlink.
+		ghURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", item.Owner, item.Repo, item.Number)
 
 		// Wrap to next line if needed (allow ~5 items per line).
 		if i > 0 && lineWidth+entryLen+2 > m.width-2 {
@@ -256,7 +258,9 @@ func (m Model) renderTrackedStrip() string {
 			lineWidth += 2
 		}
 		line.WriteString(dot)
+		line.WriteString(fmt.Sprintf("\033]8;;%s\033\\", ghURL))
 		line.WriteString(mutedStyle().Render(entry))
+		line.WriteString("\033]8;;\033\\")
 		lineWidth += entryLen
 	}
 	b.WriteString(line.String())


### PR DESCRIPTION
## Summary
- Wraps tracked item references (e.g. `#42[Open]`) in OSC 8 terminal hyperlinks pointing to the corresponding GitHub issue/PR page
- Clicking a tracked item in the TUI now opens it in the browser
- Works in iTerm2, Ghostty, WezTerm, kitty, and other terminals that support OSC 8

## Test plan
- [x] Run `agent-minder start` with tracked issues and verify items are clickable in a supported terminal
- [x] Confirm the link opens the correct GitHub page (issues and PRs)
- [x] Verify display is unchanged in terminals without OSC 8 support (escape sequences are silently ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)