### PR TITLE
Add expandable concerns, auto theme detection, and settings dialog

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -138,20 +138,22 @@ type Poller struct {
 	publisher *msgbus.Publisher
 	events    chan Event
 
-	mu      sync.Mutex
-	paused  bool
-	cancel  context.CancelFunc
-	stopped chan struct{}
+	mu              sync.Mutex
+	paused          bool
+	cancel          context.CancelFunc
+	stopped         chan struct{}
+	intervalChanged chan time.Duration // signals run loop to reset ticker
 }
 
 // New creates a new Poller. Publisher may be nil if bus publishing is not available.
 func New(store *db.Store, project *db.Project, provider llm.Provider, publisher *msgbus.Publisher) *Poller {
 	return &Poller{
-		store:     store,
-		project:   project,
-		provider:  provider,
-		publisher: publisher,
-		events:    make(chan Event, 64),
+		store:           store,
+		project:         project,
+		provider:        provider,
+		publisher:       publisher,
+		events:          make(chan Event, 64),
+		intervalChanged: make(chan time.Duration, 1),
 	}
 }
 
@@ -163,6 +165,19 @@ func (p *Poller) Events() <-chan Event {
 // Project returns the poller's project.
 func (p *Poller) Project() *db.Project {
 	return p.project
+}
+
+// SetRefreshInterval updates the poll interval at runtime.
+// The change takes effect on the next tick cycle.
+func (p *Poller) SetRefreshInterval(d time.Duration) {
+	p.mu.Lock()
+	p.project.RefreshIntervalSec = int(d.Seconds())
+	p.mu.Unlock()
+	// Non-blocking send to signal the run loop.
+	select {
+	case p.intervalChanged <- d:
+	default:
+	}
 }
 
 // Start begins the polling loop in a goroutine.
@@ -470,6 +485,8 @@ func (p *Poller) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case d := <-p.intervalChanged:
+			ticker.Reset(d)
 		case <-ticker.C:
 			if p.IsPaused() {
 				continue

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -125,6 +125,10 @@ type Model struct {
 	trackedExpanded  bool // 'x' toggles compact strip vs expanded list with titles
 	concernsExpanded bool // 'c' toggles capped vs full concern display
 
+	// Settings dialog.
+	settingsState  *settingsState
+	settingsStatus string
+
 	// Worktree display (refreshed on poll results).
 	showWorktrees bool
 	worktrees     []db.WorktreeWithRepo
@@ -251,6 +255,7 @@ func (m Model) Init() tea.Cmd {
 		listenForEvents(m.poller),
 		tickEvery(),
 		m.spinner.Tick,
+		func() tea.Msg { return tea.RequestBackgroundColor() },
 	}
 	if m.project.IdlePauseSec > 0 {
 		cmds = append(cmds, idleCheckTick())
@@ -293,9 +298,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateTrack(msg)
 		case "filter":
 			return m.updateFilter(msg)
+		case "settings":
+			return m.updateSettings(msg)
 		default:
 			return m.updateNormal(msg)
 		}
+
+	case tea.BackgroundColorMsg:
+		if msg.IsDark() {
+			setThemeByName("dark")
+		} else {
+			setThemeByName("light")
+		}
+		m.applyTextareaTheme()
+		m.rebuildAnalysisContent()
+		m.rebuildEventLogContent()
+		return m, nil
 
 	case spinner.TickMsg:
 		var cmd tea.Cmd
@@ -495,6 +513,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.filterStatus = ""
 		return m, nil
 
+	case settingsSavedMsg:
+		if msg.err != nil {
+			m.settingsStatus = fmt.Sprintf("Error: %v", msg.err)
+		} else {
+			m.settingsStatus = fmt.Sprintf("%s updated", msg.field)
+		}
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearSettingsStatusMsg{}
+		})
+
+	case clearSettingsStatusMsg:
+		m.settingsStatus = ""
+		return m, nil
+
 	case idleCheckMsg:
 		threshold := m.project.IdlePauseDuration()
 		if threshold > 0 && !m.autoPaused && !m.poller.IsPaused() && time.Since(m.lastUserInput) >= threshold {
@@ -520,6 +552,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 type clearBroadcastStatusMsg struct{}
 type clearOnboardStatusMsg struct{}
 type clearFilterStatusMsg struct{}
+type clearSettingsStatusMsg struct{}
 
 func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
@@ -614,6 +647,16 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "c":
 		m.concernsExpanded = !m.concernsExpanded
+		m.resizeViewports()
+		return m, nil
+	case "s":
+		pollMinutes := m.project.RefreshIntervalSec / 60
+		if pollMinutes < 1 {
+			pollMinutes = 1
+		}
+		m.settingsState = newSettingsState(pollMinutes)
+		m.settingsStatus = ""
+		m.mode = "settings"
 		m.resizeViewports()
 		return m, nil
 	case "d":

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -50,8 +50,11 @@ func (m Model) View() tea.View {
 		}
 	}
 
-	// Main content area: filter/track-preview modes replace analysis+event log.
-	if m.mode == "filter" {
+	// Main content area: modal modes replace analysis+event log.
+	if m.mode == "settings" {
+		b.WriteString(m.renderSettingsView())
+		b.WriteString("\n")
+	} else if m.mode == "filter" {
 		b.WriteString(m.renderFilterView())
 		b.WriteString("\n")
 	} else if (m.mode == "track" || m.mode == "untrack") && m.trackStep == trackStepPreview {
@@ -683,6 +686,18 @@ func (m Model) renderBottomBar() string {
 			b.WriteString(helpStyle().Render(help))
 			b.WriteString("\n")
 		}
+	case "settings":
+		if m.settingsStatus != "" {
+			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.settingsStatus)))
+		} else if m.settingsState != nil {
+			switch m.settingsState.step {
+			case settingsStepSelectField:
+				b.WriteString(helpStyle().Render("up/down: select \u2022 enter: edit \u2022 esc: close"))
+			case settingsStepEditValue:
+				b.WriteString(helpStyle().Render("enter: save \u2022 esc: cancel"))
+			}
+		}
+		b.WriteString("\n\n")
 	case "filter":
 		if m.filterStatus != "" {
 			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.filterStatus)))
@@ -774,6 +789,7 @@ func allHelpHints() []struct{ key, desc string } {
 		{"w", "toggle worktrees"},
 		{"x", "expand/collapse tracked"},
 		{"c", "expand/collapse concerns"},
+		{"s", "settings"},
 		{"i", "track issues"},
 		{"I", "untrack issues"},
 		{"f", "filter & bulk track"},

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -1,0 +1,203 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/bubbles/v2/textinput"
+)
+
+// settingsStep represents the current step in the settings flow.
+type settingsStep int
+
+const (
+	settingsStepSelectField settingsStep = iota
+	settingsStepEditValue
+)
+
+// settingsField represents a configurable project setting.
+type settingsField struct {
+	label       string
+	description string
+	value       string
+	unit        string
+}
+
+// settingsState holds all state for the settings dialog.
+type settingsState struct {
+	step     settingsStep
+	fields   []settingsField
+	fieldIdx int
+	input    textinput.Model
+	err      string
+}
+
+// settingsSavedMsg is sent when settings are persisted.
+type settingsSavedMsg struct {
+	field string
+	err   error
+}
+
+// newSettingsState initializes the settings dialog.
+func newSettingsState(pollMinutes int) *settingsState {
+	ti := textinput.New()
+	ti.Placeholder = "value..."
+	ti.CharLimit = 10
+	ti.SetWidth(20)
+
+	return &settingsState{
+		step:  settingsStepSelectField,
+		input: ti,
+		fields: []settingsField{
+			{
+				label:       "Poll interval",
+				description: "How often to poll for changes",
+				value:       strconv.Itoa(pollMinutes),
+				unit:        "min",
+			},
+		},
+	}
+}
+
+// updateSettings handles keypresses for the settings mode.
+func (m Model) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	ss := m.settingsState
+	if ss == nil {
+		m.mode = "normal"
+		return m, nil
+	}
+
+	switch ss.step {
+	case settingsStepSelectField:
+		return m.updateSettingsSelectField(msg)
+	case settingsStepEditValue:
+		return m.updateSettingsEditValue(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) updateSettingsSelectField(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	ss := m.settingsState
+
+	switch msg.String() {
+	case "esc":
+		m.mode = "normal"
+		m.settingsState = nil
+		m.resizeViewports()
+		return m, nil
+	case "up", "k":
+		if ss.fieldIdx > 0 {
+			ss.fieldIdx--
+		}
+		return m, nil
+	case "down", "j":
+		if ss.fieldIdx < len(ss.fields)-1 {
+			ss.fieldIdx++
+		}
+		return m, nil
+	case "enter":
+		ss.step = settingsStepEditValue
+		ss.err = ""
+		ss.input.SetValue(ss.fields[ss.fieldIdx].value)
+		cmd := ss.input.Focus()
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m Model) updateSettingsEditValue(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	ss := m.settingsState
+
+	switch msg.String() {
+	case "esc":
+		ss.step = settingsStepSelectField
+		ss.input.Blur()
+		ss.err = ""
+		return m, nil
+	case "enter":
+		raw := ss.input.Value()
+		field := ss.fields[ss.fieldIdx]
+
+		switch field.label {
+		case "Poll interval":
+			minutes, err := strconv.Atoi(raw)
+			if err != nil || minutes < 1 {
+				ss.err = "Enter a number >= 1"
+				return m, nil
+			}
+			newSec := minutes * 60
+			m.project.RefreshIntervalSec = newSec
+			ss.fields[ss.fieldIdx].value = strconv.Itoa(minutes)
+			ss.input.Blur()
+			ss.step = settingsStepSelectField
+			ss.err = ""
+
+			return m, func() tea.Msg {
+				err := m.store.UpdateProject(m.project)
+				if err == nil {
+					m.poller.SetRefreshInterval(m.project.RefreshInterval())
+				}
+				return settingsSavedMsg{field: "Poll interval", err: err}
+			}
+		}
+
+		return m, nil
+	}
+
+	// Forward to text input.
+	var cmd tea.Cmd
+	ss.input, cmd = ss.input.Update(msg)
+	return m, cmd
+}
+
+// renderSettingsView renders the settings dialog.
+func (m Model) renderSettingsView() string {
+	ss := m.settingsState
+	if ss == nil {
+		return ""
+	}
+
+	var b strings.Builder
+
+	b.WriteString(headerStyle().Render("Settings"))
+	b.WriteString("\n\n")
+
+	switch ss.step {
+	case settingsStepSelectField:
+		for i, f := range ss.fields {
+			prefix := "  "
+			if i == ss.fieldIdx {
+				prefix = "> "
+			}
+			entry := fmt.Sprintf("  %s%s: %s %s", prefix, f.label, f.value, f.unit)
+			if f.description != "" {
+				entry += "  " + mutedStyle().Render(fmt.Sprintf("(%s)", f.description))
+			}
+			if i == ss.fieldIdx {
+				b.WriteString(headerStyle().Render(entry))
+			} else {
+				b.WriteString(textStyle().Render(entry))
+			}
+			b.WriteString("\n")
+		}
+
+	case settingsStepEditValue:
+		f := ss.fields[ss.fieldIdx]
+		b.WriteString(textStyle().Render(fmt.Sprintf("  %s (%s):", f.label, f.unit)))
+		b.WriteString("\n")
+		b.WriteString("  ")
+		b.WriteString(ss.input.View())
+		b.WriteString("\n")
+		if ss.err != "" {
+			b.WriteString("  ")
+			b.WriteString(errorStyle().Render(ss.err))
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -60,6 +60,15 @@ func cycleTheme() Theme {
 	return currentTheme()
 }
 
+func setThemeByName(name string) {
+	for i, t := range themes {
+		if t.Name == name {
+			themeIndex = i
+			return
+		}
+	}
+}
+
 // Style builders that read from current theme.
 
 func titleStyle() lipgloss.Style {


### PR DESCRIPTION
## Summary
- **Expandable concerns**: `c` key toggles between capped (5 items, 8 lines) and full concern display in TUI
- **Auto dark/light theme**: Detects terminal background color on startup via `tea.BackgroundColorMsg` and selects the appropriate theme automatically
- **Settings dialog**: `s` key opens a settings view to modify poll interval (minutes), persists to DB and resets poller ticker at runtime via new `Poller.SetRefreshInterval()` method

## Test plan
- [x] Verify `c` key expands/collapses concerns when >5 exist
- [x] Verify theme auto-detects correctly in dark and light terminals (manual `t` still works to override)
- [x] Verify `s` → enter → type new poll interval → enter saves and updates ticker
- [x] Verify esc cancels at each settings step without saving
- [x] Verify invalid poll interval input (0, negative, non-numeric) shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)