### PR TITLE
Add analyzer focus setting to customize tier 2 LLM persona

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -21,6 +21,7 @@ type Project struct {
 	LLMSummarizerModel   string `db:"llm_summarizer_model"`
 	LLMAnalyzerModel     string `db:"llm_analyzer_model"`
 	IdlePauseSec         int    `db:"idle_pause_sec"`
+	AnalyzerFocus        string `db:"analyzer_focus"`
 	CreatedAt            string `db:"created_at"`
 }
 

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -28,10 +28,10 @@ func (s *Store) CreateProject(p *Project) error {
 	result, err := s.db.NamedExec(`
 		INSERT INTO projects (name, goal_type, goal_description, refresh_interval_sec,
 			message_ttl_sec, auto_enroll_worktrees, minder_identity, llm_provider, llm_model,
-			llm_summarizer_model, llm_analyzer_model, idle_pause_sec)
+			llm_summarizer_model, llm_analyzer_model, idle_pause_sec, analyzer_focus)
 		VALUES (:name, :goal_type, :goal_description, :refresh_interval_sec,
 			:message_ttl_sec, :auto_enroll_worktrees, :minder_identity, :llm_provider, :llm_model,
-			:llm_summarizer_model, :llm_analyzer_model, :idle_pause_sec)
+			:llm_summarizer_model, :llm_analyzer_model, :idle_pause_sec, :analyzer_focus)
 	`, p)
 	if err != nil {
 		return fmt.Errorf("insert project: %w", err)
@@ -85,7 +85,8 @@ func (s *Store) UpdateProject(p *Project) error {
 			llm_model = :llm_model,
 			llm_summarizer_model = :llm_summarizer_model,
 			llm_analyzer_model = :llm_analyzer_model,
-			idle_pause_sec = :idle_pause_sec
+			idle_pause_sec = :idle_pause_sec,
+			analyzer_focus = :analyzer_focus
 		WHERE id = :id
 	`, p)
 	return err

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -8,7 +8,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 7
+const currentVersion = 8
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS projects (
 	llm_summarizer_model  TEXT DEFAULT 'claude-haiku-4-5',
 	llm_analyzer_model    TEXT DEFAULT 'claude-sonnet-4-6',
 	idle_pause_sec        INTEGER DEFAULT 14400,
+	analyzer_focus        TEXT DEFAULT '',
 	created_at            TEXT DEFAULT (datetime('now'))
 );
 
@@ -186,6 +187,12 @@ func migrate(db *sqlx.DB) error {
 		}
 	}
 
+	if version < 8 {
+		if err := migrateV8(db); err != nil {
+			return fmt.Errorf("apply migration v8: %w", err)
+		}
+	}
+
 	_, err = db.Exec("UPDATE schema_version SET version = ?", currentVersion)
 	return err
 }
@@ -311,6 +318,17 @@ func migrateV7(db *sqlx.DB) error {
 	`)
 	if err != nil {
 		return fmt.Errorf("create completed_items table: %w", err)
+	}
+	return nil
+}
+
+func migrateV8(db *sqlx.DB) error {
+	_, err := db.Exec(`ALTER TABLE projects ADD COLUMN analyzer_focus TEXT DEFAULT ''`)
+	if err != nil {
+		return fmt.Errorf("add analyzer_focus: %w", err)
+	}
+	if _, err := db.Exec(`UPDATE projects SET analyzer_focus = '' WHERE analyzer_focus IS NULL`); err != nil {
+		return fmt.Errorf("null-fill analyzer_focus: %w", err)
 	}
 	return nil
 }

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -811,11 +811,11 @@ func (p *Poller) doPoll(ctx context.Context) (*PollResult, error) {
 	}
 
 	tier2Prompt := p.buildTier2Prompt(gitTier1, busTier1, trackedChanges, prStatusSection, concerns, trackedItems, completedItems)
-	debugLog("llm call", "stage", "tier2", "step", "input", "component", "analyzer", "model", tier2Model, "system_prompt", tier2SystemPrompt(p.project.Name), "user_prompt", tier2Prompt)
+	debugLog("llm call", "stage", "tier2", "step", "input", "component", "analyzer", "model", tier2Model, "system_prompt", tier2SystemPrompt(p.project.Name, p.project.AnalyzerFocus), "user_prompt", tier2Prompt)
 
 	tier2Resp, err := p.provider.Complete(ctx, &llm.Request{
 		Model:     tier2Model,
-		System:    tier2SystemPrompt(p.project.Name),
+		System:    tier2SystemPrompt(p.project.Name, p.project.AnalyzerFocus),
 		Messages:  []llm.Message{{Role: "user", Content: tier2Prompt}},
 		MaxTokens: 1024,
 	})
@@ -973,8 +973,8 @@ func buildBusSummaryPrompt(project *db.Project, msgActivity string) string {
 
 // --- Tier 2 System Prompt (Opus analyzer) ---
 
-func tier2SystemPrompt(projectName string) string {
-	return fmt.Sprintf(`You are an AI project analyzer for %q. You receive focused summaries of recent git activity and bus messages (from separate summarizer agents), plus full tracked issue/PR context from sweep agents. Produce a structured analysis.
+func tier2SystemPrompt(projectName, analyzerFocus string) string {
+	base := fmt.Sprintf(`You are an AI project analyzer for %q. You receive focused summaries of recent git activity and bus messages (from separate summarizer agents), plus full tracked issue/PR context from sweep agents. Produce a structured analysis.
 
 Respond with a JSON object (no markdown fences):
 {
@@ -1016,7 +1016,19 @@ Evidence standards:
 - "Worktree PR Status" is authoritative for branch-to-PR association. Cross-reference it against every existing concern that mentions branches or PRs. A branch with an open PR means work has been submitted for review — you MUST remove or rewrite any concern claiming that branch has no PR, is stalled, or has unclear status. Use the PR review state (approved, changes_requested, pending) to assess readiness.
 
 Keep analysis concise and focused on cross-repo coordination.`, projectName, projectName)
+
+	focus := analyzerFocus
+	if focus == "" {
+		focus = DefaultAnalyzerFocus
+	}
+	base += fmt.Sprintf("\n\n## Analyzer Focus\nThe user has configured the following focus for your analysis. This shapes how you interpret data, what you pay attention to, and how you communicate:\n\n%s", focus)
+
+	return base
 }
+
+// DefaultAnalyzerFocus is the default analyzer focus used when none is configured.
+// It reflects the analyzer's built-in engineering coordinator persona.
+const DefaultAnalyzerFocus = `Focus on cross-repo coordination and engineering progress. Be concise, evidence-based, and actionable. Prioritize blockers and coordination needs. Use direct, professional language.`
 
 func (p *Poller) buildTier2Prompt(gitSummary, busSummary, trackedChanges, prStatus string, concerns []db.Concern, trackedItems []db.TrackedItem, completedItems []db.CompletedItem) string {
 	var b strings.Builder

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -654,7 +654,15 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if pollMinutes < 1 {
 			pollMinutes = 1
 		}
-		m.settingsState = newSettingsState(pollMinutes)
+		m.settingsState = newSettingsState(pollMinutes, m.project.AnalyzerFocus)
+		// Apply textarea theme to match current theme.
+		var s textarea.Styles
+		if currentTheme().Name == "light" {
+			s = textarea.DefaultLightStyles()
+		} else {
+			s = textarea.DefaultDarkStyles()
+		}
+		m.settingsState.textarea.SetStyles(s)
 		m.settingsStatus = ""
 		m.mode = "settings"
 		m.resizeViewports()

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -695,6 +695,8 @@ func (m Model) renderBottomBar() string {
 				b.WriteString(helpStyle().Render("up/down: select \u2022 enter: edit \u2022 esc: close"))
 			case settingsStepEditValue:
 				b.WriteString(helpStyle().Render("enter: save \u2022 esc: cancel"))
+			case settingsStepEditTextarea:
+				b.WriteString(helpStyle().Render("ctrl+d: save \u2022 esc: cancel"))
 			}
 		}
 		b.WriteString("\n\n")

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
+	"github.com/dustinlange/agent-minder/internal/poller"
 )
 
 // settingsStep represents the current step in the settings flow.
@@ -15,6 +17,7 @@ type settingsStep int
 const (
 	settingsStepSelectField settingsStep = iota
 	settingsStepEditValue
+	settingsStepEditTextarea
 )
 
 // settingsField represents a configurable project setting.
@@ -23,6 +26,7 @@ type settingsField struct {
 	description string
 	value       string
 	unit        string
+	multiline   bool // true for textarea fields
 }
 
 // settingsState holds all state for the settings dialog.
@@ -31,6 +35,7 @@ type settingsState struct {
 	fields   []settingsField
 	fieldIdx int
 	input    textinput.Model
+	textarea textarea.Model
 	err      string
 }
 
@@ -41,21 +46,44 @@ type settingsSavedMsg struct {
 }
 
 // newSettingsState initializes the settings dialog.
-func newSettingsState(pollMinutes int) *settingsState {
+func newSettingsState(pollMinutes int, analyzerFocus string) *settingsState {
 	ti := textinput.New()
 	ti.Placeholder = "value..."
 	ti.CharLimit = 10
 	ti.SetWidth(20)
 
+	ta := textarea.New()
+	ta.Placeholder = "Describe how the analyzer should think, what to focus on, and how to communicate..."
+	ta.CharLimit = 2000
+	ta.SetHeight(5)
+	ta.SetWidth(80)
+
+	// Show the effective focus (default if empty) truncated for the field list.
+	effectiveFocus := analyzerFocus
+	if effectiveFocus == "" {
+		effectiveFocus = poller.DefaultAnalyzerFocus
+	}
+	displayFocus := effectiveFocus
+	if len(displayFocus) > 60 {
+		displayFocus = displayFocus[:57] + "..."
+	}
+
 	return &settingsState{
-		step:  settingsStepSelectField,
-		input: ti,
+		step:     settingsStepSelectField,
+		input:    ti,
+		textarea: ta,
 		fields: []settingsField{
 			{
 				label:       "Poll interval",
 				description: "How often to poll for changes",
 				value:       strconv.Itoa(pollMinutes),
 				unit:        "min",
+			},
+			{
+				label:       "Analyzer focus",
+				description: "Custom instructions for the analyzer's perspective and communication style",
+				value:       displayFocus,
+				multiline:   true,
 			},
 		},
 	}
@@ -74,6 +102,8 @@ func (m Model) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.updateSettingsSelectField(msg)
 	case settingsStepEditValue:
 		return m.updateSettingsEditValue(msg)
+	case settingsStepEditTextarea:
+		return m.updateSettingsEditTextarea(msg)
 	}
 
 	return m, nil
@@ -99,9 +129,24 @@ func (m Model) updateSettingsSelectField(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		}
 		return m, nil
 	case "enter":
-		ss.step = settingsStepEditValue
+		field := ss.fields[ss.fieldIdx]
 		ss.err = ""
-		ss.input.SetValue(ss.fields[ss.fieldIdx].value)
+		if field.multiline {
+			ss.step = settingsStepEditTextarea
+			// Load the effective value (default when empty) so users can see and edit it.
+			focus := m.project.AnalyzerFocus
+			if focus == "" {
+				focus = poller.DefaultAnalyzerFocus
+			}
+			ss.textarea.SetValue(focus)
+			if m.width > 4 {
+				ss.textarea.SetWidth(m.width - 4)
+			}
+			cmd := ss.textarea.Focus()
+			return m, cmd
+		}
+		ss.step = settingsStepEditValue
+		ss.input.SetValue(field.value)
 		cmd := ss.input.Focus()
 		return m, cmd
 	}
@@ -154,6 +199,49 @@ func (m Model) updateSettingsEditValue(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 	return m, cmd
 }
 
+func (m Model) updateSettingsEditTextarea(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	ss := m.settingsState
+
+	switch msg.String() {
+	case "esc":
+		ss.step = settingsStepSelectField
+		ss.textarea.Blur()
+		ss.err = ""
+		return m, nil
+	case "ctrl+d":
+		value := strings.TrimSpace(ss.textarea.Value())
+		// If unchanged from default, store empty so the default can evolve with code updates.
+		if value == poller.DefaultAnalyzerFocus {
+			value = ""
+		}
+		m.project.AnalyzerFocus = value
+		ss.textarea.Blur()
+		ss.step = settingsStepSelectField
+		ss.err = ""
+
+		// Update display value (show effective, which is default when empty).
+		effectiveFocus := value
+		if effectiveFocus == "" {
+			effectiveFocus = poller.DefaultAnalyzerFocus
+		}
+		displayFocus := effectiveFocus
+		if len(displayFocus) > 60 {
+			displayFocus = displayFocus[:57] + "..."
+		}
+		ss.fields[ss.fieldIdx].value = displayFocus
+
+		return m, func() tea.Msg {
+			err := m.store.UpdateProject(m.project)
+			return settingsSavedMsg{field: "Analyzer focus", err: err}
+		}
+	}
+
+	// Forward to textarea.
+	var cmd tea.Cmd
+	ss.textarea, cmd = ss.textarea.Update(msg)
+	return m, cmd
+}
+
 // renderSettingsView renders the settings dialog.
 func (m Model) renderSettingsView() string {
 	ss := m.settingsState
@@ -173,7 +261,12 @@ func (m Model) renderSettingsView() string {
 			if i == ss.fieldIdx {
 				prefix = "> "
 			}
-			entry := fmt.Sprintf("  %s%s: %s %s", prefix, f.label, f.value, f.unit)
+			var entry string
+			if f.unit != "" {
+				entry = fmt.Sprintf("  %s%s: %s %s", prefix, f.label, f.value, f.unit)
+			} else {
+				entry = fmt.Sprintf("  %s%s: %s", prefix, f.label, f.value)
+			}
 			if f.description != "" {
 				entry += "  " + mutedStyle().Render(fmt.Sprintf("(%s)", f.description))
 			}
@@ -191,6 +284,19 @@ func (m Model) renderSettingsView() string {
 		b.WriteString("\n")
 		b.WriteString("  ")
 		b.WriteString(ss.input.View())
+		b.WriteString("\n")
+		if ss.err != "" {
+			b.WriteString("  ")
+			b.WriteString(errorStyle().Render(ss.err))
+			b.WriteString("\n")
+		}
+
+	case settingsStepEditTextarea:
+		f := ss.fields[ss.fieldIdx]
+		b.WriteString(textStyle().Render(fmt.Sprintf("  %s:", f.label)))
+		b.WriteString("\n")
+		b.WriteString("  ")
+		b.WriteString(ss.textarea.View())
 		b.WriteString("\n")
 		if ss.err != "" {
 			b.WriteString("  ")


### PR DESCRIPTION
## Summary
- Adds per-project "Analyzer Focus" field that injects custom instructions into the tier 2 analyzer system prompt
- Users can reshape how the analyzer interprets data, what it prioritizes, and how it communicates (e.g. engineering coordinator vs compassionate coach)
- Schema v8 migration adds `analyzer_focus` column; default reflects built-in engineering persona
- Settings dialog (`s` key) exposes multi-line textarea editor (`ctrl+d` to save)
- Saving text identical to the default stores empty string so the default can evolve with code updates

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds
- [x] Manual: `s` → select "Analyzer focus" → edit → ctrl+d → verify next poll uses custom focus
- [ ] Manual: Verify empty/default roundtrip (save default text → stores as empty)
- [ ] Manual: Verify migration on existing DB (v7 → v8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)