### PR TITLE
Add autopilot: concurrent Claude Code agents for GitHub issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code ownership — all changes require review from primary maintainer
+* @dmays-newb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,25 +41,54 @@ Each poll cycle with new activity runs two sequential LLM calls:
 
 ### TUI (internal/tui)
 
-Bubbletea v2 dashboard. Key bindings: `p` pause, `r` poll now, `e` expand, `u` user msg, `m` broadcast, `o` onboard, `t` theme, `q` quit.
+Bubbletea v2 dashboard. Key bindings: `p` pause, `r` poll now, `e` expand, `u` user msg, `m` broadcast, `o` onboard, `a` autopilot, `A` stop autopilot (with confirmation), `t` theme, `q` quit.
 
 - Spinner (bubbles/v2/spinner MiniDot) shown during manual poll (`r`), broadcast, and onboard generation
 - Concerns capped at 5 displayed with "+N more" indicator; color-coded by severity (info=muted, warning=amber, danger=bold red)
 - Event log dynamically sized to remaining terminal height
 - Broadcast mode: `m` opens textarea, ctrl+d sends through tier 2 LLM → publishes to bus
 - Onboard mode: `o` opens textarea for optional guidance, ctrl+d generates onboarding message via tier 2 LLM → publishes to `<project>/onboarding` with replace semantics
+- Autopilot modes: `""` (normal) → `"confirm"` (y/n to launch) → `"running"` (slot status displayed) → `"stop-confirm"` (y/n to stop)
+- During autopilot, poll frequency is halved (min 30s) and `StatusBlock()` is injected into tier 2 analyzer input
 
-### DB schema (internal/db) — currently v7
+### Autopilot (internal/autopilot)
 
-**projects**: name, goal_type, goal_description, refresh_interval_sec, message_ttl_sec, auto_enroll_worktrees, minder_identity, llm_provider, llm_model, llm_summarizer_model, llm_analyzer_model
+Supervisor manages N concurrent Claude Code agents working on GitHub issues in isolated worktrees.
+
+**Flow:** `a` in TUI → `Prepare()` (clears old tasks, converts tracked items, builds dep graph) → user confirms → `Launch()` fills slots with unblocked tasks → agents run `claude -p` → inspect outcome → clean up → refill slots.
+
+**Task lifecycle:** `queued` → `running` → `review` (PR opened) → `done` (PR merged) | `bailed` (no PR, agent gave up)
+
+**Key behaviors:**
+- `Prepare()` always starts fresh — clears old tasks, cleans orphaned worktrees, fetches live GitHub status (not cached labels)
+- Issues with the skip label (default `no-agent`, configurable via `project.AutopilotSkipLabel`) are excluded
+- Dependency graph built via one LLM call using analyzer model; includes all tracked items as context for cross-repo deps
+- External dependency blocking: `QueuedUnblockedTasks()` cross-references `tracked_items` — if a dep is tracked and open, it blocks
+- Dynamic task discovery: every 60s when idle slots exist, checks for new tracked items not yet in autopilot_tasks
+- Review check: every 30s, checks if PRs for `review` tasks have been merged → promotes to `done`
+- Label management: agent adds `in-progress` on start; supervisor swaps to `needs-review` when PR detected; removes `needs-review` when merged
+- On restart, `Prepare()` clears all tasks and rebuilds — no resume of stale state
+- Stop confirmation: `A` → "Stop all running agents? (y/n)" — waits for agent processes to exit naturally
+
+**Paths:**
+- Worktree: `~/.agent-minder/worktrees/<project>/issue-<N>`, branch: `agent/issue-<N>`
+- Agent logs: `~/.agent-minder/agents/<project>-issue-<N>.log`
+
+**Agent command:** `claude -p --max-turns <N> --max-budget-usd <B> --dangerously-skip-permissions "<prompt>"` with `GITHUB_TOKEN` env var
+
+### DB schema (internal/db) — currently v9
+
+**projects**: name, goal_type, goal_description, refresh_interval_sec, message_ttl_sec, auto_enroll_worktrees, minder_identity, llm_provider, llm_model, llm_summarizer_model, llm_analyzer_model, autopilot_max_agents, autopilot_max_turns, autopilot_max_budget_usd, autopilot_skip_label
 
 **polls**: project_id, new_commits, new_messages, concerns_raised, llm_response (legacy), tier1_response, tier2_response, bus_message_sent, polled_at
+
+**autopilot_tasks**: project_id, issue_number, issue_title, issue_body, dependencies (JSON), status (queued/running/done/bailed/blocked), worktree_path, branch, pr_number, agent_log, started_at, completed_at — UNIQUE on project_id+issue_number
 
 **completed_items**: project_id, source, owner, repo, number, item_type, title, final_status, summary, completed_at — archived from tracked_items when they reach terminal state (only if progress_summary was non-empty)
 
 **Also**: repos, worktrees, topics, concerns (see `schema.go` for full DDL)
 
-Migrations: v1→v2 (two-tier LLM columns), v3 (tracked_items), v4 (content hash + summaries), v5 (idle_pause_sec), v6 (is_draft + review_state), v7 (completed_items).
+Migrations: v1→v2 (two-tier LLM columns), v3 (tracked_items), v4 (content hash + summaries), v5 (idle_pause_sec), v6 (is_draft + review_state), v7 (completed_items), v8 (analyzer_focus), v9 (autopilot_tasks table + autopilot project columns).
 
 `Poll.LLMResponse()` accessor returns tier2 > tier1 > raw (backward compat).
 
@@ -67,6 +96,7 @@ Migrations: v1→v2 (two-tier LLM columns), v3 (tracked_items), v4 (content hash
 
 | Package | Purpose | Notes |
 |---------|---------|-------|
+| `internal/autopilot` | Autopilot supervisor | Manages concurrent Claude Code agents on GitHub issues |
 | `cmd/` | Cobra commands | init, start, status, enroll, pause, resume |
 | `internal/db` | SQLite schema + CRUD | `Store` wraps sqlx.DB, migrations in `schema.go` |
 | `internal/llm` | LLM provider interface | Anthropic + OpenAI adapters, `Provider.Complete()` |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Launches the TUI dashboard + polling loop. Key bindings:
 | `u` | User message — post a raw message to a topic |
 | `m` | Broadcast mode — type a message for the LLM to craft and publish to the bus |
 | `o` | Onboard mode — generate an onboarding message for new agents |
+| `a` | Launch autopilot — assign agents to tracked GitHub issues |
+| `A` | Stop autopilot (with confirmation) |
 | `t` | Cycle theme (dark/light) |
 | `q` | Quit |
 
@@ -168,9 +170,17 @@ Press `m` in the TUI to enter broadcast mode. Type a prompt describing what you 
 
 Press `o` to generate an onboarding message for new agents joining the project. Optionally provide guidance text. The tier 2 model generates a comprehensive onboarding message and publishes it to `<project>/onboarding` with replace semantics (only the latest onboarding message is kept).
 
+### Autopilot
+
+Press `a` to launch autopilot — minder converts tracked GitHub issues into a task queue, builds a dependency graph (one LLM call), and dispatches up to N concurrent Claude Code agents to work on unblocked issues in isolated git worktrees. Agents self-triage: they either complete the work and open a draft PR, or bail with a detailed comment explaining what they found.
+
+**Minder is a work dispatcher, not a quality gate.** It generates the dependency graph and assigns work — the target repo's own tooling (pre-commit hooks, linters, test suites, CI/CD) is responsible for enforcing code quality. Repos should have a `CLAUDE.md` with project conventions and build/test commands so agents can work effectively.
+
+See [docs/automated-agents-design.md](docs/automated-agents-design.md) for the full design.
+
 ### Data storage
 
-All state lives in SQLite at `~/.agent-minder/minder.db` (WAL mode, foreign keys). Schema version: **v7**.
+All state lives in SQLite at `~/.agent-minder/minder.db` (WAL mode, foreign keys). Schema version: **v9**.
 
 - **projects** — Name, goal, LLM config, poll settings, idle pause
 - **repos** — Git repositories tracked per project (with optional summary)
@@ -180,6 +190,7 @@ All state lives in SQLite at `~/.agent-minder/minder.db` (WAL mode, foreign keys
 - **polls** — Full history of poll results with tier 1/tier 2 responses
 - **tracked_items** — GitHub issues/PRs being monitored (with content hash, progress summary, draft/review state)
 - **completed_items** — Archived from tracked_items when they reach terminal state
+- **autopilot_tasks** — Issue work queue for autopilot (status, dependencies, worktree path, PR number)
 
 ## Project structure
 
@@ -199,11 +210,12 @@ agent-minder/
 │   ├── pause.go         # Pause hint
 │   └── resume.go        # Alias for start
 ├── internal/
-│   ├── db/              # SQLite schema, migrations (v1→v7), CRUD
+│   ├── autopilot/       # Autopilot supervisor, agent prompt, slot management
+│   ├── db/              # SQLite schema, migrations (v1→v9), CRUD
 │   ├── llm/             # Provider interface (Anthropic + OpenAI-compatible)
 │   ├── poller/          # Two-tier poll loop, analysis parsing, item sweep
 │   ├── tui/             # Bubbletea v2 dashboard (app, styles, layout, filter)
-│   ├── git/             # Git CLI wrappers
+│   ├── git/             # Git CLI wrappers (log, branches, worktrees)
 │   ├── github/          # GitHub API client (go-github), issue/PR status fetching
 │   ├── discovery/       # Repo scanning, project name derivation
 │   ├── sqliteutil/      # SQLite health + WAL recovery

--- a/docs/automated-agents-design.md
+++ b/docs/automated-agents-design.md
@@ -1,0 +1,311 @@
+# Automated Agents Design
+
+Extends agent-minder to launch Claude Code agents that work on GitHub issues in isolated git worktrees.
+
+## Overview
+
+From the TUI, the user triggers "autopilot" (`a` key) which:
+
+1. Converts open tracked items (excluding `no-agent` label) into autopilot tasks
+2. Fetches live GitHub status for each item (not cached labels)
+3. Extracts a dependency graph (one LLM call, includes all tracked items as context)
+4. Launches up to N agents on unblocked issues, each in its own worktree
+5. Agents self-triage: do the work or bail with questions
+6. On completion/bail, the worktree is cleaned up and the slot is refilled
+7. Dynamic discovery: every 60s, checks for new tracked items to add to the task pool
+
+## Prerequisites
+
+Autopilot delegates work to Claude Code agents running in isolated worktrees. Minder does not handle quality checks, linting, testing, or merge conflicts — it generates a dependency graph and assigns work. The target repo must already have proper tooling in place.
+
+### Repository requirements
+
+- **Pre-commit hooks / linters**: Agents respect existing git hooks (husky, pre-commit, etc.). If the repo has no hooks, agents won't run linters automatically.
+- **Test suites**: Agents will run tests if the repo has them and the issue context suggests it. No test suite = no test validation.
+- **CI/CD**: Draft PRs opened by agents should trigger the same CI pipeline as human PRs. This is your safety net.
+- **Branch protection**: Recommended on the default branch. Agents push to `agent/issue-<N>` branches and open draft PRs — they never push to main directly.
+- **CLAUDE.md**: A `CLAUDE.md` in the target repo helps agents understand project conventions, build commands, test commands, and architecture. Without it, agents rely solely on issue context and codebase exploration.
+
+### Minder requirements
+
+- **Tracked items**: Issues must be tracked in the TUI (via GitHub integration) before autopilot can pick them up.
+- **GitHub token**: `GITHUB_TOKEN` env var or configured integration token — agents use `gh` CLI for labels, comments, and PRs.
+- **Claude CLI**: `claude` must be on `$PATH` and working.
+
+### What minder does NOT do
+
+- Run linters, formatters, or test suites itself
+- Resolve merge conflicts between concurrent agent branches
+- Validate code quality beyond what the repo's own hooks enforce
+- Retry failed agents automatically (bailed tasks stay bailed)
+- Manage CI/CD pipelines or deployment
+
+## Core Principles
+
+- **Minder is the coordinator, agents are workers.** Agents don't know about agent-msg, the bus, or each other. They just do claude code things: read issues, explore code, commit, push, open PRs.
+- **GitHub is the source of truth.** Issue status, comments, PRs, and labels are the primary state. Minder observes these through its existing poll/sweep cycle.
+- **Worktrees are ephemeral.** Created for a task, deleted when the agent exits. No long-lived worktrees.
+- **Agents self-triage.** No separate triage phase. The agent explores the codebase and decides whether to proceed or bail.
+- **Always fresh start.** `Prepare()` clears old tasks and rebuilds from scratch — no stale state resume.
+
+## User Flow
+
+```
+User in TUI → presses 'a'
+  → Minder shows: "12 issues, 8 unblocked. Launch 3 agents? [y/n]"
+  → User confirms with 'y'
+  → Agents start working
+  → TUI shows slot status: "Slot 1: #42 Title (3m)", "Slot 2: #38 Title (1m)", "Slot 3: idle"
+  → As agents finish, slots refill from unblocked queue
+  → Every 60s, new tracked items are discovered and added to the task pool
+  → Every 30s, review tasks are checked for PR merge → promoted to done
+  → 'A' to stop (with y/n confirmation)
+  → Existing poll cycle picks up new commits, PRs, comments naturally
+```
+
+## Task Lifecycle
+
+```
+queued → running → review (PR opened) → done (PR merged)
+                 → bailed (no PR, agent gave up)
+```
+
+### Startup
+1. Minder creates worktree: `git worktree add ~/.agent-minder/worktrees/<project>/issue-<N> -b agent/issue-<N>`
+2. Stale branch from prior run is deleted first if it exists
+3. Minder launches claude code in print mode in that directory
+4. Agent's first actions:
+   - Add `in-progress` label: `gh issue edit <N> --add-label "in-progress"`
+   - Post comment: "Agent starting work on this issue"
+   - Read the full issue and explore the codebase
+
+### Decision Point
+
+**Fork A — "I can do this"**
+- Implement the changes
+- Commits pass repo's own quality gates (husky, pre-commit hooks, tests)
+- Push branch, open draft PR referencing the issue (`Fixes #N`)
+- Exit
+
+**Fork B — "I can't/shouldn't do this"**
+- Post GH issue comment with:
+  - What was explored and learned
+  - Specific questions or blockers
+  - A ready-to-paste prompt for a manual claude code follow-up session
+- Add `blocked` label, remove `in-progress` label
+- Exit without code changes
+
+### Cleanup (Minder handles this, not the agent)
+1. Agent process exits
+2. Minder inspects outcome:
+   - PR detected → status `review`, swap `in-progress` label to `needs-review`
+   - No PR → status `bailed`, remove worktree and branch
+3. PR merge detected (30s review check) → status `done`, remove `needs-review` label, clean worktree
+4. Check dependency graph → fill slot with next unblocked issue
+
+### Label Management
+
+| Event | Label added | Label removed |
+|-------|-------------|---------------|
+| Agent starts | `in-progress` | — |
+| PR opened (review) | `needs-review` | `in-progress` |
+| PR merged (done) | — | `needs-review` |
+| Agent bails | `blocked` | `in-progress` |
+
+The `no-agent` label (configurable via `autopilot_skip_label`) excludes issues from the task pool entirely.
+
+## Dependency Graph
+
+### Extraction
+One LLM call when autopilot is triggered. Input: all autopilot task issue titles + bodies, plus all other tracked items (closed, skipped, etc.) as context for cross-references. Output:
+
+```json
+{
+  "42": [],
+  "38": [42],
+  "55": [42, 38],
+  "61": []
+}
+```
+
+The graph is computed once at `Prepare()` time. Fallback if LLM fails: sequential ordering by issue number.
+
+### Unblock Detection
+- **Internal deps** (other autopilot tasks): blocked until dep task reaches `done` status
+- **External deps** (tracked items not in autopilot): blocked while tracked item is `open`; unblocked when closed/merged
+- Dynamically discovered tasks get empty dependencies (start unblocked)
+
+## Agent Invocation
+
+```bash
+claude -p \
+  --max-turns 50 \
+  --max-budget-usd 3.00 \
+  --dangerously-skip-permissions \
+  "<templated prompt>"
+```
+
+Environment: `GITHUB_TOKEN` is set for `gh` CLI access.
+
+### Prompt Template
+
+```
+You are working on GitHub issue #<NUMBER>: <TITLE>
+
+<ISSUE BODY>
+
+You are in a git worktree at: <WORKTREE_PATH>
+Branch: agent/issue-<NUMBER> (already checked out)
+Base branch: <BASE_BRANCH>
+Repository: <OWNER>/<REPO>
+
+## Your first steps
+
+1. Move the issue to "In Progress" — run: gh issue edit <NUMBER> --add-label "in-progress" -R <OWNER>/<REPO>
+2. Post a comment: gh issue comment <NUMBER> --body "Agent starting work on this issue" -R <OWNER>/<REPO>
+3. Read the full issue and any linked issues for context
+4. Explore the codebase to understand the relevant code
+
+## Your decision
+
+After exploring, decide:
+
+### If you can confidently complete this work:
+- Implement the changes
+- Ensure all tests pass and pre-commit hooks are satisfied
+- If tests or hooks fail, you may retry up to 3 times
+- Commit with "Fixes #<NUMBER>" in the commit message
+- Push the branch
+- Open a draft PR
+
+### If you cannot proceed (too risky, blocked, unclear, or failing after retries):
+- Do NOT make code changes
+- Post a comment on #<NUMBER> with:
+  - What you explored and learned about the codebase
+  - Your specific questions or what's blocking you
+  - A follow-up prompt that could be pasted into a future claude code session
+- Add the "blocked" label: gh issue edit <NUMBER> --add-label "blocked" -R <OWNER>/<REPO>
+- Remove "in-progress" label: gh issue edit <NUMBER> --remove-label "in-progress" -R <OWNER>/<REPO>
+
+## Important constraints
+
+- Only modify files within this worktree directory
+- Do not keep retrying if you are stuck — bail early with good context
+- Do not over-engineer. Implement exactly what the issue asks for.
+- Quality gates: this repo may have pre-commit hooks, linters, or test suites. Respect them.
+```
+
+## Resource Limits
+
+| Limit | Default | Configurable | Purpose |
+|-------|---------|--------------|---------|
+| `--max-turns` | 50 | `autopilot_max_turns` | Prevents agents from spinning forever |
+| `--max-budget-usd` | 3.00 | `autopilot_max_budget_usd` | Cost safety net per issue |
+| Max concurrent agents | 3 | `autopilot_max_agents` | Worktree/resource cap |
+| Skip label | `no-agent` | `autopilot_skip_label` | Exclude issues from task pool |
+| Retry budget (in prompt) | 3 attempts | — | For test/hook failures |
+
+## Agent Communication
+
+Agents do NOT use agent-msg. Their artifacts are observed by minder through existing mechanisms:
+
+| Agent action | How minder sees it |
+|---|---|
+| Commits + push | Git polling (existing) |
+| Draft PR opened | `inspectOutcome()` checks via `gh pr list --head <branch>` |
+| Issue comment posted | Visible on GH issue |
+| Issue label changed | Tracked items sweep (existing) |
+| Process exit | Supervisor goroutine `cmd.Wait()` |
+| PR merged | Review check ticker (30s) via `gh pr view` |
+
+The coordinator (minder) posts to the bus on behalf of agents when relevant — the tier 2 analyzer sees autopilot status and can include it in bus messages.
+
+## DB Schema (v9)
+
+### `autopilot_tasks` table
+
+```sql
+CREATE TABLE autopilot_tasks (
+    id INTEGER PRIMARY KEY,
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    issue_number INTEGER NOT NULL,
+    issue_title TEXT NOT NULL DEFAULT '',
+    issue_body TEXT NOT NULL DEFAULT '',
+    dependencies TEXT DEFAULT '[]',  -- JSON array of issue numbers
+    status TEXT NOT NULL DEFAULT 'queued',  -- queued, running, review, done, bailed
+    worktree_path TEXT DEFAULT '',
+    branch TEXT DEFAULT '',
+    pr_number INTEGER DEFAULT 0,
+    agent_log TEXT DEFAULT '',
+    started_at DATETIME,
+    completed_at DATETIME,
+    UNIQUE(project_id, issue_number)
+);
+```
+
+### Additions to `projects` table
+
+```sql
+ALTER TABLE projects ADD COLUMN autopilot_max_agents INTEGER DEFAULT 3;
+ALTER TABLE projects ADD COLUMN autopilot_max_turns INTEGER DEFAULT 50;
+ALTER TABLE projects ADD COLUMN autopilot_max_budget_usd REAL DEFAULT 3.00;
+ALTER TABLE projects ADD COLUMN autopilot_skip_label TEXT DEFAULT 'no-agent';
+```
+
+Note: `autopilot_filter_type` and `autopilot_filter_value` columns exist in schema but are unused — autopilot works from tracked items directly.
+
+## Supervisor Architecture
+
+```
+Minder process
+  ├── TUI (bubbletea) ← shows slot status, handles a/A keys
+  ├── Poller loop (existing) ← detects agent artifacts, injects StatusBlock()
+  └── Autopilot Supervisor
+       ├── Main loop (fills slots, handles events)
+       ├── Review check ticker (30s) ← promotes review → done
+       ├── Discovery ticker (60s) ← finds new tracked items
+       ├── Slot 1: goroutine → exec.Cmd (claude process)
+       ├── Slot 2: goroutine → exec.Cmd (claude process)
+       └── Slot 3: (idle, waiting for unblocked work)
+```
+
+Each slot goroutine:
+1. Deletes stale branch if exists
+2. Creates worktree + branch
+3. Renders prompt template with issue context
+4. Launches `claude -p` via `exec.Command` with `GITHUB_TOKEN` env
+5. Blocks on `cmd.Wait()`
+6. Inspects result: checks for PR via `gh pr list --head <branch>`
+7. Updates `autopilot_tasks` status (review if PR, bailed if not)
+8. Manages labels (swap in-progress → needs-review, or add blocked)
+9. Removes worktree (keeps branch if PR opened, deletes if bailed)
+10. Emits event to TUI
+11. Clears slot, triggers `fillSlots()` for newly unblocked work
+
+Agent stdout/stderr logged to `~/.agent-minder/agents/<project>-issue-<N>.log`.
+
+## Polling During Autopilot
+
+The existing poller continues running during autopilot. Two adjustments:
+
+### Increased poll frequency
+When autopilot starts, poll interval is halved (minimum 30s). Original interval restored when autopilot ends.
+
+### Analyzer context injection
+`Supervisor.StatusBlock()` is injected into the tier 2 analyzer input via `poller.SetAutopilotStatusFunc()`:
+
+```
+## Autopilot Status
+- Slot 1: #42 "Add pagination" (agent/issue-42, running 4m)
+- Slot 2: #38 "Fix auth refresh" (agent/issue-38, running 1m)
+- Slot 3: idle
+Task summary: 2 queued, 1 running, 0 in review, 1 done, 1 bailed
+```
+
+## Future Considerations
+
+- **Agent-to-agent awareness**: Agents working on related issues could benefit from knowing what other agents are doing. Could inject "FYI: agent is also working on #38 which touches the auth module" into the prompt.
+- **Partial completion**: Agent did 80% but hit a wall. Currently this is "bail" — could support pushing a WIP branch with a comment explaining what's left.
+- **Auto-retry after unblock**: When a blocked issue is unblocked (questions answered), automatically re-queue it without user intervention.
+- **Cost reporting**: Aggregate `--max-budget-usd` actuals across all agent runs.
+- **Split poll loops** (issue #65): Separate mechanical status checks (30s) from AI analysis (5m) to reduce LLM costs during autopilot.

--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -1,0 +1,59 @@
+package autopilot
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dustinlange/agent-minder/internal/db"
+)
+
+// renderPrompt builds the agent prompt from the design doc template.
+func renderPrompt(task *db.AutopilotTask, baseBranch, owner, repo string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "You are working on GitHub issue #%d: %s\n\n", task.IssueNumber, task.IssueTitle)
+
+	if task.IssueBody != "" {
+		b.WriteString(task.IssueBody)
+		b.WriteString("\n\n")
+	}
+
+	fmt.Fprintf(&b, "You are in a git worktree at: %s\n", task.WorktreePath)
+	fmt.Fprintf(&b, "Branch: %s (already checked out)\n", task.Branch)
+	fmt.Fprintf(&b, "Base branch: %s\n", baseBranch)
+	fmt.Fprintf(&b, "Repository: %s/%s\n\n", owner, repo)
+
+	b.WriteString("## Your first steps\n\n")
+	fmt.Fprintf(&b, "1. Move the issue to \"In Progress\" — run: gh issue edit %d --add-label \"in-progress\" -R %s/%s\n", task.IssueNumber, owner, repo)
+	fmt.Fprintf(&b, "2. Post a comment: gh issue comment %d --body \"Agent starting work on this issue\" -R %s/%s\n", task.IssueNumber, owner, repo)
+	b.WriteString("3. Read the full issue and any linked issues for context\n")
+	b.WriteString("4. Explore the codebase to understand the relevant code\n\n")
+
+	b.WriteString("## Your decision\n\n")
+	b.WriteString("After exploring, decide:\n\n")
+
+	b.WriteString("### If you can confidently complete this work:\n")
+	b.WriteString("- Implement the changes\n")
+	b.WriteString("- Ensure all tests pass and pre-commit hooks are satisfied\n")
+	b.WriteString("- If tests or hooks fail, you may retry up to 3 times\n")
+	fmt.Fprintf(&b, "- Commit with \"Fixes #%d\" in the commit message\n", task.IssueNumber)
+	b.WriteString("- Push the branch\n")
+	b.WriteString("- Open a draft PR\n\n")
+
+	b.WriteString("### If you cannot proceed (too risky, blocked, unclear, or failing after retries):\n")
+	b.WriteString("- Do NOT make code changes\n")
+	fmt.Fprintf(&b, "- Post a comment on #%d with:\n", task.IssueNumber)
+	b.WriteString("  - What you explored and learned about the codebase\n")
+	b.WriteString("  - Your specific questions or what's blocking you\n")
+	b.WriteString("  - A follow-up prompt that could be pasted into a future claude code session\n")
+	fmt.Fprintf(&b, "- Add the \"blocked\" label: gh issue edit %d --add-label \"blocked\" -R %s/%s\n", task.IssueNumber, owner, repo)
+	fmt.Fprintf(&b, "- Remove \"in-progress\" label: gh issue edit %d --remove-label \"in-progress\" -R %s/%s\n\n", task.IssueNumber, owner, repo)
+
+	b.WriteString("## Important constraints\n\n")
+	b.WriteString("- Only modify files within this worktree directory\n")
+	b.WriteString("- Do not keep retrying if you are stuck — bail early with good context\n")
+	b.WriteString("- Do not over-engineer. Implement exactly what the issue asks for.\n")
+	b.WriteString("- Quality gates: this repo may have pre-commit hooks, linters, or test suites. Respect them.\n")
+
+	return b.String()
+}

--- a/internal/autopilot/prompt_test.go
+++ b/internal/autopilot/prompt_test.go
@@ -1,0 +1,61 @@
+package autopilot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dustinlange/agent-minder/internal/db"
+)
+
+func TestRenderPrompt(t *testing.T) {
+	task := &db.AutopilotTask{
+		IssueNumber:  42,
+		IssueTitle:   "Add user authentication",
+		IssueBody:    "Implement OAuth2 login flow",
+		WorktreePath: "/home/user/.agent-minder/worktrees/myproject/issue-42",
+		Branch:       "agent/issue-42",
+	}
+
+	prompt := renderPrompt(task, "main", "myorg", "myrepo")
+
+	// Check key content is present.
+	checks := []string{
+		"#42: Add user authentication",
+		"OAuth2 login flow",
+		"issue-42",
+		"agent/issue-42",
+		"main",
+		"myorg/myrepo",
+		"gh issue edit 42",
+		"gh issue comment 42",
+		"Fixes #42",
+		"--add-label \"in-progress\"",
+		"--add-label \"blocked\"",
+		"-R myorg/myrepo",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(prompt, check) {
+			t.Errorf("prompt missing expected content: %q", check)
+		}
+	}
+}
+
+func TestRenderPromptEmptyBody(t *testing.T) {
+	task := &db.AutopilotTask{
+		IssueNumber:  1,
+		IssueTitle:   "Fix bug",
+		IssueBody:    "",
+		WorktreePath: "/tmp/worktree",
+		Branch:       "agent/issue-1",
+	}
+
+	prompt := renderPrompt(task, "main", "owner", "repo")
+
+	if strings.Contains(prompt, "\n\n\n\n") {
+		t.Error("prompt has excessive blank lines when body is empty")
+	}
+	if !strings.Contains(prompt, "#1: Fix bug") {
+		t.Error("prompt missing issue title")
+	}
+}

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -1,0 +1,824 @@
+// Package autopilot manages automated Claude Code agents that work on GitHub issues.
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dustinlange/agent-minder/internal/db"
+	gitpkg "github.com/dustinlange/agent-minder/internal/git"
+	ghpkg "github.com/dustinlange/agent-minder/internal/github"
+	"github.com/dustinlange/agent-minder/internal/llm"
+)
+
+// Event is emitted by the supervisor for the TUI to consume.
+type Event struct {
+	Time    time.Time
+	Type    string // "started", "completed", "bailed", "error", "stopped"
+	Summary string
+	Task    *db.AutopilotTask
+}
+
+// SlotInfo describes the current state of an agent slot for TUI display.
+type SlotInfo struct {
+	SlotNum     int
+	IssueNumber int
+	IssueTitle  string
+	Branch      string
+	RunningFor  time.Duration
+	Status      string // "running" or "idle"
+}
+
+type slotState struct {
+	task      *db.AutopilotTask
+	startedAt time.Time
+	cmd       *exec.Cmd
+}
+
+// Supervisor manages concurrent autopilot agents working on GitHub issues.
+type Supervisor struct {
+	store    *db.Store
+	project  *db.Project
+	provider llm.Provider
+	repoDir  string // primary repo for worktree operations
+	owner    string
+	repo     string
+	ghToken  string
+
+	mu     sync.Mutex
+	slots  []*slotState // len == maxAgents; nil = idle
+	active bool
+	events chan Event
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// New creates a new Supervisor.
+func New(store *db.Store, project *db.Project, provider llm.Provider, repoDir, owner, repo, ghToken string) *Supervisor {
+	maxAgents := project.AutopilotMaxAgents
+	if maxAgents < 1 {
+		maxAgents = 3
+	}
+	return &Supervisor{
+		store:   store,
+		project: project,
+		provider: provider,
+		repoDir: repoDir,
+		owner:   owner,
+		repo:    repo,
+		ghToken: ghToken,
+		slots:   make([]*slotState, maxAgents),
+		events:  make(chan Event, 64),
+	}
+}
+
+// Events returns the channel of events for the TUI.
+func (s *Supervisor) Events() <-chan Event {
+	return s.events
+}
+
+// IsActive returns whether the supervisor is currently running.
+func (s *Supervisor) IsActive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active
+}
+
+// Prepare fetches tracked issues, creates autopilot tasks, and builds a dependency graph.
+// Always starts fresh — clears previous tasks, cleans up orphaned worktrees.
+func (s *Supervisor) Prepare(ctx context.Context) (total, unblocked int, err error) {
+	// Clean up any leftovers from a previous run.
+	s.store.ClearAutopilotTasks(s.project.ID)
+	s.cleanOrphanedWorktrees()
+
+	// Convert tracked items to autopilot tasks.
+	tasks, err := s.convertTrackedItems(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("convert tracked items: %w", err)
+	}
+	if len(tasks) == 0 {
+		return 0, 0, nil
+	}
+
+	// Build dependency graph.
+	if err := s.buildDependencyGraph(ctx, tasks); err != nil {
+		s.emitEvent("error", fmt.Sprintf("Dependency graph failed: %v — falling back to sequential order", err), nil)
+		s.setSequentialDeps(tasks)
+	}
+
+	unblockedTasks, err := s.store.QueuedUnblockedTasks(s.project.ID)
+	if err != nil {
+		return len(tasks), 0, fmt.Errorf("count unblocked: %w", err)
+	}
+
+	return len(tasks), len(unblockedTasks), nil
+}
+
+// cleanOrphanedWorktrees removes worktrees left behind by interrupted agents.
+func (s *Supervisor) cleanOrphanedWorktrees() {
+	worktreeBase := filepath.Join(os.Getenv("HOME"), ".agent-minder", "worktrees", s.project.Name)
+	entries, err := os.ReadDir(worktreeBase)
+	if err != nil {
+		return // directory may not exist
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		path := filepath.Join(worktreeBase, e.Name())
+		if err := gitpkg.WorktreeRemove(s.repoDir, path); err != nil {
+			// Best-effort: try direct removal if git worktree remove fails.
+			os.RemoveAll(path)
+		}
+	}
+}
+
+// Launch starts filling slots with agents. Call after Prepare + user confirmation.
+func (s *Supervisor) Launch(ctx context.Context) {
+	s.mu.Lock()
+	if s.active {
+		s.mu.Unlock()
+		return
+	}
+	ctx, s.cancel = context.WithCancel(ctx)
+	s.active = true
+	s.done = make(chan struct{})
+	s.mu.Unlock()
+
+	go func() {
+		defer close(s.done)
+		s.fillSlots(ctx)
+
+		// Main loop: wait for agents, check review PRs for merges,
+		// discover new tracked items, fill new slots.
+		reviewCheckTicker := time.NewTicker(30 * time.Second)
+		defer reviewCheckTicker.Stop()
+		discoveryTicker := time.NewTicker(60 * time.Second)
+		defer discoveryTicker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				s.mu.Lock()
+				s.active = false
+				s.mu.Unlock()
+				s.emitEvent("stopped", "Autopilot cancelled", nil)
+				return
+			case <-reviewCheckTicker.C:
+				promoted := s.checkReviewTasks(ctx)
+				if promoted > 0 {
+					s.fillSlots(ctx)
+				}
+			case <-discoveryTicker.C:
+				if s.hasIdleSlot() {
+					added := s.discoverNewTasks(ctx)
+					if added > 0 {
+						s.fillSlots(ctx)
+					}
+				}
+			default:
+			}
+
+			s.mu.Lock()
+			anyRunning := false
+			for _, slot := range s.slots {
+				if slot != nil {
+					anyRunning = true
+					break
+				}
+			}
+			s.mu.Unlock()
+
+			// Check if there's any work left (running agents, queued tasks, or tasks in review).
+			hasWork := anyRunning
+			if !hasWork {
+				tasks, _ := s.store.GetAutopilotTasks(s.project.ID)
+				for _, t := range tasks {
+					if t.Status == "queued" || t.Status == "review" {
+						hasWork = true
+						break
+					}
+				}
+			}
+
+			if !hasWork {
+				break
+			}
+			time.Sleep(2 * time.Second)
+		}
+
+		s.mu.Lock()
+		s.active = false
+		s.mu.Unlock()
+		s.emitEvent("stopped", "All agents finished", nil)
+	}()
+}
+
+// Stop cancels all agent processes and cleans up.
+func (s *Supervisor) Stop() {
+	s.mu.Lock()
+	if !s.active {
+		s.mu.Unlock()
+		return
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.mu.Unlock()
+
+	// Wait for done signal.
+	if s.done != nil {
+		<-s.done
+	}
+}
+
+// SlotStatus returns the current state of all agent slots.
+func (s *Supervisor) SlotStatus() []SlotInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	infos := make([]SlotInfo, len(s.slots))
+	for i, slot := range s.slots {
+		if slot == nil {
+			infos[i] = SlotInfo{
+				SlotNum: i + 1,
+				Status:  "idle",
+			}
+		} else {
+			infos[i] = SlotInfo{
+				SlotNum:     i + 1,
+				IssueNumber: slot.task.IssueNumber,
+				IssueTitle:  slot.task.IssueTitle,
+				Branch:      slot.task.Branch,
+				RunningFor:  time.Since(slot.startedAt),
+				Status:      "running",
+			}
+		}
+	}
+	return infos
+}
+
+// StatusBlock returns a formatted text block for injection into the tier 2 analyzer prompt.
+func (s *Supervisor) StatusBlock() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.active {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Autopilot Status\n")
+
+	for i, slot := range s.slots {
+		if slot == nil {
+			fmt.Fprintf(&b, "- Slot %d: idle\n", i+1)
+		} else {
+			elapsed := time.Since(slot.startedAt).Round(time.Second)
+			fmt.Fprintf(&b, "- Slot %d: #%d %s (%s, running %s)\n",
+				i+1, slot.task.IssueNumber, slot.task.IssueTitle, slot.task.Branch, elapsed)
+		}
+	}
+
+	// Summary counts.
+	tasks, _ := s.store.GetAutopilotTasks(s.project.ID)
+	var queued, running, review, done, bailed int
+	for _, t := range tasks {
+		switch t.Status {
+		case "queued":
+			queued++
+		case "running":
+			running++
+		case "review":
+			review++
+		case "done":
+			done++
+		case "bailed":
+			bailed++
+		}
+	}
+	fmt.Fprintf(&b, "\nTask summary: %d queued, %d running, %d in review, %d done, %d bailed\n", queued, running, review, done, bailed)
+
+	return b.String()
+}
+
+// convertTrackedItems reads the user's already-tracked issues and creates autopilot tasks.
+func (s *Supervisor) convertTrackedItems(ctx context.Context) ([]*db.AutopilotTask, error) {
+	items, err := s.store.GetTrackedItems(s.project.ID)
+	if err != nil {
+		return nil, fmt.Errorf("get tracked items: %w", err)
+	}
+
+	// Filter out issues with the skip label, non-open items, and PRs.
+	skipLabel := s.project.AutopilotSkipLabel
+	if skipLabel == "" {
+		skipLabel = "no-agent"
+	}
+
+	ghClient := ghpkg.NewClient(s.ghToken)
+
+	var tasks []*db.AutopilotTask
+	for _, item := range items {
+		// Only process open issues.
+		if item.ItemType != "issue" || item.State != "open" {
+			continue
+		}
+
+		// Fetch live status from GitHub (cached labels may be stale).
+		liveStatus, err := ghClient.FetchItem(ctx, item.Owner, item.Repo, item.Number)
+		if err != nil {
+			continue
+		}
+		if liveStatus.State != "open" {
+			continue
+		}
+		if hasLabel(liveStatus.Labels, skipLabel) {
+			continue
+		}
+
+		// Fetch issue body.
+		body := ""
+		content, err := ghClient.FetchItemContent(ctx, item.Owner, item.Repo, item.Number, "issue")
+		if err == nil {
+			body = content.Body
+		}
+
+		tasks = append(tasks, &db.AutopilotTask{
+			ProjectID:    s.project.ID,
+			IssueNumber:  item.Number,
+			IssueTitle:   liveStatus.Title,
+			IssueBody:    body,
+			Dependencies: "[]",
+			Status:       "queued",
+		})
+	}
+
+	if len(tasks) == 0 {
+		return nil, nil
+	}
+
+	_, err = s.store.BulkCreateAutopilotTasks(tasks)
+	if err != nil {
+		return nil, fmt.Errorf("store tasks: %w", err)
+	}
+
+	return tasks, nil
+}
+
+func hasLabel(labels []string, target string) bool {
+	for _, l := range labels {
+		if l == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Supervisor) buildDependencyGraph(ctx context.Context, tasks []*db.AutopilotTask) error {
+	if len(tasks) <= 1 {
+		return nil // No dependencies possible with 0-1 tasks.
+	}
+
+	// Build task issue numbers set for quick lookup.
+	taskIssues := make(map[int]bool, len(tasks))
+	for _, t := range tasks {
+		taskIssues[t.IssueNumber] = true
+	}
+
+	// Build issue list for the LLM — include tasks being worked on.
+	var issueList strings.Builder
+	issueList.WriteString("## Issues to be worked on by agents:\n")
+	for _, t := range tasks {
+		fmt.Fprintf(&issueList, "Issue #%d: %s\n", t.IssueNumber, t.IssueTitle)
+		if t.IssueBody != "" {
+			body := t.IssueBody
+			if len(body) > 200 {
+				body = body[:200] + "..."
+			}
+			fmt.Fprintf(&issueList, "  %s\n", body)
+		}
+	}
+
+	// Include other tracked issues as context (skipped, closed, etc.)
+	// so the LLM can identify external dependencies.
+	trackedItems, _ := s.store.GetTrackedItems(s.project.ID)
+	var contextList strings.Builder
+	for _, item := range trackedItems {
+		if taskIssues[item.Number] || item.ItemType != "issue" {
+			continue
+		}
+		fmt.Fprintf(&contextList, "Issue #%d [%s]: %s\n", item.Number, item.State, item.Title)
+	}
+	if contextList.Len() > 0 {
+		issueList.WriteString("\n## Other tracked issues (not being worked on by agents, but may be dependencies):\n")
+		issueList.WriteString(contextList.String())
+	}
+
+	prompt := fmt.Sprintf(`Analyze these GitHub issues and determine dependencies between them.
+A dependency means issue B cannot start until issue A is completed (e.g., B builds on A's infrastructure or schema changes).
+
+Dependencies can include issues from BOTH sections — an agent task can depend on a non-agent issue if that issue's work must be done first.
+
+%s
+
+Respond with ONLY a JSON object. Keys are issue numbers (only for issues being worked on by agents), values are arrays of integer issue numbers that must complete first. Issues with no dependencies get an empty array.
+
+IMPORTANT: Use integer values in the arrays, not strings.
+Example: {"42": [], "38": [42], "15": [42, 38]}
+
+Be conservative — only add a dependency if the work truly cannot proceed without the other issue being done first.`, issueList.String())
+
+	messages := []llm.Message{{Role: "user", Content: prompt}}
+
+	var rawGraph map[string]json.RawMessage
+	var content string
+
+	for attempt := 0; attempt < 2; attempt++ {
+		resp, err := s.provider.Complete(ctx, &llm.Request{
+			Model:       s.project.LLMAnalyzerModel,
+			System:      "You are analyzing issue dependencies. Respond with ONLY valid JSON, no explanation or preamble.",
+			Messages:    messages,
+			MaxTokens:   512,
+			Temperature: 0,
+		})
+		if err != nil {
+			return fmt.Errorf("LLM call: %w", err)
+		}
+
+		content = strings.TrimSpace(resp.Content)
+		// Strip markdown fencing if present.
+		if strings.HasPrefix(content, "```") {
+			lines := strings.Split(content, "\n")
+			if len(lines) > 2 {
+				content = strings.Join(lines[1:len(lines)-1], "\n")
+			}
+		}
+		// Extract JSON object — trim any leading/trailing non-JSON text.
+		if start := strings.Index(content, "{"); start >= 0 {
+			if end := strings.LastIndex(content, "}"); end > start {
+				content = content[start : end+1]
+			}
+		}
+
+		if err := json.Unmarshal([]byte(content), &rawGraph); err != nil {
+			if attempt == 0 {
+				// Retry with error feedback.
+				messages = append(messages,
+					llm.Message{Role: "assistant", Content: resp.Content},
+					llm.Message{Role: "user", Content: fmt.Sprintf("That was not valid JSON: %v\n\nPlease respond with ONLY the JSON object, no text before or after.", err)},
+				)
+				continue
+			}
+			return fmt.Errorf("parse dep graph: %w", err)
+		}
+		break
+	}
+
+	// Update each task's dependencies.
+	for _, t := range tasks {
+		key := strconv.Itoa(t.IssueNumber)
+		rawDeps, ok := rawGraph[key]
+		if !ok {
+			continue
+		}
+
+		// Try []int first, then []string, then []any.
+		var deps []int
+		if err := json.Unmarshal(rawDeps, &deps); err != nil {
+			var strDeps []string
+			if err2 := json.Unmarshal(rawDeps, &strDeps); err2 != nil {
+				continue
+			}
+			for _, sd := range strDeps {
+				if n, err3 := strconv.Atoi(sd); err3 == nil {
+					deps = append(deps, n)
+				}
+			}
+		}
+
+		if len(deps) > 0 {
+			depsJSON, _ := json.Marshal(deps)
+			if err := s.store.UpdateAutopilotTaskDeps(t.ID, string(depsJSON)); err != nil {
+				return fmt.Errorf("update deps for #%d: %w", t.IssueNumber, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// setSequentialDeps creates a simple chain: each task depends on the previous one (by issue number).
+// This is the safe fallback when the LLM dep graph fails — tasks run one at a time in order.
+func (s *Supervisor) setSequentialDeps(tasks []*db.AutopilotTask) {
+	// Tasks are already sorted by issue number from the DB query.
+	for i := 1; i < len(tasks); i++ {
+		deps := []int{tasks[i-1].IssueNumber}
+		depsJSON, _ := json.Marshal(deps)
+		s.store.UpdateAutopilotTaskDeps(tasks[i].ID, string(depsJSON))
+	}
+}
+
+func (s *Supervisor) fillSlots(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, slot := range s.slots {
+		if slot != nil {
+			continue // Slot occupied.
+		}
+
+		// Find next unblocked task.
+		tasks, err := s.store.QueuedUnblockedTasks(s.project.ID)
+		if err != nil || len(tasks) == 0 {
+			break
+		}
+
+		task := tasks[0]
+		s.launchAgent(ctx, i, &task)
+	}
+}
+
+func (s *Supervisor) hasIdleSlot() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, slot := range s.slots {
+		if slot == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// discoverNewTasks checks tracked items for new open issues not already in the
+// autopilot task list and adds them. Returns the number of new tasks added.
+func (s *Supervisor) discoverNewTasks(ctx context.Context) int {
+	existing, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return 0
+	}
+	knownIssues := make(map[int]bool, len(existing))
+	for _, t := range existing {
+		knownIssues[t.IssueNumber] = true
+	}
+
+	items, err := s.store.GetTrackedItems(s.project.ID)
+	if err != nil {
+		return 0
+	}
+
+	skipLabel := s.project.AutopilotSkipLabel
+	if skipLabel == "" {
+		skipLabel = "no-agent"
+	}
+	ghClient := ghpkg.NewClient(s.ghToken)
+
+	var newTasks []*db.AutopilotTask
+	for _, item := range items {
+		if item.ItemType != "issue" || item.State != "open" {
+			continue
+		}
+		if knownIssues[item.Number] {
+			continue
+		}
+
+		// Fetch live status to check labels.
+		liveStatus, err := ghClient.FetchItem(ctx, item.Owner, item.Repo, item.Number)
+		if err != nil || liveStatus.State != "open" {
+			continue
+		}
+		if hasLabel(liveStatus.Labels, skipLabel) {
+			continue
+		}
+
+		body := ""
+		content, err := ghClient.FetchItemContent(ctx, item.Owner, item.Repo, item.Number, "issue")
+		if err == nil {
+			body = content.Body
+		}
+
+		newTasks = append(newTasks, &db.AutopilotTask{
+			ProjectID:    s.project.ID,
+			IssueNumber:  item.Number,
+			IssueTitle:   liveStatus.Title,
+			IssueBody:    body,
+			Dependencies: "[]", // No deps — new tasks start unblocked.
+			Status:       "queued",
+		})
+	}
+
+	if len(newTasks) == 0 {
+		return 0
+	}
+
+	added, err := s.store.BulkCreateAutopilotTasks(newTasks)
+	if err != nil {
+		return 0
+	}
+
+	for _, t := range newTasks {
+		s.emitEvent("discovered", fmt.Sprintf("New task #%d: %s", t.IssueNumber, t.IssueTitle), nil)
+	}
+
+	return added
+}
+
+func (s *Supervisor) launchAgent(ctx context.Context, slotIdx int, task *db.AutopilotTask) {
+	// Set up worktree path and branch.
+	home, _ := os.UserHomeDir()
+	worktreeBase := filepath.Join(home, ".agent-minder", "worktrees", s.project.Name)
+	worktreePath := filepath.Join(worktreeBase, fmt.Sprintf("issue-%d", task.IssueNumber))
+	branch := fmt.Sprintf("agent/issue-%d", task.IssueNumber)
+	logDir := filepath.Join(home, ".agent-minder", "agents")
+	logPath := filepath.Join(logDir, fmt.Sprintf("%s-issue-%d.log", s.project.Name, task.IssueNumber))
+
+	task.WorktreePath = worktreePath
+	task.Branch = branch
+	task.AgentLog = logPath
+
+	// Update task in DB to running.
+	if err := s.store.UpdateAutopilotTaskRunning(task.ID, worktreePath, branch, logPath); err != nil {
+		s.emitEvent("error", fmt.Sprintf("Failed to update task #%d: %v", task.IssueNumber, err), task)
+		return
+	}
+
+	s.slots[slotIdx] = &slotState{
+		task:      task,
+		startedAt: time.Now(),
+	}
+
+	go s.runAgent(ctx, slotIdx, task)
+}
+
+func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.AutopilotTask) {
+	defer func() {
+		s.mu.Lock()
+		s.slots[slotIdx] = nil
+		s.mu.Unlock()
+		// Try to fill slots with newly unblocked work.
+		s.fillSlots(ctx)
+	}()
+
+	home, _ := os.UserHomeDir()
+
+	// Ensure directories exist.
+	os.MkdirAll(filepath.Dir(task.WorktreePath), 0755)
+	os.MkdirAll(filepath.Join(home, ".agent-minder", "agents"), 0755)
+
+	// Clean up stale branch from previous run if it exists.
+	gitpkg.DeleteBranch(s.repoDir, task.Branch)
+
+	// Create worktree.
+	if err := gitpkg.WorktreeAdd(s.repoDir, task.WorktreePath, task.Branch); err != nil {
+		s.emitEvent("error", fmt.Sprintf("Failed to create worktree for #%d: %v", task.IssueNumber, err), task)
+		s.store.UpdateAutopilotTaskStatus(task.ID, "bailed")
+		return
+	}
+
+	s.emitEvent("started", fmt.Sprintf("Agent started on #%d: %s", task.IssueNumber, task.IssueTitle), task)
+
+	// Get base branch.
+	baseBranch, _ := gitpkg.DefaultBranch(s.repoDir)
+
+	// Build prompt.
+	prompt := renderPrompt(task, baseBranch, s.owner, s.repo)
+
+	// Open log file.
+	logFile, err := os.Create(task.AgentLog)
+	if err != nil {
+		s.emitEvent("error", fmt.Sprintf("Failed to open log for #%d: %v", task.IssueNumber, err), task)
+		s.cleanup(task, true)
+		return
+	}
+	defer logFile.Close()
+
+	// Build claude command.
+	maxTurns := s.project.AutopilotMaxTurns
+	if maxTurns < 1 {
+		maxTurns = 50
+	}
+	maxBudget := s.project.AutopilotMaxBudgetUSD
+	if maxBudget <= 0 {
+		maxBudget = 3.00
+	}
+
+	cmd := exec.CommandContext(ctx, "claude",
+		"-p",
+		"--max-turns", strconv.Itoa(maxTurns),
+		"--max-budget-usd", fmt.Sprintf("%.2f", maxBudget),
+		"--dangerously-skip-permissions",
+		prompt,
+	)
+	cmd.Dir = task.WorktreePath
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	// Set GITHUB_TOKEN for gh CLI calls within the agent.
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+s.ghToken)
+
+	s.mu.Lock()
+	if s.slots[slotIdx] != nil {
+		s.slots[slotIdx].cmd = cmd
+	}
+	s.mu.Unlock()
+
+	// Run the agent.
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+	}
+
+	// Inspect outcome.
+	status := s.inspectOutcome(ctx, task, exitCode)
+	s.store.UpdateAutopilotTaskStatus(task.ID, status)
+
+	if status == "review" {
+		// Swap in-progress → needs-review label on the issue.
+		ghClient := ghpkg.NewClient(s.ghToken)
+		ghClient.RemoveLabel(ctx, s.owner, s.repo, task.IssueNumber, "in-progress")
+		ghClient.AddLabel(ctx, s.owner, s.repo, task.IssueNumber, "needs-review")
+		s.emitEvent("completed", fmt.Sprintf("Agent completed #%d — PR opened, awaiting review & merge", task.IssueNumber), task)
+	} else {
+		s.emitEvent("bailed", fmt.Sprintf("Agent bailed on #%d (exit code %d)", task.IssueNumber, exitCode), task)
+	}
+
+	// Cleanup: remove worktree, delete branch only if bailed.
+	s.cleanup(task, status == "bailed")
+}
+
+// checkReviewTasks checks if any tasks in "review" status have had their PRs merged.
+// Returns the number of tasks promoted to "done".
+func (s *Supervisor) checkReviewTasks(ctx context.Context) int {
+	tasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return 0
+	}
+
+	ghClient := ghpkg.NewClient(s.ghToken)
+	promoted := 0
+
+	for _, task := range tasks {
+		if task.Status != "review" || task.PRNumber == 0 {
+			continue
+		}
+
+		item, err := ghClient.FetchItem(ctx, s.owner, s.repo, task.PRNumber)
+		if err != nil {
+			continue
+		}
+
+		if item.State == "merged" || item.State == "closed" {
+			s.store.UpdateAutopilotTaskStatus(task.ID, "done")
+			// Clean up the needs-review label.
+			ghClient.RemoveLabel(ctx, s.owner, s.repo, task.IssueNumber, "needs-review")
+			promoted++
+			s.emitEvent("completed", fmt.Sprintf("PR #%d for issue #%d merged — dependents unblocked", task.PRNumber, task.IssueNumber), &task)
+		}
+	}
+
+	return promoted
+}
+
+func (s *Supervisor) inspectOutcome(ctx context.Context, task *db.AutopilotTask, exitCode int) string {
+	// Check if a PR was opened for this branch.
+	ghClient := ghpkg.NewClient(s.ghToken)
+	pr, err := ghClient.FetchPRForBranch(ctx, s.owner, s.repo, task.Branch)
+	if err == nil && pr != nil && pr.Number > 0 {
+		s.store.UpdateAutopilotTaskPR(task.ID, pr.Number)
+		return "review" // awaiting human review & merge before dependents unblock
+	}
+	return "bailed"
+}
+
+func (s *Supervisor) cleanup(task *db.AutopilotTask, deleteBranch bool) {
+	// Remove worktree.
+	gitpkg.WorktreeRemove(s.repoDir, task.WorktreePath)
+
+	// Delete branch only if bailed (keep if PR opened).
+	if deleteBranch {
+		gitpkg.DeleteBranch(s.repoDir, task.Branch)
+	}
+}
+
+func (s *Supervisor) emitEvent(typ, summary string, task *db.AutopilotTask) {
+	select {
+	case s.events <- Event{
+		Time:    time.Now(),
+		Type:    typ,
+		Summary: summary,
+		Task:    task,
+	}:
+	default:
+		// Drop event if channel is full.
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1298,3 +1298,260 @@ func TestPruneTrackedItems_ArchivesBeforeDelete(t *testing.T) {
 		t.Errorf("archived item number = %d, want 6", completed[0].Number)
 	}
 }
+
+func TestMigrationV9_AutopilotTasks(t *testing.T) {
+	store := openTestDB(t)
+
+	// Verify schema version is 9.
+	var version int
+	if err := store.DB().Get(&version, "SELECT version FROM schema_version LIMIT 1"); err != nil {
+		t.Fatalf("get version: %v", err)
+	}
+	if version != 9 {
+		t.Errorf("version = %d, want 9", version)
+	}
+
+	// Create a project with autopilot fields.
+	p := &Project{
+		Name:                  "autopilot-test",
+		GoalType:              "feature",
+		GoalDescription:       "test autopilot",
+		RefreshIntervalSec:    300,
+		MessageTTLSec:         172800,
+		LLMProvider:           "anthropic",
+		LLMModel:              "claude-haiku-4-5",
+		LLMSummarizerModel:    "claude-haiku-4-5",
+		LLMAnalyzerModel:      "claude-sonnet-4-6",
+		AutopilotMaxAgents:    5,
+		AutopilotMaxTurns:     100,
+		AutopilotMaxBudgetUSD: 5.50,
+		AutopilotSkipLabel:    "skip-me",
+	}
+	if err := store.CreateProject(p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Verify autopilot fields persist.
+	got, err := store.GetProject("autopilot-test")
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	if got.AutopilotMaxAgents != 5 {
+		t.Errorf("AutopilotMaxAgents = %d, want 5", got.AutopilotMaxAgents)
+	}
+	if got.AutopilotMaxTurns != 100 {
+		t.Errorf("AutopilotMaxTurns = %d, want 100", got.AutopilotMaxTurns)
+	}
+	if got.AutopilotMaxBudgetUSD != 5.50 {
+		t.Errorf("AutopilotMaxBudgetUSD = %f, want 5.50", got.AutopilotMaxBudgetUSD)
+	}
+	if got.AutopilotSkipLabel != "skip-me" {
+		t.Errorf("AutopilotSkipLabel = %q, want %q", got.AutopilotSkipLabel, "skip-me")
+	}
+}
+
+func TestAutopilotTasksCRUD(t *testing.T) {
+	store := openTestDB(t)
+
+	p := &Project{
+		Name:               "ap-crud",
+		GoalType:           "feature",
+		GoalDescription:    "test",
+		RefreshIntervalSec: 300,
+		MessageTTLSec:      172800,
+		LLMProvider:        "anthropic",
+		LLMModel:           "claude-haiku-4-5",
+		LLMSummarizerModel: "claude-haiku-4-5",
+		LLMAnalyzerModel:   "claude-sonnet-4-6",
+	}
+	if err := store.CreateProject(p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Create a task.
+	task := &AutopilotTask{
+		ProjectID:    p.ID,
+		IssueNumber:  42,
+		IssueTitle:   "Add auth",
+		IssueBody:    "Implement OAuth",
+		Dependencies: "[]",
+		Status:       "queued",
+	}
+	if err := store.CreateAutopilotTask(task); err != nil {
+		t.Fatalf("CreateAutopilotTask: %v", err)
+	}
+	if task.ID == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+
+	// Get tasks.
+	tasks, err := store.GetAutopilotTasks(p.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(tasks))
+	}
+	if tasks[0].IssueNumber != 42 {
+		t.Errorf("IssueNumber = %d, want 42", tasks[0].IssueNumber)
+	}
+
+	// Update status.
+	if err := store.UpdateAutopilotTaskStatus(task.ID, "running"); err != nil {
+		t.Fatalf("UpdateAutopilotTaskStatus: %v", err)
+	}
+	tasks, _ = store.GetAutopilotTasks(p.ID)
+	if tasks[0].Status != "running" {
+		t.Errorf("Status = %q, want running", tasks[0].Status)
+	}
+
+	// Update running info.
+	if err := store.UpdateAutopilotTaskRunning(task.ID, "/tmp/wt", "agent/issue-42", "/tmp/log"); err != nil {
+		t.Fatalf("UpdateAutopilotTaskRunning: %v", err)
+	}
+	tasks, _ = store.GetAutopilotTasks(p.ID)
+	if tasks[0].WorktreePath != "/tmp/wt" {
+		t.Errorf("WorktreePath = %q, want /tmp/wt", tasks[0].WorktreePath)
+	}
+
+	// Update PR number.
+	if err := store.UpdateAutopilotTaskPR(task.ID, 99); err != nil {
+		t.Fatalf("UpdateAutopilotTaskPR: %v", err)
+	}
+	tasks, _ = store.GetAutopilotTasks(p.ID)
+	if tasks[0].PRNumber != 99 {
+		t.Errorf("PRNumber = %d, want 99", tasks[0].PRNumber)
+	}
+
+	// Mark done.
+	if err := store.UpdateAutopilotTaskStatus(task.ID, "done"); err != nil {
+		t.Fatalf("UpdateAutopilotTaskStatus done: %v", err)
+	}
+	tasks, _ = store.GetAutopilotTasks(p.ID)
+	if tasks[0].Status != "done" {
+		t.Errorf("Status = %q, want done", tasks[0].Status)
+	}
+	if tasks[0].CompletedAt == "" {
+		t.Error("CompletedAt should be set when done")
+	}
+
+	// Clear.
+	if err := store.ClearAutopilotTasks(p.ID); err != nil {
+		t.Fatalf("ClearAutopilotTasks: %v", err)
+	}
+	tasks, _ = store.GetAutopilotTasks(p.ID)
+	if len(tasks) != 0 {
+		t.Errorf("got %d tasks after clear, want 0", len(tasks))
+	}
+}
+
+func TestBulkCreateAutopilotTasks(t *testing.T) {
+	store := openTestDB(t)
+
+	p := &Project{
+		Name:               "ap-bulk",
+		GoalType:           "feature",
+		GoalDescription:    "test",
+		RefreshIntervalSec: 300,
+		MessageTTLSec:      172800,
+		LLMProvider:        "anthropic",
+		LLMModel:           "claude-haiku-4-5",
+		LLMSummarizerModel: "claude-haiku-4-5",
+		LLMAnalyzerModel:   "claude-sonnet-4-6",
+	}
+	store.CreateProject(p)
+
+	tasks := []*AutopilotTask{
+		{ProjectID: p.ID, IssueNumber: 1, IssueTitle: "Task 1", Dependencies: "[]", Status: "queued"},
+		{ProjectID: p.ID, IssueNumber: 2, IssueTitle: "Task 2", Dependencies: "[]", Status: "queued"},
+		{ProjectID: p.ID, IssueNumber: 1, IssueTitle: "Task 1 dup", Dependencies: "[]", Status: "queued"}, // duplicate
+	}
+
+	inserted, err := store.BulkCreateAutopilotTasks(tasks)
+	if err != nil {
+		t.Fatalf("BulkCreateAutopilotTasks: %v", err)
+	}
+	if inserted != 2 {
+		t.Errorf("inserted = %d, want 2 (1 duplicate)", inserted)
+	}
+
+	got, _ := store.GetAutopilotTasks(p.ID)
+	if len(got) != 2 {
+		t.Errorf("got %d tasks, want 2", len(got))
+	}
+}
+
+func TestQueuedUnblockedTasks(t *testing.T) {
+	store := openTestDB(t)
+
+	p := &Project{
+		Name:               "ap-deps",
+		GoalType:           "feature",
+		GoalDescription:    "test",
+		RefreshIntervalSec: 300,
+		MessageTTLSec:      172800,
+		LLMProvider:        "anthropic",
+		LLMModel:           "claude-haiku-4-5",
+		LLMSummarizerModel: "claude-haiku-4-5",
+		LLMAnalyzerModel:   "claude-sonnet-4-6",
+	}
+	store.CreateProject(p)
+
+	// Task 1: no deps (should be unblocked).
+	t1 := &AutopilotTask{ProjectID: p.ID, IssueNumber: 1, IssueTitle: "Base", Dependencies: "[]", Status: "queued"}
+	// Task 2: depends on task 1 (should be blocked).
+	t2 := &AutopilotTask{ProjectID: p.ID, IssueNumber: 2, IssueTitle: "Depends on 1", Dependencies: "[1]", Status: "queued"}
+	// Task 3: no deps (should be unblocked).
+	t3 := &AutopilotTask{ProjectID: p.ID, IssueNumber: 3, IssueTitle: "Independent", Dependencies: "[]", Status: "queued"}
+
+	store.CreateAutopilotTask(t1)
+	store.CreateAutopilotTask(t2)
+	store.CreateAutopilotTask(t3)
+
+	unblocked, err := store.QueuedUnblockedTasks(p.ID)
+	if err != nil {
+		t.Fatalf("QueuedUnblockedTasks: %v", err)
+	}
+	if len(unblocked) != 2 {
+		t.Fatalf("got %d unblocked, want 2", len(unblocked))
+	}
+
+	// Complete task 1.
+	store.UpdateAutopilotTaskStatus(t1.ID, "done")
+
+	// Now task 2 should also be unblocked.
+	unblocked, err = store.QueuedUnblockedTasks(p.ID)
+	if err != nil {
+		t.Fatalf("QueuedUnblockedTasks after done: %v", err)
+	}
+	if len(unblocked) != 2 {
+		t.Fatalf("got %d unblocked after done, want 2 (tasks 2 and 3)", len(unblocked))
+	}
+}
+
+func TestParseDependencies(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []int
+	}{
+		{"[]", nil},
+		{"", nil},
+		{"[1]", []int{1}},
+		{"[1, 2, 3]", []int{1, 2, 3}},
+		{"[42]", []int{42}},
+		{"invalid", nil},
+	}
+
+	for _, tt := range tests {
+		got := parseDependencies(tt.input)
+		if len(got) != len(tt.want) {
+			t.Errorf("parseDependencies(%q) = %v, want %v", tt.input, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("parseDependencies(%q)[%d] = %d, want %d", tt.input, i, got[i], tt.want[i])
+			}
+		}
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -20,9 +20,15 @@ type Project struct {
 	LLMModel             string `db:"llm_model"`
 	LLMSummarizerModel   string `db:"llm_summarizer_model"`
 	LLMAnalyzerModel     string `db:"llm_analyzer_model"`
-	IdlePauseSec         int    `db:"idle_pause_sec"`
-	AnalyzerFocus        string `db:"analyzer_focus"`
-	CreatedAt            string `db:"created_at"`
+	IdlePauseSec           int     `db:"idle_pause_sec"`
+	AnalyzerFocus          string  `db:"analyzer_focus"`
+	AutopilotFilterType    string  `db:"autopilot_filter_type"`  // deprecated, unused
+	AutopilotFilterValue   string  `db:"autopilot_filter_value"` // deprecated, unused
+	AutopilotMaxAgents     int     `db:"autopilot_max_agents"`
+	AutopilotMaxTurns      int     `db:"autopilot_max_turns"`
+	AutopilotMaxBudgetUSD  float64 `db:"autopilot_max_budget_usd"`
+	AutopilotSkipLabel     string  `db:"autopilot_skip_label"`
+	CreatedAt              string  `db:"created_at"`
 }
 
 // RefreshInterval returns the refresh interval as a time.Duration.
@@ -143,6 +149,23 @@ type CompletedItem struct {
 // DisplayRef returns a compact reference like "owner/repo#123".
 func (c *CompletedItem) DisplayRef() string {
 	return fmt.Sprintf("%s/%s#%d", c.Owner, c.Repo, c.Number)
+}
+
+// AutopilotTask represents an issue being worked on by an autopilot agent.
+type AutopilotTask struct {
+	ID           int64  `db:"id"`
+	ProjectID    int64  `db:"project_id"`
+	IssueNumber  int    `db:"issue_number"`
+	IssueTitle   string `db:"issue_title"`
+	IssueBody    string `db:"issue_body"`
+	Dependencies string `db:"dependencies"` // JSON array of issue numbers
+	Status       string `db:"status"`       // queued, running, done, bailed, blocked
+	WorktreePath string `db:"worktree_path"`
+	Branch       string `db:"branch"`
+	PRNumber     int    `db:"pr_number"`
+	AgentLog     string `db:"agent_log"`
+	StartedAt    string `db:"started_at"`
+	CompletedAt  string `db:"completed_at"`
 }
 
 // LLMResponse returns the best available response: tier 2 if present, else tier 1, else raw.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -28,10 +29,14 @@ func (s *Store) CreateProject(p *Project) error {
 	result, err := s.db.NamedExec(`
 		INSERT INTO projects (name, goal_type, goal_description, refresh_interval_sec,
 			message_ttl_sec, auto_enroll_worktrees, minder_identity, llm_provider, llm_model,
-			llm_summarizer_model, llm_analyzer_model, idle_pause_sec, analyzer_focus)
+			llm_summarizer_model, llm_analyzer_model, idle_pause_sec, analyzer_focus,
+			autopilot_filter_type, autopilot_filter_value, autopilot_max_agents,
+			autopilot_max_turns, autopilot_max_budget_usd, autopilot_skip_label)
 		VALUES (:name, :goal_type, :goal_description, :refresh_interval_sec,
 			:message_ttl_sec, :auto_enroll_worktrees, :minder_identity, :llm_provider, :llm_model,
-			:llm_summarizer_model, :llm_analyzer_model, :idle_pause_sec, :analyzer_focus)
+			:llm_summarizer_model, :llm_analyzer_model, :idle_pause_sec, :analyzer_focus,
+			:autopilot_filter_type, :autopilot_filter_value, :autopilot_max_agents,
+			:autopilot_max_turns, :autopilot_max_budget_usd, :autopilot_skip_label)
 	`, p)
 	if err != nil {
 		return fmt.Errorf("insert project: %w", err)
@@ -86,7 +91,13 @@ func (s *Store) UpdateProject(p *Project) error {
 			llm_summarizer_model = :llm_summarizer_model,
 			llm_analyzer_model = :llm_analyzer_model,
 			idle_pause_sec = :idle_pause_sec,
-			analyzer_focus = :analyzer_focus
+			analyzer_focus = :analyzer_focus,
+			autopilot_filter_type = :autopilot_filter_type,
+			autopilot_filter_value = :autopilot_filter_value,
+			autopilot_max_agents = :autopilot_max_agents,
+			autopilot_max_turns = :autopilot_max_turns,
+			autopilot_max_budget_usd = :autopilot_max_budget_usd,
+			autopilot_skip_label = :autopilot_skip_label
 		WHERE id = :id
 	`, p)
 	return err
@@ -591,6 +602,228 @@ func (s *Store) PruneCompletedItems(projectID int64, maxAgeSec int) (int, error)
 	}
 	n, _ := result.RowsAffected()
 	return int(n), nil
+}
+
+// --- Autopilot Tasks ---
+
+// CreateAutopilotTask inserts a new autopilot task.
+func (s *Store) CreateAutopilotTask(task *AutopilotTask) error {
+	result, err := s.db.NamedExec(`
+		INSERT INTO autopilot_tasks (project_id, issue_number, issue_title, issue_body, dependencies, status)
+		VALUES (:project_id, :issue_number, :issue_title, :issue_body, :dependencies, :status)
+	`, task)
+	if err != nil {
+		return fmt.Errorf("insert autopilot task: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("last insert id: %w", err)
+	}
+	task.ID = id
+	return nil
+}
+
+// BulkCreateAutopilotTasks inserts multiple autopilot tasks in a transaction.
+// Uses INSERT OR IGNORE to skip duplicates.
+func (s *Store) BulkCreateAutopilotTasks(tasks []*AutopilotTask) (int, error) {
+	if len(tasks) == 0 {
+		return 0, nil
+	}
+	tx, err := s.db.Beginx()
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	inserted := 0
+	for _, task := range tasks {
+		result, err := tx.Exec(`
+			INSERT OR IGNORE INTO autopilot_tasks (project_id, issue_number, issue_title, issue_body, dependencies, status)
+			VALUES (?, ?, ?, ?, ?, ?)
+		`, task.ProjectID, task.IssueNumber, task.IssueTitle, task.IssueBody, task.Dependencies, task.Status)
+		if err != nil {
+			return inserted, fmt.Errorf("insert autopilot task: %w", err)
+		}
+		n, _ := result.RowsAffected()
+		if n > 0 {
+			id, _ := result.LastInsertId()
+			task.ID = id
+			inserted++
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+	return inserted, nil
+}
+
+// GetAutopilotTasks returns all autopilot tasks for a project.
+func (s *Store) GetAutopilotTasks(projectID int64) ([]AutopilotTask, error) {
+	var tasks []AutopilotTask
+	if err := s.db.Select(&tasks, `
+		SELECT * FROM autopilot_tasks WHERE project_id = ? ORDER BY issue_number
+	`, projectID); err != nil {
+		return nil, fmt.Errorf("get autopilot tasks: %w", err)
+	}
+	return tasks, nil
+}
+
+// UpdateAutopilotTaskStatus updates only the status and completed_at of an autopilot task.
+func (s *Store) UpdateAutopilotTaskStatus(id int64, status string) error {
+	completedAt := ""
+	if status == "done" || status == "bailed" {
+		completedAt = "datetime('now')"
+		_, err := s.db.Exec(`
+			UPDATE autopilot_tasks SET status = ?, completed_at = datetime('now') WHERE id = ?
+		`, status, id)
+		return err
+	}
+	_ = completedAt
+	_, err := s.db.Exec(`UPDATE autopilot_tasks SET status = ? WHERE id = ?`, status, id)
+	return err
+}
+
+// UpdateAutopilotTaskRunning sets a task to running with its worktree info.
+func (s *Store) UpdateAutopilotTaskRunning(id int64, worktreePath, branch, agentLog string) error {
+	_, err := s.db.Exec(`
+		UPDATE autopilot_tasks SET status = 'running', worktree_path = ?, branch = ?, agent_log = ?, started_at = datetime('now')
+		WHERE id = ?
+	`, worktreePath, branch, agentLog, id)
+	return err
+}
+
+// UpdateAutopilotTaskPR sets the PR number for a completed task.
+func (s *Store) UpdateAutopilotTaskPR(id int64, prNumber int) error {
+	_, err := s.db.Exec(`UPDATE autopilot_tasks SET pr_number = ? WHERE id = ?`, prNumber, id)
+	return err
+}
+
+// UpdateAutopilotTaskDeps updates the dependencies JSON for a task.
+func (s *Store) UpdateAutopilotTaskDeps(id int64, deps string) error {
+	_, err := s.db.Exec(`UPDATE autopilot_tasks SET dependencies = ? WHERE id = ?`, deps, id)
+	return err
+}
+
+// QueuedUnblockedTasks returns queued tasks where all dependencies are done.
+func (s *Store) QueuedUnblockedTasks(projectID int64) ([]AutopilotTask, error) {
+	// Get all tasks for the project.
+	allTasks, err := s.GetAutopilotTasks(projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a map of issue number → status.
+	statusMap := make(map[int]string, len(allTasks))
+	for _, t := range allTasks {
+		statusMap[t.IssueNumber] = t.Status
+	}
+
+	// Build a map of tracked item number → state for external dep checks.
+	// If a dep isn't an autopilot task but IS a tracked open issue, it blocks.
+	trackedItems, _ := s.GetTrackedItems(projectID)
+	trackedState := make(map[int]string, len(trackedItems))
+	for _, item := range trackedItems {
+		trackedState[item.Number] = item.State
+	}
+
+	// Filter queued tasks where all deps are done.
+	var unblocked []AutopilotTask
+	for _, t := range allTasks {
+		if t.Status != "queued" {
+			continue
+		}
+		deps := parseDependencies(t.Dependencies)
+		allDone := true
+		for _, dep := range deps {
+			if taskStatus, ok := statusMap[dep]; ok {
+				// Dep is an autopilot task — must be done.
+				if taskStatus != "done" {
+					allDone = false
+					break
+				}
+			} else if state, ok := trackedState[dep]; ok {
+				// Dep is a tracked item but not an autopilot task (e.g., skipped via no-agent).
+				// Block unless the issue is closed/merged.
+				if state == "open" {
+					allDone = false
+					break
+				}
+			}
+			// If dep isn't tracked at all, treat as non-blocking.
+		}
+		if allDone {
+			unblocked = append(unblocked, t)
+		}
+	}
+	return unblocked, nil
+}
+
+// RunningAutopilotTasks returns all running autopilot tasks for a project.
+func (s *Store) RunningAutopilotTasks(projectID int64) ([]AutopilotTask, error) {
+	var tasks []AutopilotTask
+	if err := s.db.Select(&tasks, `
+		SELECT * FROM autopilot_tasks WHERE project_id = ? AND status = 'running' ORDER BY issue_number
+	`, projectID); err != nil {
+		return nil, fmt.Errorf("running autopilot tasks: %w", err)
+	}
+	return tasks, nil
+}
+
+// ClearAutopilotTasks removes all autopilot tasks for a project.
+func (s *Store) ClearAutopilotTasks(projectID int64) error {
+	_, err := s.db.Exec(`DELETE FROM autopilot_tasks WHERE project_id = ?`, projectID)
+	return err
+}
+
+// ResetStaleAutopilotTasks resets interrupted tasks back to "queued".
+// "running" tasks are always reset (the process is gone).
+// "bailed" tasks are only reset if completed_at is NULL (interrupted before finishing).
+// Bailed tasks WITH completed_at were legitimate failures — the agent ran and gave up.
+// Returns the number of tasks reset.
+func (s *Store) ResetStaleAutopilotTasks(projectID int64) (int, error) {
+	result, err := s.db.Exec(`
+		UPDATE autopilot_tasks
+		SET status = 'queued', worktree_path = '', branch = '', agent_log = '',
+		    started_at = NULL, completed_at = NULL
+		WHERE project_id = ? AND (
+			status = 'running'
+			OR (status = 'bailed' AND completed_at IS NULL)
+		)
+	`, projectID)
+	if err != nil {
+		return 0, fmt.Errorf("reset stale tasks: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}
+
+// parseDependencies parses a JSON array of issue numbers.
+func parseDependencies(deps string) []int {
+	if deps == "" || deps == "[]" {
+		return nil
+	}
+	// Simple parser for JSON int arrays like [42, 38].
+	deps = strings.TrimSpace(deps)
+	if len(deps) < 2 || deps[0] != '[' || deps[len(deps)-1] != ']' {
+		return nil
+	}
+	inner := deps[1 : len(deps)-1]
+	if strings.TrimSpace(inner) == "" {
+		return nil
+	}
+	parts := strings.Split(inner, ",")
+	var result []int
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(p, "%d", &n); err == nil {
+			result = append(result, n)
+		}
+	}
+	return result
 }
 
 // LastPoll returns the most recent poll for a project, or nil if none.

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -8,7 +8,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 8
+const currentVersion = 9
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -30,6 +30,12 @@ CREATE TABLE IF NOT EXISTS projects (
 	llm_analyzer_model    TEXT DEFAULT 'claude-sonnet-4-6',
 	idle_pause_sec        INTEGER DEFAULT 14400,
 	analyzer_focus        TEXT DEFAULT '',
+	autopilot_filter_type  TEXT DEFAULT '',
+	autopilot_filter_value TEXT DEFAULT '',
+	autopilot_max_agents   INTEGER DEFAULT 3,
+	autopilot_max_turns    INTEGER DEFAULT 50,
+	autopilot_max_budget_usd REAL DEFAULT 3.00,
+	autopilot_skip_label   TEXT DEFAULT 'no-agent',
 	created_at            TEXT DEFAULT (datetime('now'))
 );
 
@@ -99,6 +105,23 @@ CREATE TABLE IF NOT EXISTS tracked_items (
 	progress_summary    TEXT DEFAULT '',
 	created_at          TEXT DEFAULT (datetime('now')),
 	UNIQUE(project_id, source, owner, repo, number)
+);
+
+CREATE TABLE IF NOT EXISTS autopilot_tasks (
+	id             INTEGER PRIMARY KEY,
+	project_id     INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+	issue_number   INTEGER NOT NULL,
+	issue_title    TEXT NOT NULL DEFAULT '',
+	issue_body     TEXT NOT NULL DEFAULT '',
+	dependencies   TEXT DEFAULT '[]',
+	status         TEXT NOT NULL DEFAULT 'queued',
+	worktree_path  TEXT DEFAULT '',
+	branch         TEXT DEFAULT '',
+	pr_number      INTEGER DEFAULT 0,
+	agent_log      TEXT DEFAULT '',
+	started_at     TEXT DEFAULT '',
+	completed_at   TEXT DEFAULT '',
+	UNIQUE(project_id, issue_number)
 );
 
 CREATE TABLE IF NOT EXISTS completed_items (
@@ -190,6 +213,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 8 {
 		if err := migrateV8(db); err != nil {
 			return fmt.Errorf("apply migration v8: %w", err)
+		}
+	}
+
+	if version < 9 {
+		if err := migrateV9(db); err != nil {
+			return fmt.Errorf("apply migration v9: %w", err)
 		}
 	}
 
@@ -329,6 +358,53 @@ func migrateV8(db *sqlx.DB) error {
 	}
 	if _, err := db.Exec(`UPDATE projects SET analyzer_focus = '' WHERE analyzer_focus IS NULL`); err != nil {
 		return fmt.Errorf("null-fill analyzer_focus: %w", err)
+	}
+	return nil
+}
+
+func migrateV9(db *sqlx.DB) error {
+	// Create autopilot_tasks table.
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS autopilot_tasks (
+			id             INTEGER PRIMARY KEY,
+			project_id     INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			issue_number   INTEGER NOT NULL,
+			issue_title    TEXT NOT NULL DEFAULT '',
+			issue_body     TEXT NOT NULL DEFAULT '',
+			dependencies   TEXT DEFAULT '[]',
+			status         TEXT NOT NULL DEFAULT 'queued',
+			worktree_path  TEXT DEFAULT '',
+			branch         TEXT DEFAULT '',
+			pr_number      INTEGER DEFAULT 0,
+			agent_log      TEXT DEFAULT '',
+			started_at     TEXT DEFAULT '',
+			completed_at   TEXT DEFAULT '',
+			UNIQUE(project_id, issue_number)
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create autopilot_tasks table: %w", err)
+	}
+
+	// Add autopilot columns to projects.
+	stmts := []string{
+		`ALTER TABLE projects ADD COLUMN autopilot_filter_type TEXT DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN autopilot_filter_value TEXT DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN autopilot_max_agents INTEGER DEFAULT 3`,
+		`ALTER TABLE projects ADD COLUMN autopilot_max_turns INTEGER DEFAULT 50`,
+		`ALTER TABLE projects ADD COLUMN autopilot_max_budget_usd REAL DEFAULT 3.00`,
+		`ALTER TABLE projects ADD COLUMN autopilot_skip_label TEXT DEFAULT 'no-agent'`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("%s: %w", stmt, err)
+		}
+	}
+	// Null-fill new text columns.
+	for _, col := range []string{"autopilot_filter_type", "autopilot_filter_value", "autopilot_skip_label"} {
+		if _, err := db.Exec(fmt.Sprintf(`UPDATE projects SET %s = '' WHERE %s IS NULL`, col, col)); err != nil {
+			return fmt.Errorf("null-fill %s: %w", col, err)
+		}
 	}
 	return nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -238,6 +238,37 @@ func DiffStat(dir, spec string) (string, error) {
 	return run(dir, "diff", "--stat", spec)
 }
 
+// WorktreeAdd creates a new git worktree at the given path on a new branch.
+func WorktreeAdd(repoDir, worktreePath, branch string) error {
+	_, err := run(repoDir, "worktree", "add", worktreePath, "-b", branch)
+	return err
+}
+
+// WorktreeRemove removes a git worktree.
+func WorktreeRemove(repoDir, worktreePath string) error {
+	_, err := run(repoDir, "worktree", "remove", "--force", worktreePath)
+	return err
+}
+
+// DeleteBranch deletes a local branch.
+func DeleteBranch(repoDir, branch string) error {
+	_, err := run(repoDir, "branch", "-D", branch)
+	return err
+}
+
+// DefaultBranch returns the default branch name (main, master, etc.).
+func DefaultBranch(dir string) (string, error) {
+	out, err := run(dir, "symbolic-ref", "refs/remotes/origin/HEAD")
+	if err == nil {
+		// Returns something like "refs/remotes/origin/main".
+		parts := strings.Split(out, "/")
+		if len(parts) > 0 {
+			return parts[len(parts)-1], nil
+		}
+	}
+	return "main", nil
+}
+
 // CommitsSince returns the number of commits since a given ref.
 func CommitsSince(dir, ref string) (int, error) {
 	out, err := run(dir, "rev-list", "--count", ref+"..HEAD")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -140,3 +140,66 @@ func TestWorktrees(t *testing.T) {
 		t.Error("first worktree should be marked as main")
 	}
 }
+
+func TestWorktreeAddRemove(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// Add a worktree.
+	wtPath := filepath.Join(t.TempDir(), "wt-test")
+	if err := WorktreeAdd(dir, wtPath, "test-branch"); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+
+	// Verify worktree exists.
+	worktrees, err := Worktrees(dir)
+	if err != nil {
+		t.Fatalf("Worktrees: %v", err)
+	}
+	if len(worktrees) != 2 {
+		t.Fatalf("expected 2 worktrees, got %d", len(worktrees))
+	}
+
+	// Find the new worktree.
+	found := false
+	for _, wt := range worktrees {
+		if wt.Branch == "test-branch" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("new worktree with branch 'test-branch' not found")
+	}
+
+	// Remove worktree.
+	if err := WorktreeRemove(dir, wtPath); err != nil {
+		t.Fatalf("WorktreeRemove: %v", err)
+	}
+
+	// Verify worktree is gone.
+	worktrees, err = Worktrees(dir)
+	if err != nil {
+		t.Fatalf("Worktrees after remove: %v", err)
+	}
+	if len(worktrees) != 1 {
+		t.Fatalf("expected 1 worktree after remove, got %d", len(worktrees))
+	}
+
+	// Delete branch.
+	if err := DeleteBranch(dir, "test-branch"); err != nil {
+		t.Fatalf("DeleteBranch: %v", err)
+	}
+}
+
+func TestDefaultBranch(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// Without origin, should fall back to "main".
+	branch, err := DefaultBranch(dir)
+	if err != nil {
+		t.Fatalf("DefaultBranch: %v", err)
+	}
+	if branch != "main" {
+		t.Errorf("DefaultBranch = %q, want 'main'", branch)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -35,6 +35,8 @@ func (s *ItemStatus) CompactStatus() string {
 		return "Appvd"
 	case s.ReviewState == "changes_requested":
 		return "ChReq"
+	case hasLabel(s.Labels, "needs-review"), hasLabel(s.Labels, "needs review"):
+		return "Revew"
 	case hasLabel(s.Labels, "in progress"), hasLabel(s.Labels, "in-progress"), hasLabel(s.Labels, "wip"):
 		return "InProg"
 	default:
@@ -287,6 +289,17 @@ func (c *Client) ListLabels(ctx context.Context, owner, repo string) ([]RepoChoi
 		opts.Page = resp.NextPage
 	}
 	return all, nil
+}
+
+// AddLabel adds a label to an issue/PR. Creates the label if it doesn't exist.
+func (c *Client) AddLabel(ctx context.Context, owner, repo string, number int, label string) error {
+	_, _, err := c.gh.Issues.AddLabelsToIssue(ctx, owner, repo, number, []string{label})
+	return err
+}
+
+// RemoveLabel removes a label from an issue/PR. Ignores errors if label isn't present.
+func (c *Client) RemoveLabel(ctx context.Context, owner, repo string, number int, label string) {
+	c.gh.Issues.RemoveLabelForIssue(ctx, owner, repo, number, label)
 }
 
 // ListMilestones returns open milestones for a repo.

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -143,6 +143,8 @@ type Poller struct {
 	cancel          context.CancelFunc
 	stopped         chan struct{}
 	intervalChanged chan time.Duration // signals run loop to reset ticker
+
+	autopilotStatus func() string // optional callback for autopilot status injection
 }
 
 // New creates a new Poller. Publisher may be nil if bus publishing is not available.
@@ -165,6 +167,19 @@ func (p *Poller) Events() <-chan Event {
 // Project returns the poller's project.
 func (p *Poller) Project() *db.Project {
 	return p.project
+}
+
+// Provider returns the poller's LLM provider.
+func (p *Poller) Provider() llm.Provider {
+	return p.provider
+}
+
+// SetAutopilotStatusFunc sets a callback that returns autopilot status text
+// for injection into the tier 2 analyzer prompt.
+func (p *Poller) SetAutopilotStatusFunc(fn func() string) {
+	p.mu.Lock()
+	p.autopilotStatus = fn
+	p.mu.Unlock()
 }
 
 // SetRefreshInterval updates the poll interval at runtime.
@@ -1092,6 +1107,17 @@ func (p *Poller) buildTier2Prompt(gitSummary, busSummary, trackedChanges, prStat
 			}
 		}
 		b.WriteString("\n")
+	}
+
+	// Autopilot status injection (mechanical, from supervisor callback).
+	p.mu.Lock()
+	autopilotFn := p.autopilotStatus
+	p.mu.Unlock()
+	if autopilotFn != nil {
+		if statusBlock := autopilotFn(); statusBlock != "" {
+			b.WriteString(statusBlock)
+			b.WriteString("\n")
+		}
 	}
 
 	b.WriteString("## Active Concerns\n")

--- a/internal/poller/sweep.go
+++ b/internal/poller/sweep.go
@@ -213,14 +213,6 @@ func (p *Poller) sweepTrackedItems(ctx context.Context, items []db.TrackedItem, 
 		}
 	}
 
-	// Auto-prune oldest terminal items when the list is full (archives before deleting).
-	pruned, err := p.store.PruneTrackedItems(p.project.ID, 10, 2)
-	if err != nil {
-		p.emit("error", fmt.Sprintf("pruning tracked items: %v", err), nil)
-	} else if pruned > 0 {
-		p.emit("tracked", fmt.Sprintf("Archived and pruned %d resolved tracked items", pruned), nil)
-	}
-
 	// Prune old completed items beyond the TTL (default 14 days).
 	ttl := p.project.MessageTTLSec
 	if ttl <= 0 {

--- a/internal/poller/tracked.go
+++ b/internal/poller/tracked.go
@@ -122,22 +122,15 @@ func (p *Poller) ClearAndBulkAddTrackedItems(ctx context.Context, items []ghpkg.
 	return p.BulkAddTrackedItems(ctx, items, owner, repo)
 }
 
-// UpdateTrackedItems removes terminal (closed/merged/not-planned) items and adds new ones.
-// Returns (added, removed, error).
+// UpdateTrackedItems adds new items to the tracked list (skips duplicates).
+// Returns (added, 0, error). Terminal items are kept for analyzer context;
+// use the TUI cleanup action (c) to archive them manually.
 func (p *Poller) UpdateTrackedItems(ctx context.Context, items []ghpkg.ItemStatus, owner, repo string) (int, int, error) {
-	removed, err := p.store.ArchiveTerminalTrackedItems(p.project.ID)
-	if err != nil {
-		return 0, 0, fmt.Errorf("archive+remove terminal items: %w", err)
-	}
-	if removed > 0 {
-		p.emit("tracked", fmt.Sprintf("Archived and removed %d closed/merged items", removed), nil)
-	}
-
 	added, err := p.BulkAddTrackedItems(ctx, items, owner, repo)
 	if err != nil {
-		return 0, removed, err
+		return 0, 0, err
 	}
-	return added, removed, nil
+	return added, 0, nil
 }
 
 // DefaultOwnerRepo derives a default owner/repo from the project's enrolled repos.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -13,6 +13,8 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
+	"github.com/dustinlange/agent-minder/internal/autopilot"
+	"github.com/dustinlange/agent-minder/internal/config"
 	"github.com/dustinlange/agent-minder/internal/db"
 	ghpkg "github.com/dustinlange/agent-minder/internal/github"
 	"github.com/dustinlange/agent-minder/internal/poller"
@@ -98,6 +100,20 @@ type trackFetchResultMsg struct {
 // clearTrackStatusMsg clears the track status after a delay.
 type clearTrackStatusMsg struct{}
 
+// autopilotPrepareResultMsg is sent when autopilot issue fetch completes.
+type autopilotPrepareResultMsg struct {
+	total     int
+	unblocked int
+	err       error
+}
+
+// autopilotEventMsg wraps an autopilot supervisor event.
+type autopilotEventMsg autopilot.Event
+
+// clearAutopilotStatusMsg clears a temporary autopilot status message.
+type clearAutopilotStatusMsg struct{}
+
+
 // idleCheckMsg triggers periodic idle timeout checking.
 type idleCheckMsg time.Time
 
@@ -162,6 +178,14 @@ type Model struct {
 	// Filter mode (bulk add tracked items).
 	filterState  *filterState
 	filterStatus string
+
+	// Autopilot.
+	autopilotSupervisor *autopilot.Supervisor
+	autopilotMode       string // "", "confirm", "running", "stop-confirm"
+	autopilotStatus     string
+	autopilotTotal      int
+	autopilotUnblocked  int
+	origPollInterval    time.Duration // saved to restore after autopilot stops
 
 	// Auto-pause on idle.
 	lastUserInput time.Time
@@ -450,6 +474,58 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		return m, nil
 
+	case autopilotPrepareResultMsg:
+		m.polling = false
+		if msg.err != nil {
+			m.autopilotStatus = fmt.Sprintf("Error: %v", msg.err)
+			m.autopilotMode = ""
+			m.autopilotSupervisor = nil
+			return m, tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+				return clearAutopilotStatusMsg{}
+			})
+		}
+		if msg.total == 0 {
+			m.autopilotStatus = "No issues found matching filter"
+			m.autopilotMode = ""
+			m.autopilotSupervisor = nil
+			return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+				return clearAutopilotStatusMsg{}
+			})
+		}
+		m.autopilotTotal = msg.total
+		m.autopilotUnblocked = msg.unblocked
+		m.autopilotMode = "confirm"
+		m.autopilotStatus = ""
+		return m, nil
+
+	case autopilotEventMsg:
+		event := autopilot.Event(msg)
+		m.events = append(m.events, poller.Event{
+			Time:    event.Time,
+			Type:    "autopilot",
+			Summary: fmt.Sprintf("[%s] %s", event.Type, event.Summary),
+		})
+		if len(m.events) > 50 {
+			m.events = m.events[len(m.events)-50:]
+		}
+		m.rebuildEventLogContent()
+		if event.Type == "stopped" {
+			m.autopilotMode = ""
+			// Restore poll interval.
+			if m.origPollInterval > 0 {
+				m.poller.SetRefreshInterval(m.origPollInterval)
+				m.origPollInterval = 0
+			}
+			m.poller.SetAutopilotStatusFunc(nil)
+			m.autopilotSupervisor = nil
+		}
+		m.resizeViewports()
+		return m, listenForAutopilotEvents(m.autopilotSupervisor)
+
+	case clearAutopilotStatusMsg:
+		m.autopilotStatus = ""
+		return m, nil
+
 	case filterChoicesMsg:
 		if m.filterState != nil {
 			if msg.err != nil || len(msg.choices) == 0 {
@@ -555,6 +631,30 @@ type clearFilterStatusMsg struct{}
 type clearSettingsStatusMsg struct{}
 
 func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// Autopilot confirm mode intercepts y/n/esc.
+	if m.autopilotMode == "confirm" {
+		switch msg.String() {
+		case "y":
+			return m.confirmAutopilot()
+		case "n", "esc":
+			m.autopilotMode = ""
+			m.autopilotSupervisor = nil
+			m.autopilotStatus = ""
+			return m, nil
+		}
+		return m, nil
+	}
+	if m.autopilotMode == "stop-confirm" {
+		switch msg.String() {
+		case "y":
+			return m.confirmStopAutopilot()
+		case "n", "esc":
+			m.autopilotMode = "running"
+			return m, nil
+		}
+		return m, nil
+	}
+
 	switch msg.String() {
 	case "?":
 		m.showHelp = !m.showHelp
@@ -654,7 +754,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if pollMinutes < 1 {
 			pollMinutes = 1
 		}
-		m.settingsState = newSettingsState(pollMinutes, m.project.AnalyzerFocus)
+		m.settingsState = newSettingsState(pollMinutes, m.project.AnalyzerFocus, m.project)
 		// Apply textarea theme to match current theme.
 		var s textarea.Styles
 		if currentTheme().Name == "light" {
@@ -707,6 +807,10 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		cmd := m.onboardInput.Focus()
 		return m, cmd
+	case "a":
+		return m.startAutopilot()
+	case "A":
+		return m.stopAutopilot()
 	case "up", "down", "pgup", "pgdown":
 		var cmd tea.Cmd
 		m.eventLogVP, cmd = m.eventLogVP.Update(msg)
@@ -1169,6 +1273,132 @@ func idleCheckTick() tea.Cmd {
 	return func() tea.Msg {
 		time.Sleep(60 * time.Second)
 		return idleCheckMsg(time.Now())
+	}
+}
+
+// startAutopilot begins the autopilot flow: fetch issues and show confirmation.
+func (m Model) startAutopilot() (tea.Model, tea.Cmd) {
+	if m.autopilotMode == "running" {
+		m.autopilotStatus = "Autopilot already running — press A to stop"
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearAutopilotStatusMsg{}
+		})
+	}
+
+	// Check prerequisites: need tracked issues.
+	trackedItems, _ := m.store.GetTrackedItems(m.project.ID)
+	hasOpenIssue := false
+	for _, item := range trackedItems {
+		if item.ItemType == "issue" && item.State == "open" {
+			hasOpenIssue = true
+			break
+		}
+	}
+	if !hasOpenIssue {
+		m.autopilotStatus = "No open issues tracked — use 'i' or 'f' to track issues first"
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearAutopilotStatusMsg{}
+		})
+	}
+
+	ghRepos := m.poller.GitHubRepos()
+	if len(ghRepos) == 0 {
+		m.autopilotStatus = "No GitHub repos enrolled"
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearAutopilotStatusMsg{}
+		})
+	}
+
+	// Get repo info for supervisor.
+	repos, _ := m.store.GetRepos(m.project.ID)
+	if len(repos) == 0 {
+		m.autopilotStatus = "No repos enrolled"
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearAutopilotStatusMsg{}
+		})
+	}
+
+	ghToken := config.GetIntegrationToken("github")
+	if ghToken == "" {
+		m.autopilotStatus = "GitHub token required (GITHUB_TOKEN, GH_TOKEN, or keychain)"
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearAutopilotStatusMsg{}
+		})
+	}
+
+	sup := autopilot.New(
+		m.store, m.project, m.poller.Provider(),
+		repos[0].Path,
+		ghRepos[0].Owner, ghRepos[0].Repo,
+		ghToken,
+	)
+	m.autopilotSupervisor = sup
+	m.autopilotStatus = "Fetching issues..."
+	m.polling = true
+
+	return m, tea.Batch(m.spinner.Tick, func() tea.Msg {
+		total, unblocked, err := sup.Prepare(context.Background())
+		return autopilotPrepareResultMsg{total: total, unblocked: unblocked, err: err}
+	})
+}
+
+// confirmAutopilot launches the autopilot after user confirms.
+func (m Model) confirmAutopilot() (tea.Model, tea.Cmd) {
+	sup := m.autopilotSupervisor
+	if sup == nil {
+		m.autopilotMode = ""
+		return m, nil
+	}
+
+	m.autopilotMode = "running"
+
+	// Wire autopilot status into poller.
+	m.poller.SetAutopilotStatusFunc(sup.StatusBlock)
+
+	// Bump poll frequency.
+	m.origPollInterval = m.project.RefreshInterval()
+	newInterval := m.origPollInterval / 2
+	if newInterval < 30*time.Second {
+		newInterval = 30 * time.Second
+	}
+	m.poller.SetRefreshInterval(newInterval)
+
+	sup.Launch(context.Background())
+
+	return m, tea.Batch(
+		listenForAutopilotEvents(sup),
+	)
+}
+
+// stopAutopilot stops the running autopilot.
+func (m Model) stopAutopilot() (tea.Model, tea.Cmd) {
+	if m.autopilotMode != "running" || m.autopilotSupervisor == nil {
+		return m, nil
+	}
+	m.autopilotMode = "stop-confirm"
+	return m, nil
+}
+
+func (m Model) confirmStopAutopilot() (tea.Model, tea.Cmd) {
+	m.autopilotMode = "running"
+	sup := m.autopilotSupervisor
+	return m, func() tea.Msg {
+		sup.Stop()
+		return nil
+	}
+}
+
+// listenForAutopilotEvents returns a command that waits for the next autopilot event.
+func listenForAutopilotEvents(sup *autopilot.Supervisor) tea.Cmd {
+	if sup == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		event, ok := <-sup.Events()
+		if !ok {
+			return nil
+		}
+		return autopilotEventMsg(event)
 	}
 }
 

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -50,6 +50,15 @@ func (m Model) View() tea.View {
 		}
 	}
 
+	// Autopilot slot status (when running).
+	if m.autopilotMode == "running" && m.autopilotSupervisor != nil {
+		ap := m.renderAutopilotSlots()
+		if ap != "" {
+			b.WriteString(ap)
+			b.WriteString("\n")
+		}
+	}
+
 	// Main content area: modal modes replace analysis+event log.
 	if m.mode == "settings" {
 		b.WriteString(m.renderSettingsView())
@@ -517,6 +526,14 @@ func (m Model) computeHeightBudget() (analysisH, eventLogH int) {
 		}
 	}
 
+	if m.autopilotMode == "running" && m.autopilotSupervisor != nil {
+		apContent := m.renderAutopilotSlots()
+		if apContent != "" {
+			fixed += strings.Count(apContent, "\n")
+			fixed += 1 // blank line after autopilot slots
+		}
+	}
+
 	fixed += 1 // analysis header
 	fixed += 1 // event log header
 	fixed += 3 // blank lines (after analysis VP, after event log VP, before bottom bar)
@@ -725,6 +742,22 @@ func (m Model) renderBottomBar() string {
 		}
 		b.WriteString("\n\n")
 	default:
+		if m.autopilotMode == "confirm" {
+			b.WriteString(headerStyle().Render(
+				fmt.Sprintf("  %d issues found, %d unblocked. Launch %d agents? (y/n)",
+					m.autopilotTotal, m.autopilotUnblocked, m.project.AutopilotMaxAgents)))
+			b.WriteString("\n")
+			b.WriteString(helpStyle().Render("y: launch • n: cancel"))
+			b.WriteString("\n")
+		} else if m.autopilotMode == "stop-confirm" {
+			b.WriteString(concernDangerStyle().Render("  Stop all running agents? (y/n)"))
+			b.WriteString("\n")
+			b.WriteString(helpStyle().Render("y: stop • n: cancel"))
+			b.WriteString("\n")
+		} else if m.autopilotStatus != "" {
+			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.autopilotStatus)))
+			b.WriteString("\n")
+		}
 		if m.broadcastStatus != "" {
 			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.broadcastStatus)))
 			b.WriteString("\n")
@@ -798,6 +831,8 @@ func allHelpHints() []struct{ key, desc string } {
 		{"u", "post user message"},
 		{"m", "broadcast to agents"},
 		{"o", "generate onboarding"},
+		{"a", "launch autopilot"},
+		{"A", "stop autopilot"},
 		{"d", "toggle repo/topic details"},
 		{"t", "cycle theme"},
 		{"\u2191/\u2193", "scroll event log"},
@@ -827,6 +862,38 @@ func renderHelpOverlay(width int) string {
 	return b.String()
 }
 
+// renderAutopilotSlots returns a display of autopilot agent slot status.
+func (m Model) renderAutopilotSlots() string {
+	if m.autopilotSupervisor == nil {
+		return ""
+	}
+
+	slots := m.autopilotSupervisor.SlotStatus()
+	var b strings.Builder
+	b.WriteString(headerStyle().Render("Autopilot Agents"))
+	b.WriteString("  ")
+	b.WriteString(mutedStyle().Render("[A: stop]"))
+	b.WriteString("\n")
+
+	for _, slot := range slots {
+		if slot.Status == "idle" {
+			b.WriteString(mutedStyle().Render(fmt.Sprintf("  Slot %d: idle", slot.SlotNum)))
+		} else {
+			elapsed := slot.RunningFor.Round(time.Second)
+			title := slot.IssueTitle
+			if len(title) > 40 {
+				title = title[:37] + "..."
+			}
+			b.WriteString(statusRunningStyle().Render(fmt.Sprintf("  Slot %d: #%d %s (%s)",
+				slot.SlotNum, slot.IssueNumber, title, elapsed)))
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// renderAgentLogPreview shows the last N lines of the active agent's log.
 // truncateLine truncates a string to maxWidth characters, adding "..." if truncated.
 func truncateLine(s string, maxWidth int) string {
 	if maxWidth <= 0 {

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
+	"github.com/dustinlange/agent-minder/internal/db"
 	"github.com/dustinlange/agent-minder/internal/poller"
 )
 
@@ -46,7 +47,7 @@ type settingsSavedMsg struct {
 }
 
 // newSettingsState initializes the settings dialog.
-func newSettingsState(pollMinutes int, analyzerFocus string) *settingsState {
+func newSettingsState(pollMinutes int, analyzerFocus string, project *db.Project) *settingsState {
 	ti := textinput.New()
 	ti.Placeholder = "value..."
 	ti.CharLimit = 10
@@ -84,6 +85,27 @@ func newSettingsState(pollMinutes int, analyzerFocus string) *settingsState {
 				description: "Custom instructions for the analyzer's perspective and communication style",
 				value:       displayFocus,
 				multiline:   true,
+			},
+			{
+				label:       "Autopilot max agents",
+				description: "Maximum concurrent agents",
+				value:       strconv.Itoa(project.AutopilotMaxAgents),
+			},
+			{
+				label:       "Autopilot max turns",
+				description: "Max turns per agent",
+				value:       strconv.Itoa(project.AutopilotMaxTurns),
+			},
+			{
+				label:       "Autopilot max budget",
+				description: "Max USD budget per agent",
+				value:       fmt.Sprintf("%.2f", project.AutopilotMaxBudgetUSD),
+				unit:        "USD",
+			},
+			{
+				label:       "Autopilot skip label",
+				description: "Issues with this label are excluded",
+				value:       project.AutopilotSkipLabel,
 			},
 		},
 	}
@@ -188,6 +210,33 @@ func (m Model) updateSettingsEditValue(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 				}
 				return settingsSavedMsg{field: "Poll interval", err: err}
 			}
+		case "Autopilot max agents":
+			n, err := strconv.Atoi(raw)
+			if err != nil || n < 1 || n > 10 {
+				ss.err = "Enter a number 1-10"
+				return m, nil
+			}
+			m.project.AutopilotMaxAgents = n
+			return m.saveSettingsField(ss, field.label, raw)
+		case "Autopilot max turns":
+			n, err := strconv.Atoi(raw)
+			if err != nil || n < 1 {
+				ss.err = "Enter a positive number"
+				return m, nil
+			}
+			m.project.AutopilotMaxTurns = n
+			return m.saveSettingsField(ss, field.label, raw)
+		case "Autopilot max budget":
+			f, err := strconv.ParseFloat(raw, 64)
+			if err != nil || f <= 0 {
+				ss.err = "Enter a positive number"
+				return m, nil
+			}
+			m.project.AutopilotMaxBudgetUSD = f
+			return m.saveSettingsField(ss, field.label, fmt.Sprintf("%.2f", f))
+		case "Autopilot skip label":
+			m.project.AutopilotSkipLabel = strings.TrimSpace(raw)
+			return m.saveSettingsField(ss, field.label, strings.TrimSpace(raw))
 		}
 
 		return m, nil
@@ -240,6 +289,19 @@ func (m Model) updateSettingsEditTextarea(msg tea.KeyPressMsg) (tea.Model, tea.C
 	var cmd tea.Cmd
 	ss.textarea, cmd = ss.textarea.Update(msg)
 	return m, cmd
+}
+
+// saveSettingsField is a common helper for saving a simple text/numeric setting.
+func (m Model) saveSettingsField(ss *settingsState, label, displayValue string) (tea.Model, tea.Cmd) {
+	ss.fields[ss.fieldIdx].value = displayValue
+	ss.input.Blur()
+	ss.step = settingsStepSelectField
+	ss.err = ""
+
+	return m, func() tea.Msg {
+		err := m.store.UpdateProject(m.project)
+		return settingsSavedMsg{field: label, err: err}
+	}
 }
 
 // renderSettingsView renders the settings dialog.

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -136,10 +136,12 @@ func spinnerStyle() lipgloss.Style {
 }
 
 // statusDot returns a colored status indicator for tracked items.
-// Colors: Open=cyan, InProgress=amber, Closed=green, Blocked=red, Merged=green.
+// Colors: Open=cyan, InProgress=amber, Closed=green, Blocked=red, Merged=green, Review=magenta.
 func statusDot(status string) string {
 	t := currentTheme()
 	switch status {
+	case "Revew":
+		return lipgloss.NewStyle().Foreground(t.Primary).Render("\u25cf")
 	case "InProg":
 		return lipgloss.NewStyle().Foreground(t.Warning).Render("\u25cf")
 	case "Blckd":


### PR DESCRIPTION
## Summary

- Adds autopilot supervisor (`internal/autopilot/`) that dispatches up to N concurrent Claude Code agents to work on tracked GitHub issues in isolated git worktrees
- Agents self-triage: complete the work and open a draft PR, or bail with detailed context
- Dependency graph extracted via one LLM call; external deps cross-referenced against tracked items
- Dynamic task discovery (60s) picks up new tracked items during autopilot
- Review gate: tasks stay in `review` until PR is merged, then promote to `done`
- Label management: `in-progress` → `needs-review` → removed on merge; `no-agent` skip label
- Stop confirmation dialog (`A` key)
- DB schema v9: `autopilot_tasks` table + project autopilot settings columns
- Git worktree add/remove helpers with stale branch cleanup
- TUI: `a` to launch, `A` to stop, slot status display, settings integration
- Updated CLAUDE.md, README.md, and design doc to reflect implementation
- Added CODEOWNERS (`@dmays-newb`)

## Test plan

- [x] `go test ./...` passes
- [x] Schema v9 migration applies cleanly on fresh DB and upgrade from v8
- [x] `a` in TUI fetches tracked issues, shows confirmation with counts
- [x] Agents launch in worktrees, open draft PRs or bail with comments
- [x] Dependency blocking works (internal tasks + external tracked items)
- [x] Dynamic discovery picks up newly tracked items
- [x] `A` shows stop confirmation, `y` stops agents cleanly
- [x] Labels managed correctly through lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)