### PR TITLE
Replace --dangerously-skip-permissions with least-privilege agent permissions

### DIFF
--- a/docs/automated-agents-design.md
+++ b/docs/automated-agents-design.md
@@ -141,9 +141,16 @@ The graph is computed once at `Prepare()` time. Fallback if LLM fails: sequentia
 claude -p \
   --max-turns 50 \
   --max-budget-usd 3.00 \
-  --dangerously-skip-permissions \
+  --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*),..." \
   "<templated prompt>"
 ```
+
+The `--allowedTools` flag pre-approves specific tools without granting unrestricted system access.
+Claude Code scopes file operations (Read, Write, Edit) to the working directory (the worktree),
+so agents can only access files within their assigned worktree. Bash commands are restricted to
+common development tools via prefix-match patterns (see `permissions.go` for the full list).
+
+Projects can extend the allowed tools via `.claude/settings.json` in their repo.
 
 Environment: `GITHUB_TOKEN` is set for `gh` CLI access.
 

--- a/internal/autopilot/permissions.go
+++ b/internal/autopilot/permissions.go
@@ -1,0 +1,61 @@
+package autopilot
+
+import "strings"
+
+// defaultAllowedTools defines the tools pre-approved for autopilot agents.
+//
+// This replaces --dangerously-skip-permissions with a least-privilege approach.
+// Claude Code scopes file operations (Read, Write, Edit) to the working directory,
+// so agents can only access files within their assigned worktree. Bash commands
+// are restricted to common development tools via prefix-match patterns.
+//
+// Projects can extend this list via .claude/settings.json in their repo.
+var defaultAllowedTools = []string{
+	// Core file operations (scoped to worktree by Claude Code)
+	"Read", "Write", "Edit", "Glob", "Grep",
+	// Web access
+	"WebFetch", "WebSearch",
+	// Version control
+	"Bash(git:*)", "Bash(gh:*)",
+	// Go
+	"Bash(go:*)", "Bash(golangci-lint:*)", "Bash(gofmt:*)", "Bash(goimports:*)",
+	// Make
+	"Bash(make:*)",
+	// Node.js ecosystem
+	"Bash(npm:*)", "Bash(npx:*)", "Bash(yarn:*)", "Bash(pnpm:*)",
+	"Bash(bun:*)", "Bash(node:*)", "Bash(deno:*)", "Bash(tsc:*)",
+	// Python
+	"Bash(python:*)", "Bash(python3:*)", "Bash(pip:*)", "Bash(pip3:*)",
+	"Bash(pytest:*)", "Bash(uv:*)",
+	// Rust
+	"Bash(cargo:*)", "Bash(rustc:*)",
+	// Java/JVM
+	"Bash(mvn:*)", "Bash(gradle:*)", "Bash(java:*)", "Bash(javac:*)",
+	// .NET
+	"Bash(dotnet:*)",
+	// Ruby
+	"Bash(bundle:*)", "Bash(rake:*)", "Bash(ruby:*)", "Bash(gem:*)",
+	// Swift
+	"Bash(swift:*)", "Bash(swiftc:*)",
+	// Linters/formatters
+	"Bash(eslint:*)", "Bash(prettier:*)", "Bash(black:*)", "Bash(ruff:*)",
+	// Docker
+	"Bash(docker:*)", "Bash(docker-compose:*)",
+	// Shell utilities
+	"Bash(ls:*)", "Bash(cat:*)", "Bash(mkdir:*)", "Bash(cp:*)", "Bash(mv:*)",
+	"Bash(rm:*)", "Bash(chmod:*)", "Bash(echo:*)", "Bash(printf:*)",
+	"Bash(grep:*)", "Bash(find:*)", "Bash(fd:*)", "Bash(rg:*)",
+	"Bash(head:*)", "Bash(tail:*)", "Bash(wc:*)", "Bash(sort:*)",
+	"Bash(sed:*)", "Bash(awk:*)", "Bash(diff:*)", "Bash(which:*)",
+	"Bash(pwd:*)", "Bash(env:*)", "Bash(cd:*)", "Bash(touch:*)",
+	"Bash(test:*)", "Bash([:*)", "Bash(tee:*)", "Bash(tr:*)",
+	"Bash(cut:*)", "Bash(xargs:*)", "Bash(true:*)", "Bash(false:*)",
+	"Bash(export:*)", "Bash(date:*)", "Bash(uname:*)",
+	"Bash(curl:*)", "Bash(wget:*)",
+	"Bash(tar:*)", "Bash(unzip:*)", "Bash(gzip:*)",
+}
+
+// allowedToolsArg returns the --allowedTools argument value for the claude CLI.
+func allowedToolsArg() string {
+	return strings.Join(defaultAllowedTools, ",")
+}

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -713,7 +713,7 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 		"-p",
 		"--max-turns", strconv.Itoa(maxTurns),
 		"--max-budget-usd", fmt.Sprintf("%.2f", maxBudget),
-		"--dangerously-skip-permissions",
+		"--allowedTools", allowedToolsArg(),
 		prompt,
 	)
 	cmd.Dir = task.WorktreePath


### PR DESCRIPTION
## Summary

- Replaces `--dangerously-skip-permissions` with `--allowedTools` flag for autopilot agents
- Adds `permissions.go` with a curated whitelist of development tools (file ops, git/gh, build tools, shell utilities)
- Claude Code scopes file operations to the working directory (worktree), so agents can only access files within their assignment
- Projects can extend allowed tools via `.claude/settings.json` in their repo

Fixes #66

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/autopilot/...` passes
- [x] All other tests pass (one pre-existing failure in `internal/config` unrelated to this change)
- [ ] Manual test: run autopilot and verify agents can complete tasks with the new permission model
- [ ] Verify agents cannot access files outside their worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)