### PR TITLE
Remove in-progress label when agent bails

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -742,13 +742,18 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 	status := s.inspectOutcome(ctx, task, exitCode)
 	s.store.UpdateAutopilotTaskStatus(task.ID, status)
 
+	ghClient := ghpkg.NewClient(s.ghToken)
+
 	if status == "review" {
 		// Swap in-progress → needs-review label on the issue.
-		ghClient := ghpkg.NewClient(s.ghToken)
 		ghClient.RemoveLabel(ctx, s.owner, s.repo, task.IssueNumber, "in-progress")
 		ghClient.AddLabel(ctx, s.owner, s.repo, task.IssueNumber, "needs-review")
 		s.emitEvent("completed", fmt.Sprintf("Agent completed #%d — PR opened, awaiting review & merge", task.IssueNumber), task)
 	} else {
+		// Agent bailed — always remove in-progress as safety net.
+		// The agent may have already removed it per prompt instructions,
+		// but RemoveLabel is idempotent.
+		ghClient.RemoveLabel(ctx, s.owner, s.repo, task.IssueNumber, "in-progress")
 		s.emitEvent("bailed", fmt.Sprintf("Agent bailed on #%d (exit code %d)", task.IssueNumber, exitCode), task)
 	}
 


### PR DESCRIPTION
## Summary
- When an autopilot agent bails or fails (e.g., budget exceeded), the supervisor now removes the `in-progress` label as a safety net
- Previously only the `review` path cleaned up labels, leaving bailed issues falsely appearing as actively worked on
- `RemoveLabel` is idempotent, so this is safe even if the agent already removed it per prompt instructions before crashing

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/autopilot/...` passes
- [x] All other tests pass (pre-existing `internal/config` failure unrelated)
- [ ] Manual: trigger agent budget exceeded → verify `in-progress` label is removed

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)