### PR TITLE
Expose running agent worktree path for interactive access

### DIFF
--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dustinlange/agent-minder/internal/db"
+	"github.com/spf13/cobra"
+)
+
+var worktreeCmd = &cobra.Command{
+	Use:   "worktree <project> [issue-number]",
+	Short: "Print worktree path for running autopilot agents",
+	Long: `Print the worktree path for running autopilot agents.
+
+With an issue number, prints only that agent's worktree path (pipe-friendly):
+  cd $(agent-minder worktree myproject 42)
+
+Without an issue number, lists all running agents and their paths.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runWorktree,
+}
+
+func init() {
+	rootCmd.AddCommand(worktreeCmd)
+}
+
+func runWorktree(cmd *cobra.Command, args []string) error {
+	projectName := args[0]
+
+	conn, err := db.Open(db.DefaultDBPath())
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
+	defer conn.Close()
+	store := db.NewStore(conn)
+
+	project, err := store.GetProject(projectName)
+	if err != nil {
+		return fmt.Errorf("project %q not found — run 'agent-minder init' first", projectName)
+	}
+
+	tasks, err := store.RunningAutopilotTasks(project.ID)
+	if err != nil {
+		return fmt.Errorf("querying running tasks: %w", err)
+	}
+
+	// If an issue number is specified, print just that worktree path.
+	if len(args) == 2 {
+		var issueNum int
+		if _, err := fmt.Sscanf(args[1], "%d", &issueNum); err != nil {
+			return fmt.Errorf("invalid issue number: %s", args[1])
+		}
+
+		for _, t := range tasks {
+			if t.IssueNumber == issueNum {
+				fmt.Println(t.WorktreePath)
+				return nil
+			}
+		}
+		return fmt.Errorf("no running agent for issue #%d", issueNum)
+	}
+
+	// No issue number — list all running agents.
+	if len(tasks) == 0 {
+		fmt.Println("No running autopilot agents.")
+		return nil
+	}
+
+	for _, t := range tasks {
+		fmt.Printf("#%-6d %s\n", t.IssueNumber, t.WorktreePath)
+	}
+	return nil
+}

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -29,12 +29,14 @@ type Event struct {
 
 // SlotInfo describes the current state of an agent slot for TUI display.
 type SlotInfo struct {
-	SlotNum     int
-	IssueNumber int
-	IssueTitle  string
-	Branch      string
-	RunningFor  time.Duration
-	Status      string // "running" or "idle"
+	SlotNum      int
+	IssueNumber  int
+	IssueTitle   string
+	Branch       string
+	WorktreePath string
+	AgentLog     string
+	RunningFor   time.Duration
+	Status       string // "running" or "idle"
 }
 
 type slotState struct {
@@ -254,12 +256,14 @@ func (s *Supervisor) SlotStatus() []SlotInfo {
 			}
 		} else {
 			infos[i] = SlotInfo{
-				SlotNum:     i + 1,
-				IssueNumber: slot.task.IssueNumber,
-				IssueTitle:  slot.task.IssueTitle,
-				Branch:      slot.task.Branch,
-				RunningFor:  time.Since(slot.startedAt),
-				Status:      "running",
+				SlotNum:      i + 1,
+				IssueNumber:  slot.task.IssueNumber,
+				IssueTitle:   slot.task.IssueTitle,
+				Branch:       slot.task.Branch,
+				WorktreePath: slot.task.WorktreePath,
+				AgentLog:     slot.task.AgentLog,
+				RunningFor:   time.Since(slot.startedAt),
+				Status:       "running",
 			}
 		}
 	}

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -886,6 +886,10 @@ func (m Model) renderAutopilotSlots() string {
 			}
 			b.WriteString(statusRunningStyle().Render(fmt.Sprintf("  Slot %d: #%d %s (%s)",
 				slot.SlotNum, slot.IssueNumber, title, elapsed)))
+			if slot.WorktreePath != "" {
+				b.WriteString("\n")
+				b.WriteString(mutedStyle().Render(fmt.Sprintf("         cd %s", slot.WorktreePath)))
+			}
 		}
 		b.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary
- Adds `agent-minder worktree <project> [issue-number]` CLI subcommand to print worktree paths for running autopilot agents
- Shows worktree path in TUI autopilot slot display below each running agent
- Adds `WorktreePath` and `AgentLog` fields to `SlotInfo` struct so the data flows from supervisor to TUI

## Usage

**CLI — single agent (pipe-friendly):**
```bash
cd $(agent-minder worktree myproject 42)
```

**CLI — list all running agents:**
```bash
agent-minder worktree myproject
```

**TUI — visible under each running slot:**
```
Autopilot Agents  [A: stop]
  Slot 1: #42 Add user authentication (3m12s)
         cd ~/.agent-minder/worktrees/myproject/issue-42
  Slot 2: idle
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing config test failure unrelated)
- [ ] Manual: run autopilot, verify `agent-minder worktree <project>` lists paths
- [ ] Manual: verify TUI shows worktree paths under running slots
- [ ] Manual: verify `cd $(agent-minder worktree <project> <N>)` works

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)