### PR TITLE
Tabbed TUI with Catppuccin theme and user-initiated analysis (#94)

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -114,16 +114,16 @@ type TrackedItemChange struct {
 
 // PollResult holds the outcome of a single poll cycle.
 type PollResult struct {
-	NewCommits          int
-	NewMessages         int
-	NewWorktrees        int
-	TrackedItemChanges  []TrackedItemChange
-	Tier1Summary        string
-	Tier2Analysis       string
-	BusMessageSent      string
-	Concerns            []string
-	Duration            time.Duration
-	StatusOnly          bool // true for status-only polls (no LLM analysis)
+	NewCommits         int
+	NewMessages        int
+	NewWorktrees       int
+	TrackedItemChanges []TrackedItemChange
+	Tier1Summary       string
+	Tier2Analysis      string
+	BusMessageSent     string
+	Concerns           []string
+	Duration           time.Duration
+	StatusOnly         bool // true for status-only polls (no LLM analysis)
 }
 
 // LLMResponse returns the best available response for display.
@@ -142,12 +142,11 @@ type Poller struct {
 	publisher *msgbus.Publisher
 	events    chan Event
 
-	mu              sync.Mutex
-	paused          bool
-	cancel          context.CancelFunc
-	stopped         chan struct{}
-	statusIntervalChanged   chan time.Duration
-	analysisIntervalChanged chan time.Duration
+	mu                    sync.Mutex
+	paused                bool
+	cancel                context.CancelFunc
+	stopped               chan struct{}
+	statusIntervalChanged chan time.Duration
 
 	autopilotStatus func() string // optional callback for autopilot status injection
 }
@@ -155,13 +154,12 @@ type Poller struct {
 // New creates a new Poller. Publisher may be nil if bus publishing is not available.
 func New(store *db.Store, project *db.Project, provider llm.Provider, publisher *msgbus.Publisher) *Poller {
 	return &Poller{
-		store:                   store,
-		project:                 project,
-		provider:                provider,
-		publisher:               publisher,
-		events:                  make(chan Event, 64),
-		statusIntervalChanged:   make(chan time.Duration, 1),
-		analysisIntervalChanged: make(chan time.Duration, 1),
+		store:                 store,
+		project:               project,
+		provider:              provider,
+		publisher:             publisher,
+		events:                make(chan Event, 64),
+		statusIntervalChanged: make(chan time.Duration, 1),
 	}
 }
 
@@ -195,17 +193,6 @@ func (p *Poller) SetStatusInterval(d time.Duration) {
 	p.mu.Unlock()
 	select {
 	case p.statusIntervalChanged <- d:
-	default:
-	}
-}
-
-// SetAnalysisInterval updates the analysis poll interval at runtime.
-func (p *Poller) SetAnalysisInterval(d time.Duration) {
-	p.mu.Lock()
-	p.project.AnalysisIntervalSec = int(d.Seconds())
-	p.mu.Unlock()
-	select {
-	case p.analysisIntervalChanged <- d:
 	default:
 	}
 }
@@ -516,15 +503,12 @@ func (p *Poller) PostUserMessage(ctx context.Context, message string) error {
 func (p *Poller) run(ctx context.Context) {
 	defer close(p.stopped)
 
-	// Do an initial full poll immediately.
-	p.PollNow(ctx)
+	// Initial status-only check (no LLM analysis) to avoid spending tokens on startup.
+	p.StatusNow(ctx)
 
-	// Two independent tickers: fast status checks, slow analysis.
+	// Status ticker for mechanical checks. Analysis is user-initiated only (R key).
 	statusTicker := time.NewTicker(p.project.StatusInterval())
 	defer statusTicker.Stop()
-
-	analysisTicker := time.NewTicker(p.project.AnalysisInterval())
-	defer analysisTicker.Stop()
 
 	for {
 		select {
@@ -532,18 +516,11 @@ func (p *Poller) run(ctx context.Context) {
 			return
 		case d := <-p.statusIntervalChanged:
 			statusTicker.Reset(d)
-		case d := <-p.analysisIntervalChanged:
-			analysisTicker.Reset(d)
 		case <-statusTicker.C:
 			if p.IsPaused() {
 				continue
 			}
 			p.StatusNow(ctx)
-		case <-analysisTicker.C:
-			if p.IsPaused() {
-				continue
-			}
-			p.PollNow(ctx)
 		}
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
 	"github.com/dustinlange/agent-minder/internal/autopilot"
 	"github.com/dustinlange/agent-minder/internal/config"
 	"github.com/dustinlange/agent-minder/internal/db"
@@ -79,9 +79,9 @@ type trackStep int
 
 const (
 	trackStepInput          trackStep = iota // entering issue numbers
-	trackStepFetching                       // fetching item details from GitHub
-	trackStepPreview                        // showing items for confirmation
-	trackStepCleanupConfirm                 // confirming cleanup of terminal items
+	trackStepFetching                        // fetching item details from GitHub
+	trackStepPreview                         // showing items for confirmation
+	trackStepCleanupConfirm                  // confirming cleanup of terminal items
 )
 
 // trackPreviewItem holds resolved item info for the confirmation preview.
@@ -113,9 +113,14 @@ type autopilotEventMsg autopilot.Event
 // clearAutopilotStatusMsg clears a temporary autopilot status message.
 type clearAutopilotStatusMsg struct{}
 
-
 // idleCheckMsg triggers periodic idle timeout checking.
 type idleCheckMsg time.Time
+
+// Tab constants.
+const (
+	tabOperations = 0
+	tabAnalysis   = 1
+)
 
 // Model is the root bubbletea model for the dashboard.
 type Model struct {
@@ -124,6 +129,10 @@ type Model struct {
 	poller  *poller.Poller
 	width   int
 	height  int
+
+	// Tab state.
+	activeTab      int  // tabOperations or tabAnalysis
+	analysisHasNew bool // true when new analysis arrived while on Ops tab
 
 	// State.
 	events   []poller.Event
@@ -248,12 +257,13 @@ func New(project *db.Project, store *db.Store, p *poller.Poller) Model {
 		poller:         p,
 		events:         make([]poller.Event, 0, 64),
 		mode:           "normal",
+		activeTab:      tabOperations,
 		broadcastInput: bi,
 		userMsgInput:   ta,
 		onboardInput:   oi,
-		spinner:    sp,
-		polling:    true, // initial poll starts immediately
-		analysisVP: aVP,
+		spinner:        sp,
+		polling:        true, // initial status check starts immediately
+		analysisVP:     aVP,
 		eventLogVP:     eVP,
 		lastUserInput:  time.Now(),
 	}
@@ -264,7 +274,7 @@ func New(project *db.Project, store *db.Store, p *poller.Poller) Model {
 // applyTextareaTheme sets textarea styles to match the current theme.
 func (m *Model) applyTextareaTheme() {
 	var s textarea.Styles
-	if currentTheme().Name == "light" {
+	if currentTheme().Name == "latte" {
 		s = textarea.DefaultLightStyles()
 	} else {
 		s = textarea.DefaultDarkStyles()
@@ -330,9 +340,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.BackgroundColorMsg:
 		if msg.IsDark() {
-			setThemeByName("dark")
+			setThemeByName("mocha")
 		} else {
-			setThemeByName("light")
+			setThemeByName("latte")
 		}
 		m.applyTextareaTheme()
 		m.rebuildAnalysisContent()
@@ -358,6 +368,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.polling = false
 			m.trackedItems, _ = m.store.GetTrackedItems(m.project.ID)
 			m.worktrees, _ = m.store.GetWorktreesForProject(m.project.ID)
+			// Flag new analysis if user is on Ops tab and this was an analysis result.
+			if m.activeTab == tabOperations && event.PollResult.Tier2Analysis != "" {
+				m.analysisHasNew = true
+			}
 		}
 		m.rebuildEventLogContent()
 		m.rebuildAnalysisContent()
@@ -656,6 +670,33 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg.String() {
+	case "1":
+		m.activeTab = tabOperations
+		m.resizeViewports()
+		return m, nil
+	case "2":
+		m.activeTab = tabAnalysis
+		m.analysisHasNew = false
+		m.resizeViewports()
+		return m, nil
+	case "tab":
+		if m.activeTab == tabOperations {
+			m.activeTab = tabAnalysis
+			m.analysisHasNew = false
+		} else {
+			m.activeTab = tabOperations
+		}
+		m.resizeViewports()
+		return m, nil
+	case "shift+tab":
+		if m.activeTab == tabAnalysis {
+			m.activeTab = tabOperations
+		} else {
+			m.activeTab = tabAnalysis
+			m.analysisHasNew = false
+		}
+		m.resizeViewports()
+		return m, nil
 	case "?":
 		m.showHelp = !m.showHelp
 		m.resizeViewports()
@@ -676,12 +717,18 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return nil
 		}
 	case "R":
+		m.activeTab = tabAnalysis
+		m.analysisHasNew = false
+		m.resizeViewports()
 		p := m.poller
 		return m, func() tea.Msg {
 			p.PollNow(context.Background())
 			return nil
 		}
 	case "e":
+		if m.activeTab != tabAnalysis {
+			return m, nil
+		}
 		m.analysisExpanded = !m.analysisExpanded
 		m.resizeViewports()
 		return m, nil
@@ -703,7 +750,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		cmd := m.trackRows[0].input.Focus()
 		m.resizeViewports()
 		return m, cmd
-	case "f":
+	case "b":
 		repos := m.poller.GitHubRepos()
 		if len(repos) == 0 {
 			m.trackStatus = "No GitHub repos enrolled"
@@ -741,6 +788,9 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		return m, cmd
 	case "w":
+		if m.activeTab != tabOperations {
+			return m, nil
+		}
 		m.showWorktrees = !m.showWorktrees
 		if m.showWorktrees && len(m.worktrees) == 0 {
 			m.worktrees, _ = m.store.GetWorktreesForProject(m.project.ID)
@@ -748,10 +798,16 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		return m, nil
 	case "x":
+		if m.activeTab != tabOperations {
+			return m, nil
+		}
 		m.trackedExpanded = !m.trackedExpanded
 		m.resizeViewports()
 		return m, nil
 	case "c":
+		if m.activeTab != tabAnalysis {
+			return m, nil
+		}
 		m.concernsExpanded = !m.concernsExpanded
 		m.resizeViewports()
 		return m, nil
@@ -759,7 +815,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.settingsState = newSettingsState(m.project)
 		// Apply textarea theme to match current theme.
 		var s textarea.Styles
-		if currentTheme().Name == "light" {
+		if currentTheme().Name == "latte" {
 			s = textarea.DefaultLightStyles()
 		} else {
 			s = textarea.DefaultDarkStyles()
@@ -815,7 +871,11 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.stopAutopilot()
 	case "up", "down", "pgup", "pgdown":
 		var cmd tea.Cmd
-		m.eventLogVP, cmd = m.eventLogVP.Update(msg)
+		if m.activeTab == tabAnalysis {
+			m.analysisVP, cmd = m.analysisVP.Update(msg)
+		} else {
+			m.eventLogVP, cmd = m.eventLogVP.Update(msg)
+		}
 		return m, cmd
 	}
 	return m, nil

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -27,12 +27,61 @@ func (m Model) View() tea.View {
 		b.WriteString("\n")
 	}
 
-	// Active concerns.
-	concerns := m.renderConcerns()
-	if concerns != "" {
-		b.WriteString(concerns)
+	// Tab bar.
+	b.WriteString(m.renderTabBar())
+	b.WriteString("\n")
+
+	// Tab content: modal modes overlay tab content.
+	if m.mode == "settings" {
+		b.WriteString(m.renderSettingsView())
 		b.WriteString("\n")
+	} else if m.mode == "filter" {
+		b.WriteString(m.renderFilterView())
+		b.WriteString("\n")
+	} else if (m.mode == "track" || m.mode == "untrack") && m.trackStep == trackStepPreview {
+		b.WriteString(m.renderTrackPreview())
+		b.WriteString("\n")
+	} else if m.activeTab == tabOperations {
+		b.WriteString(m.renderOperationsTab())
+	} else {
+		b.WriteString(m.renderAnalysisTab())
 	}
+
+	// Bottom bar: input or help.
+	b.WriteString(m.renderBottomBar())
+
+	v := tea.NewView(b.String())
+	v.AltScreen = true
+	return v
+}
+
+// renderTabBar renders the tab selector bar.
+func (m Model) renderTabBar() string {
+	var b strings.Builder
+	b.WriteString(" ")
+
+	opsLabel := " 1: Operations "
+	analysisLabel := " 2: Analysis "
+	if m.analysisHasNew {
+		analysisLabel = " 2: Analysis \u25cf "
+	}
+
+	if m.activeTab == tabOperations {
+		b.WriteString(tabActiveStyle().Render(opsLabel))
+		b.WriteString("  ")
+		b.WriteString(tabInactiveStyle().Render(analysisLabel))
+	} else {
+		b.WriteString(tabInactiveStyle().Render(opsLabel))
+		b.WriteString("  ")
+		b.WriteString(tabActiveStyle().Render(analysisLabel))
+	}
+
+	return b.String()
+}
+
+// renderOperationsTab renders the Operations tab content.
+func (m Model) renderOperationsTab() string {
+	var b strings.Builder
 
 	// Tracked items strip.
 	tracked := m.renderTrackedStrip()
@@ -59,54 +108,80 @@ func (m Model) View() tea.View {
 		}
 	}
 
-	// Main content area: modal modes replace analysis+event log.
-	if m.mode == "settings" {
-		b.WriteString(m.renderSettingsView())
-		b.WriteString("\n")
-	} else if m.mode == "filter" {
-		b.WriteString(m.renderFilterView())
-		b.WriteString("\n")
-	} else if (m.mode == "track" || m.mode == "untrack") && m.trackStep == trackStepPreview {
-		b.WriteString(m.renderTrackPreview())
-		b.WriteString("\n")
-	} else {
-		// Analysis section.
-		expandHint := "e: expand"
-		if m.analysisExpanded {
-			expandHint = "e: collapse"
-		}
-		b.WriteString(headerStyle().Render("Last Analysis"))
-		b.WriteString("  ")
-		b.WriteString(mutedStyle().Render(fmt.Sprintf("[%s]", expandHint)))
-		if m.lastPoll != nil {
-			b.WriteString("  ")
-			b.WriteString(mutedStyle().Render(m.lastPoll.Duration.Round(time.Millisecond).String()))
-		}
-		b.WriteString("\n")
-		b.WriteString(m.analysisVP.View())
-		b.WriteString("\n\n")
+	// Event log section.
+	b.WriteString(headerStyle().Render("Event Log"))
+	scrollHint := ""
+	if !m.eventLogVP.AtTop() || !m.eventLogVP.AtBottom() {
+		pct := m.eventLogVP.ScrollPercent()
+		scrollHint = fmt.Sprintf("  [%.0f%%]", pct*100)
+	}
+	if scrollHint != "" {
+		b.WriteString(mutedStyle().Render(scrollHint))
+	}
+	b.WriteString("\n")
+	b.WriteString(m.eventLogVP.View())
+	b.WriteString("\n")
 
-		// Event log section.
-		b.WriteString(headerStyle().Render("Event Log"))
-		scrollHint := ""
-		if !m.eventLogVP.AtTop() || !m.eventLogVP.AtBottom() {
-			pct := m.eventLogVP.ScrollPercent()
-			scrollHint = fmt.Sprintf("  [%.0f%%]", pct*100)
-		}
-		if scrollHint != "" {
-			b.WriteString(mutedStyle().Render(scrollHint))
-		}
-		b.WriteString("\n")
-		b.WriteString(m.eventLogVP.View())
+	return b.String()
+}
+
+// hasAnalysis returns true if an LLM analysis result is available.
+func (m Model) hasAnalysis() bool {
+	return m.lastPoll != nil && m.lastPoll.LLMResponse() != ""
+}
+
+// renderAnalysisTab renders the Analysis tab content.
+func (m Model) renderAnalysisTab() string {
+	var b strings.Builder
+
+	// Active concerns.
+	concerns := m.renderConcerns()
+	if concerns != "" {
+		b.WriteString(concerns)
 		b.WriteString("\n")
 	}
 
-	// Bottom bar: input or help.
-	b.WriteString(m.renderBottomBar())
+	if !m.hasAnalysis() {
+		// Prominent call-to-action when no analysis exists yet.
+		b.WriteString("\n")
+		b.WriteString(headerStyle().Render("  Press R to run analysis"))
+		b.WriteString("\n\n")
+		b.WriteString(mutedStyle().Render("  Analysis uses the LLM to review recent activity, identify"))
+		b.WriteString("\n")
+		b.WriteString(mutedStyle().Render("  concerns, and optionally publish to the message bus."))
+		b.WriteString("\n")
+		return b.String()
+	}
 
-	v := tea.NewView(b.String())
-	v.AltScreen = true
-	return v
+	// Analysis section with results.
+	expandHint := "e: expand"
+	if m.analysisExpanded {
+		expandHint = "e: collapse"
+	}
+	b.WriteString(headerStyle().Render("Last Analysis"))
+	b.WriteString("  ")
+	b.WriteString(mutedStyle().Render(fmt.Sprintf("[%s]", expandHint)))
+	b.WriteString("  ")
+	b.WriteString(mutedStyle().Render("[R: rerun]"))
+	if m.lastPoll != nil {
+		b.WriteString("  ")
+		b.WriteString(mutedStyle().Render(m.lastPoll.Duration.Round(time.Millisecond).String()))
+	}
+	b.WriteString("\n")
+	b.WriteString(m.analysisVP.View())
+	b.WriteString("\n\n")
+
+	// Poll summary.
+	if m.lastPoll != nil {
+		statusParts := fmt.Sprintf("  %d commits, %d messages", m.lastPoll.NewCommits, m.lastPoll.NewMessages)
+		if m.lastPoll.NewWorktrees > 0 {
+			statusParts += fmt.Sprintf(", %d new worktrees", m.lastPoll.NewWorktrees)
+		}
+		b.WriteString(mutedStyle().Render(statusParts))
+		b.WriteString("\n")
+	}
+
+	return b.String()
 }
 
 // renderHeader returns the compact 2-line header with inline repo/topic counts.
@@ -114,10 +189,10 @@ func (m Model) renderHeader() string {
 	var b strings.Builder
 
 	// Line 1: title + status + counts + spinner + theme.
-	status := statusRunningStyle().Render("RUNNING")
+	status := statusRunningStyle().Render("SYNCING")
 	if m.autoPaused {
 		idleDur := formatDuration(time.Since(m.lastUserInput))
-		status = statusPausedStyle().Render(fmt.Sprintf("AUTO-PAUSED (idle %s)", idleDur))
+		status = statusPausedStyle().Render(fmt.Sprintf("IDLE (paused %s)", idleDur))
 	} else if m.poller.IsPaused() {
 		status = statusPausedStyle().Render("PAUSED")
 	}
@@ -455,24 +530,20 @@ func (m *Model) rebuildEventLogContent() {
 // rebuildAnalysisContent sets the analysis viewport content from the last poll.
 func (m *Model) rebuildAnalysisContent() {
 	if m.lastPoll == nil {
-		m.analysisVP.SetContent(mutedStyle().Render("  Waiting for first poll..."))
+		m.analysisVP.SetContent(mutedStyle().Render("  No analysis yet \u2014 press R to run"))
+		return
+	}
+	response := m.lastPoll.LLMResponse()
+	if response == "" {
+		m.analysisVP.SetContent(mutedStyle().Render("  No analysis yet \u2014 press R to run"))
 		return
 	}
 	var b strings.Builder
-	statusParts := fmt.Sprintf("  %d commits, %d messages", m.lastPoll.NewCommits, m.lastPoll.NewMessages)
-	if m.lastPoll.NewWorktrees > 0 {
-		statusParts += fmt.Sprintf(", %d new worktrees", m.lastPoll.NewWorktrees)
-	}
-	b.WriteString(mutedStyle().Render(statusParts))
-	b.WriteString("\n")
 	if m.lastPoll.BusMessageSent != "" {
 		b.WriteString(broadcastStyle().Render(fmt.Sprintf("  >> Bus: %s", m.lastPoll.BusMessageSent)))
 		b.WriteString("\n")
 	}
-	response := m.lastPoll.LLMResponse()
-	if response != "" {
-		b.WriteString(llmResponseStyle().Width(m.width - 2).Render(response))
-	}
+	b.WriteString(llmResponseStyle().Width(m.width - 2).Render(response))
 	m.analysisVP.SetContent(b.String())
 }
 
@@ -491,6 +562,7 @@ func (m *Model) resizeViewports() {
 }
 
 // computeHeightBudget calculates the height for analysis and event log viewports.
+// Only the active tab's viewport gets meaningful space; the other gets a minimum.
 func (m Model) computeHeightBudget() (analysisH, eventLogH int) {
 	fixed := 2 // header (title + goal)
 	fixed += 1 // blank line after header
@@ -505,51 +577,69 @@ func (m Model) computeHeightBudget() (analysisH, eventLogH int) {
 		fixed += 1 // blank line after info
 	}
 
-	// Count actual rendered concern lines (matches renderConcerns logic).
-	concernContent := m.renderConcerns()
-	if concernContent != "" {
-		fixed += strings.Count(concernContent, "\n")
-		fixed += 1 // blank line after concerns
-	}
-
-	trackedContent := m.renderTrackedStrip()
-	if trackedContent != "" {
-		fixed += strings.Count(trackedContent, "\n")
-		fixed += 1 // blank line after tracked
-	}
-
-	if m.showWorktrees {
-		wtContent := m.renderWorktrees()
-		if wtContent != "" {
-			fixed += strings.Count(wtContent, "\n")
-			fixed += 1 // blank line after worktrees
-		}
-	}
-
-	if m.autopilotMode == "running" && m.autopilotSupervisor != nil {
-		apContent := m.renderAutopilotSlots()
-		if apContent != "" {
-			fixed += strings.Count(apContent, "\n")
-			fixed += 1 // blank line after autopilot slots
-		}
-	}
-
-	fixed += 1 // analysis header
-	fixed += 1 // event log header
-	fixed += 3 // blank lines (after analysis VP, after event log VP, before bottom bar)
+	fixed += 1 // tab bar
+	fixed += 1 // blank line after tab bar
 	fixed += m.bottomBarHeight()
 
-	remaining := m.height - fixed
-	if remaining < 6 {
-		remaining = 6
-	}
+	if m.activeTab == tabOperations {
+		// Operations tab: tracked + worktrees + autopilot + event log header + VP
+		trackedContent := m.renderTrackedStrip()
+		if trackedContent != "" {
+			fixed += strings.Count(trackedContent, "\n")
+			fixed += 1
+		}
 
-	if m.analysisExpanded {
-		analysisH = remaining * 60 / 100
-		eventLogH = remaining - analysisH
+		if m.showWorktrees {
+			wtContent := m.renderWorktrees()
+			if wtContent != "" {
+				fixed += strings.Count(wtContent, "\n")
+				fixed += 1
+			}
+		}
+
+		if m.autopilotMode == "running" && m.autopilotSupervisor != nil {
+			apContent := m.renderAutopilotSlots()
+			if apContent != "" {
+				fixed += strings.Count(apContent, "\n")
+				fixed += 1
+			}
+		}
+
+		fixed += 1 // event log header
+		fixed += 1 // trailing newline
+
+		remaining := m.height - fixed
+		if remaining < 4 {
+			remaining = 4
+		}
+		eventLogH = remaining
+		analysisH = 2 // minimal for off-screen tab
 	} else {
-		analysisH = 3
-		eventLogH = remaining - 3
+		// Analysis tab: concerns + analysis header + VP + poll summary
+		concernContent := m.renderConcerns()
+		if concernContent != "" {
+			fixed += strings.Count(concernContent, "\n")
+			fixed += 1
+		}
+
+		fixed += 1 // analysis header
+		fixed += 2 // blank lines around VP
+		fixed += 1 // poll summary line
+
+		remaining := m.height - fixed
+		if remaining < 4 {
+			remaining = 4
+		}
+
+		if m.analysisExpanded {
+			analysisH = remaining
+		} else {
+			analysisH = 5
+			if analysisH > remaining {
+				analysisH = remaining
+			}
+		}
+		eventLogH = 2 // minimal for off-screen tab
 	}
 
 	if analysisH < 2 {
@@ -592,7 +682,7 @@ func (m Model) bottomBarHeight() int {
 		return 3 // blank + help + empty
 	default:
 		if m.showHelp {
-			return 2 + len(allHelpHints()) + 2 // blank + header + hints + close hint + blank
+			return 2 + helpOverlayHeight() + 2 // blank + header + body + close hint + blank
 		}
 		return 2 // blank + 1 help row
 	}
@@ -771,9 +861,9 @@ func (m Model) renderBottomBar() string {
 			b.WriteString("\n")
 		}
 		if m.showHelp {
-			b.WriteString(renderHelpOverlay(m.width))
+			b.WriteString(renderHelpOverlay(m.width, m.activeTab))
 		} else {
-			b.WriteString(renderHelpBar(m.width))
+			b.WriteString(renderHelpBar(m.width, m.activeTab))
 		}
 		b.WriteString("\n")
 	}
@@ -782,7 +872,7 @@ func (m Model) renderBottomBar() string {
 }
 
 // renderHelpBar builds a single-line condensed help bar with ? for full list.
-func renderHelpBar(width int) string {
+func renderHelpBar(width, activeTab int) string {
 	keyStyle := helpKeyStyle()
 	descStyle := helpStyle()
 	sep := descStyle.Render(" \u2022 ")
@@ -792,15 +882,27 @@ func renderHelpBar(width int) string {
 		desc string
 	}
 
-	// Show essential keys on the condensed bar.
-	condensed := []hint{
-		{"p", "pause"},
-		{"r", "poll"},
-		{"i", "track"},
-		{"f", "filter"},
-		{"m", "broadcast"},
-		{"q", "quit"},
-		{"?", "help"},
+	var condensed []hint
+	if activeTab == tabAnalysis {
+		condensed = []hint{
+			{"1/2", "tabs"},
+			{"R", "analyze"},
+			{"b", "batch track"},
+			{"u", "user msg"},
+			{"m", "broadcast"},
+			{"q", "quit"},
+			{"?", "help"},
+		}
+	} else {
+		condensed = []hint{
+			{"1/2", "tabs"},
+			{"p", "pause"},
+			{"r", "poll"},
+			{"i", "track"},
+			{"b", "batch track"},
+			{"q", "quit"},
+			{"?", "help"},
+		}
 	}
 
 	var row strings.Builder
@@ -812,54 +914,138 @@ func renderHelpBar(width int) string {
 		row.WriteString(entry)
 	}
 
+	_ = width
 	return row.String()
 }
 
-// allHelpHints returns the full list of keybind hints for the help overlay.
-func allHelpHints() []struct{ key, desc string } {
-	return []struct{ key, desc string }{
-		{"p", "pause/resume polling"},
-		{"r", "status check"},
-		{"R", "full poll (status + analysis)"},
-		{"e", "expand/collapse analysis"},
-		{"w", "toggle worktrees"},
-		{"x", "expand/collapse tracked"},
-		{"c", "expand/collapse concerns"},
-		{"s", "settings"},
-		{"i", "track issues"},
-		{"I", "untrack issues"},
-		{"f", "filter & bulk track"},
-		{"u", "post user message"},
-		{"m", "broadcast to agents"},
-		{"o", "generate onboarding"},
-		{"a", "launch autopilot"},
-		{"A", "stop autopilot"},
-		{"d", "toggle repo/topic details"},
-		{"t", "cycle theme"},
-		{"\u2191/\u2193", "scroll event log"},
-		{"?", "toggle this help"},
-		{"q", "quit"},
-	}
+type helpHint struct {
+	key  string
+	desc string
 }
 
-// renderHelpOverlay renders the full help overlay box.
-func renderHelpOverlay(width int) string {
+// Help hint groups for the columnar overlay.
+var (
+	globalHints = []helpHint{
+		{"1/2/tab", "switch tabs"},
+		{"s", "settings"},
+		{"d", "details"},
+		{"t", "theme"},
+		{"\u2191/\u2193", "scroll"},
+		{"?", "close help"},
+		{"q", "quit"},
+	}
+
+	opsHints = []helpHint{
+		{"p", "pause/resume sync"},
+		{"r", "status check"},
+		{"i", "track issues"},
+		{"I", "untrack issues"},
+		{"b", "batch track"},
+		{"x", "expand tracked"},
+		{"w", "toggle worktrees"},
+		{"a", "launch autopilot"},
+		{"A", "stop autopilot"},
+	}
+
+	analysisHints = []helpHint{
+		{"R", "run analysis"},
+		{"e", "expand analysis"},
+		{"c", "expand concerns"},
+		{"u", "user message"},
+		{"m", "broadcast"},
+		{"o", "onboarding"},
+	}
+)
+
+// helpOverlayHeight returns the number of lines the help body occupies.
+func helpOverlayHeight() int {
+	// 3 column headers + max of the three column lengths.
+	maxRows := len(globalHints)
+	if len(opsHints) > maxRows {
+		maxRows = len(opsHints)
+	}
+	if len(analysisHints) > maxRows {
+		maxRows = len(analysisHints)
+	}
+	return 1 + maxRows // 1 header row + hint rows
+}
+
+// renderHelpOverlay renders a three-column help overlay with the active tab highlighted.
+func renderHelpOverlay(width, activeTab int) string {
 	keyStyle := helpKeyStyle()
 	descStyle := helpStyle()
-	hints := allHelpHints()
+
+	// Column widths.
+	colW := 26
+	if width > 0 && width/3 > colW {
+		colW = width / 3
+	}
+
+	// Build column header labels — highlight the active tab's column.
+	globalLabel := headerStyle().Render("Global")
+	var opsLabel, analysisLabel string
+	if activeTab == tabOperations {
+		opsLabel = tabActiveStyle().Render(" Operations ")
+		analysisLabel = mutedStyle().Render("Analysis")
+	} else {
+		opsLabel = mutedStyle().Render("Operations")
+		analysisLabel = tabActiveStyle().Render(" Analysis ")
+	}
 
 	var b strings.Builder
 	b.WriteString(headerStyle().Render("Keybindings"))
 	b.WriteString("\n")
-	for _, h := range hints {
-		b.WriteString(fmt.Sprintf("  %s %s\n",
-			keyStyle.Render(fmt.Sprintf("%3s", h.key)),
-			descStyle.Render(h.desc)))
+
+	// Column headers.
+	b.WriteString(fmt.Sprintf("  %-*s", colW, globalLabel))
+	b.WriteString(fmt.Sprintf("%-*s", colW, opsLabel))
+	b.WriteString(analysisLabel)
+	b.WriteString("\n")
+
+	// Determine row count from longest column.
+	maxRows := len(globalHints)
+	if len(opsHints) > maxRows {
+		maxRows = len(opsHints)
 	}
+	if len(analysisHints) > maxRows {
+		maxRows = len(analysisHints)
+	}
+
+	dimStyle := lipgloss.NewStyle().Foreground(currentTheme().Border) // Surface2 — very faded
+
+	fmtHint := func(hints []helpHint, row int, active bool) string {
+		if row >= len(hints) {
+			return fmt.Sprintf("%-*s", colW, "")
+		}
+		h := hints[row]
+		var k, d string
+		if active {
+			k = keyStyle.Render(fmt.Sprintf("%7s", h.key))
+			d = descStyle.Render(" " + h.desc)
+		} else {
+			k = dimStyle.Render(fmt.Sprintf("%7s", h.key))
+			d = dimStyle.Render(" " + h.desc)
+		}
+		entry := k + d
+		// Pad with spaces to fill column (approximate since ANSI codes add invisible chars).
+		pad := colW - len(h.key) - 7 - len(h.desc)
+		if pad < 1 {
+			pad = 1
+		}
+		return entry + strings.Repeat(" ", pad)
+	}
+
+	for i := 0; i < maxRows; i++ {
+		b.WriteString("  ")
+		b.WriteString(fmtHint(globalHints, i, true))
+		b.WriteString(fmtHint(opsHints, i, activeTab == tabOperations))
+		b.WriteString(fmtHint(analysisHints, i, activeTab == tabAnalysis))
+		b.WriteString("\n")
+	}
+
 	b.WriteString(mutedStyle().Render("  press ? to close"))
 	b.WriteString("\n")
 
-	_ = width // available for future width-aware formatting
 	return b.String()
 }
 
@@ -894,7 +1080,6 @@ func (m Model) renderAutopilotSlots() string {
 	return b.String()
 }
 
-// renderAgentLogPreview shows the last N lines of the active agent's log.
 // truncateLine truncates a string to maxWidth characters, adding "..." if truncated.
 func truncateLine(s string, maxWidth int) string {
 	if maxWidth <= 0 {

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"strings"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
 	"github.com/dustinlange/agent-minder/internal/db"
 	gitpkg "github.com/dustinlange/agent-minder/internal/git"
 	"github.com/dustinlange/agent-minder/internal/poller"
@@ -74,10 +74,6 @@ func newSettingsState(project *db.Project) *settingsState {
 	if statusSec <= 0 {
 		statusSec = 300
 	}
-	analysisSec := project.AnalysisIntervalSec
-	if analysisSec <= 0 {
-		analysisSec = 1800
-	}
 
 	return &settingsState{
 		step:     settingsStepSelectField,
@@ -85,15 +81,9 @@ func newSettingsState(project *db.Project) *settingsState {
 		textarea: ta,
 		fields: []settingsField{
 			{
-				label:       "Status interval",
-				description: "How often to run mechanical status checks",
+				label:       "Sync interval",
+				description: "How often to run status checks",
 				value:       strconv.Itoa(statusSec / 60),
-				unit:        "min",
-			},
-			{
-				label:       "Analysis interval",
-				description: "How often to run LLM analysis",
-				value:       strconv.Itoa(analysisSec / 60),
 				unit:        "min",
 			},
 			{
@@ -211,7 +201,7 @@ func (m Model) updateSettingsEditValue(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		field := ss.fields[ss.fieldIdx]
 
 		switch field.label {
-		case "Status interval":
+		case "Sync interval":
 			minutes, err := strconv.Atoi(raw)
 			if err != nil || minutes < 1 {
 				ss.err = "Enter a number >= 1"
@@ -228,26 +218,7 @@ func (m Model) updateSettingsEditValue(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 				if err == nil {
 					m.poller.SetStatusInterval(m.project.StatusInterval())
 				}
-				return settingsSavedMsg{field: "Status interval", err: err}
-			}
-		case "Analysis interval":
-			minutes, err := strconv.Atoi(raw)
-			if err != nil || minutes < 1 {
-				ss.err = "Enter a number >= 1"
-				return m, nil
-			}
-			m.project.AnalysisIntervalSec = minutes * 60
-			ss.fields[ss.fieldIdx].value = strconv.Itoa(minutes)
-			ss.input.Blur()
-			ss.step = settingsStepSelectField
-			ss.err = ""
-
-			return m, func() tea.Msg {
-				err := m.store.UpdateProject(m.project)
-				if err == nil {
-					m.poller.SetAnalysisInterval(m.project.AnalysisInterval())
-				}
-				return settingsSavedMsg{field: "Analysis interval", err: err}
+				return settingsSavedMsg{field: "Sync interval", err: err}
 			}
 		case "Autopilot max agents":
 			n, err := strconv.Atoi(raw)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -6,7 +6,95 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// Theme holds all colors for a theme.
+// catppuccin holds the full named palette for a Catppuccin flavor.
+type catppuccin struct {
+	Rosewater color.Color
+	Flamingo  color.Color
+	Pink      color.Color
+	Mauve     color.Color
+	Red       color.Color
+	Maroon    color.Color
+	Peach     color.Color
+	Yellow    color.Color
+	Green     color.Color
+	Teal      color.Color
+	Sky       color.Color
+	Sapphire  color.Color
+	Blue      color.Color
+	Lavender  color.Color
+	Text      color.Color
+	Subtext1  color.Color
+	Subtext0  color.Color
+	Overlay2  color.Color
+	Overlay1  color.Color
+	Overlay0  color.Color
+	Surface2  color.Color
+	Surface1  color.Color
+	Surface0  color.Color
+	Base      color.Color
+	Mantle    color.Color
+	Crust     color.Color
+}
+
+var mochaPalette = catppuccin{
+	Rosewater: lipgloss.Color("#f5e0dc"),
+	Flamingo:  lipgloss.Color("#f2cdcd"),
+	Pink:      lipgloss.Color("#f5c2e7"),
+	Mauve:     lipgloss.Color("#cba6f7"),
+	Red:       lipgloss.Color("#f38ba8"),
+	Maroon:    lipgloss.Color("#eba0ac"),
+	Peach:     lipgloss.Color("#fab387"),
+	Yellow:    lipgloss.Color("#f9e2af"),
+	Green:     lipgloss.Color("#a6e3a1"),
+	Teal:      lipgloss.Color("#94e2d5"),
+	Sky:       lipgloss.Color("#89dceb"),
+	Sapphire:  lipgloss.Color("#74c7ec"),
+	Blue:      lipgloss.Color("#89b4fa"),
+	Lavender:  lipgloss.Color("#b4befe"),
+	Text:      lipgloss.Color("#cdd6f4"),
+	Subtext1:  lipgloss.Color("#bac2de"),
+	Subtext0:  lipgloss.Color("#a6adc8"),
+	Overlay2:  lipgloss.Color("#9399b2"),
+	Overlay1:  lipgloss.Color("#7f849c"),
+	Overlay0:  lipgloss.Color("#6c7086"),
+	Surface2:  lipgloss.Color("#585b70"),
+	Surface1:  lipgloss.Color("#45475a"),
+	Surface0:  lipgloss.Color("#313244"),
+	Base:      lipgloss.Color("#1e1e2e"),
+	Mantle:    lipgloss.Color("#181825"),
+	Crust:     lipgloss.Color("#11111b"),
+}
+
+var lattePalette = catppuccin{
+	Rosewater: lipgloss.Color("#dc8a78"),
+	Flamingo:  lipgloss.Color("#dd7878"),
+	Pink:      lipgloss.Color("#ea76cb"),
+	Mauve:     lipgloss.Color("#8839ef"),
+	Red:       lipgloss.Color("#d20f39"),
+	Maroon:    lipgloss.Color("#e64553"),
+	Peach:     lipgloss.Color("#fe640b"),
+	Yellow:    lipgloss.Color("#df8e1d"),
+	Green:     lipgloss.Color("#40a02b"),
+	Teal:      lipgloss.Color("#179299"),
+	Sky:       lipgloss.Color("#04a5e5"),
+	Sapphire:  lipgloss.Color("#209fb5"),
+	Blue:      lipgloss.Color("#1e66f5"),
+	Lavender:  lipgloss.Color("#7287fd"),
+	Text:      lipgloss.Color("#4c4f69"),
+	Subtext1:  lipgloss.Color("#5c5f77"),
+	Subtext0:  lipgloss.Color("#6c6f85"),
+	Overlay2:  lipgloss.Color("#7c7f93"),
+	Overlay1:  lipgloss.Color("#8c8fa1"),
+	Overlay0:  lipgloss.Color("#9ca0b0"),
+	Surface2:  lipgloss.Color("#acb0be"),
+	Surface1:  lipgloss.Color("#bcc0cc"),
+	Surface0:  lipgloss.Color("#ccd0da"),
+	Base:      lipgloss.Color("#eff1f5"),
+	Mantle:    lipgloss.Color("#e6e9ef"),
+	Crust:     lipgloss.Color("#dce0e8"),
+}
+
+// Theme holds all semantic colors for a theme.
 type Theme struct {
 	Name      string
 	Primary   color.Color
@@ -18,34 +106,33 @@ type Theme struct {
 	Text      color.Color
 	LLMText   color.Color
 	Border    color.Color
+	// Tab bar colors.
+	TabActiveFg color.Color
+	TabActiveBg color.Color
+	TabInactive color.Color
+}
+
+func themeFromPalette(name string, p catppuccin) Theme {
+	return Theme{
+		Name:        name,
+		Primary:     p.Blue,
+		Secondary:   p.Teal,
+		Success:     p.Green,
+		Warning:     p.Yellow,
+		Error:       p.Red,
+		Muted:       p.Overlay1,
+		Text:        p.Text,
+		LLMText:     p.Subtext1,
+		Border:      p.Surface2,
+		TabActiveFg: p.Blue,
+		TabActiveBg: p.Surface0,
+		TabInactive: p.Overlay0,
+	}
 }
 
 var (
-	darkTheme = Theme{
-		Name:      "dark",
-		Primary:   lipgloss.Color("#B794F4"), // lighter purple
-		Secondary: lipgloss.Color("#63E6F0"), // brighter cyan
-		Success:   lipgloss.Color("#68D391"), // brighter green
-		Warning:   lipgloss.Color("#FBD38D"), // brighter amber
-		Error:     lipgloss.Color("#FC8181"), // brighter red
-		Muted:     lipgloss.Color("#A0AEC0"), // lighter gray
-		Text:      lipgloss.Color("#F7FAFC"), // near-white
-		LLMText:   lipgloss.Color("#E2E8F0"), // light gray
-		Border:    lipgloss.Color("#718096"), // medium gray
-	}
-
-	lightTheme = Theme{
-		Name:      "light",
-		Primary:   lipgloss.Color("#6B21A8"), // deep purple
-		Secondary: lipgloss.Color("#0E7490"), // dark cyan
-		Success:   lipgloss.Color("#047857"), // dark green
-		Warning:   lipgloss.Color("#B45309"), // dark amber
-		Error:     lipgloss.Color("#B91C1C"), // dark red
-		Muted:     lipgloss.Color("#4B5563"), // dark gray
-		Text:      lipgloss.Color("#1F2937"), // near-black
-		LLMText:   lipgloss.Color("#374151"), // dark gray
-		Border:    lipgloss.Color("#9CA3AF"), // medium gray
-	}
+	darkTheme  = themeFromPalette("mocha", mochaPalette)
+	lightTheme = themeFromPalette("latte", lattePalette)
 
 	themes     = []Theme{darkTheme, lightTheme}
 	themeIndex = 0
@@ -133,6 +220,16 @@ func userMsgStyle() lipgloss.Style {
 
 func spinnerStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(currentTheme().Secondary)
+}
+
+func tabActiveStyle() lipgloss.Style {
+	t := currentTheme()
+	return lipgloss.NewStyle().Bold(true).Foreground(t.TabActiveFg).Background(t.TabActiveBg).Padding(0, 1)
+}
+
+func tabInactiveStyle() lipgloss.Style {
+	t := currentTheme()
+	return lipgloss.NewStyle().Foreground(t.TabInactive).Padding(0, 1)
 }
 
 // statusDot returns a colored status indicator for tracked items.


### PR DESCRIPTION
## Summary
- Split monolithic TUI into **Operations** and **Analysis** tabs with `1`/`2`/`tab` switching
- Replace dark/light themes with **Catppuccin Mocha/Latte** palettes (26 named colors each)
- Make LLM analysis **user-initiated only** (`R` key) — no tokens spent on startup or periodic timers
- Remove analysis interval from settings (now dead config); rename status interval → sync interval
- Tab-aware help overlay with three columns (Global / Operations / Analysis), inactive tab dimmed
- Contextual help bar shows relevant keys per tab
- Status labels: `RUNNING` → `SYNCING`, `AUTO-PAUSED` → `IDLE`
- Rename `f` (filter) keybind to `b` (batch track)

## Test plan
- [x] `go test ./...` passes
- [x] Tab switching with `1`/`2`/`tab`/`shift+tab`
- [x] No LLM call on startup (check `~/.agent-minder/debug.log`)
- [x] `R` triggers analysis, results appear on Analysis tab
- [x] New-analysis dot indicator appears on Analysis tab label when results arrive while on Ops tab
- [x] Catppuccin colors render correctly (dark + light terminals)
- [x] Modal modes (`s`, `m`, `i`, `b`) work from both tabs
- [x] Arrow keys scroll correct viewport per tab
- [x] Help overlay (`?`) shows three columns with active tab highlighted
- [x] Settings no longer shows "Analysis interval"

🤖 Generated with [Claude Code](https://claude.com/claude-code)