### PR TITLE
Add hello CLI command

### DIFF
--- a/cmd/hello.go
+++ b/cmd/hello.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var helloCmd = &cobra.Command{
+	Use:   "hello",
+	Short: "Print a greeting message",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Hello from agent-minder")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(helloCmd)
+}


### PR DESCRIPTION
## Summary
- Adds a simple `hello` CLI command that prints "Hello from agent-minder"
- Follows existing Cobra command pattern (see `cmd/pause.go`)

Fixes #102

## Test plan
- [x] `go run . hello` prints "Hello from agent-minder"
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (pre-existing config test failure unrelated)
- [x] Pre-commit hooks (fmt, vet, build) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)