### PR TITLE
Add goodbye CLI command

### DIFF
--- a/cmd/goodbye.go
+++ b/cmd/goodbye.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var goodbyeCmd = &cobra.Command{
+	Use:   "goodbye",
+	Short: "Print a farewell message",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Goodbye from agent-minder")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(goodbyeCmd)
+}


### PR DESCRIPTION
## Summary
- Adds a `goodbye` CLI command that prints "Goodbye from agent-minder"
- Follows the same pattern as the `hello` command from #102

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./cmd/...` passes
- [x] Pre-commit hooks (fmt, vet, build) pass

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)