### PR TITLE
Add version CLI command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is set at build time via -ldflags.
+var Version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of agent-minder",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
## Summary
- Adds a `version` subcommand that prints the current version
- Defaults to `"dev"` but can be set at build time via `-ldflags "-X github.com/dustinlange/agent-minder/cmd.Version=1.0.0"`

Fixes #106

## Test plan
- [x] `go run . version` prints `dev`
- [x] `go run -ldflags="-X .../cmd.Version=1.0.0" . version` prints `1.0.0`
- [x] All existing tests pass
- [x] Pre-commit hooks pass (fmt, vet, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)