### PR TITLE
Add --json flag to version command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -9,15 +11,27 @@ import (
 // Version is set at build time via -ldflags.
 var Version = "dev"
 
+var versionJSON bool
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of agent-minder",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		if versionJSON {
+			info := map[string]string{"version": Version}
+			enc := json.NewEncoder(os.Stdout)
+			if err := enc.Encode(info); err != nil {
+				fmt.Fprintf(os.Stderr, "error encoding JSON: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
 		fmt.Println(Version)
 	},
 }
 
 func init() {
+	versionCmd.Flags().BoolVar(&versionJSON, "json", false, "Output version info as JSON")
 	rootCmd.AddCommand(versionCmd)
 }


### PR DESCRIPTION
## Summary
- Adds a `--json` flag to the `version` command that outputs version info as a JSON object (`{"version":"..."}`)
- Depends on #108 (version command from issue #106)

## Test plan
- [x] `agent-minder version` still prints plain text version
- [x] `agent-minder version --json` outputs `{"version":"dev"}` JSON
- [x] All pre-commit hooks pass (fmt, vet, build)
- [x] Existing tests pass

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)