### PR TITLE
Add ping command that prints pong

### DIFF
--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var pingCmd = &cobra.Command{
+	Use:   "ping",
+	Short: "Print pong",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("pong")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pingCmd)
+}


### PR DESCRIPTION
## Summary
- Adds a `ping` CLI command that prints "pong"

Fixes #110

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing config test failure unrelated)
- [x] Pre-commit hooks pass (fmt, vet, build)
- [ ] Manual: `go run . ping` prints "pong"

🤖 Generated with [Claude Code](https://claude.com/claude-code)