### PR TITLE
Add ping --count flag

### DIFF
--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var pingCount int
+
+var pingCmd = &cobra.Command{
+	Use:   "ping",
+	Short: "Print pong",
+	Run: func(cmd *cobra.Command, args []string) {
+		for range pingCount {
+			fmt.Fprintln(cmd.OutOrStdout(), "pong")
+		}
+	},
+}
+
+func init() {
+	pingCmd.Flags().IntVarP(&pingCount, "count", "n", 1, "number of times to print pong")
+	rootCmd.AddCommand(pingCmd)
+}

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPingDefault(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"ping"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if strings.Count(got, "pong") != 1 {
+		t.Fatalf("expected 1 pong, got %q", got)
+	}
+}
+
+func TestPingCount(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"ping", "--count", "3"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if strings.Count(got, "pong") != 3 {
+		t.Fatalf("expected 3 pongs, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ping` command (from issue #110) with a `--count` / `-n` flag that repeats "pong" N times (default 1)
- Includes tests for default behavior and count flag

Fixes #111
Depends on #110

## Test plan
- [x] `go test ./cmd/ -run TestPing` passes
- [x] `go build ./...` succeeds
- [x] Pre-commit hooks (fmt, vet, build) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)