### PR TITLE
Add echo CLI command

### DIFF
--- a/cmd/echo.go
+++ b/cmd/echo.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var echoCmd = &cobra.Command{
+	Use:   "echo [args...]",
+	Short: "Print back its arguments",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(strings.Join(args, " "))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(echoCmd)
+}


### PR DESCRIPTION
## Summary
- Adds an `echo` CLI command that prints back its arguments, joined by spaces

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./cmd/...` passes
- [x] `go run . echo hello world` prints `hello world`
- [x] Pre-commit hooks (fmt, vet, build) pass

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)