### PR TITLE
Add --reverse flag to echo command

### DIFF
--- a/cmd/echo.go
+++ b/cmd/echo.go
@@ -2,21 +2,28 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+var echoReverse bool
 
 var echoCmd = &cobra.Command{
 	Use:   "echo [args...]",
 	Short: "Print back its arguments",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if echoReverse {
+			slices.Reverse(args)
+		}
 		fmt.Println(strings.Join(args, " "))
 		return nil
 	},
 }
 
 func init() {
+	echoCmd.Flags().BoolVar(&echoReverse, "reverse", false, "Print arguments in reverse order")
 	rootCmd.AddCommand(echoCmd)
 }


### PR DESCRIPTION
## Summary
- Adds a `--reverse` flag to the `echo` command that prints arguments in reverse order
- Builds on the echo command from #114

Fixes #115

## Test plan
- [x] `go run . echo hello world` → `hello world`
- [x] `go run . echo --reverse hello world` → `world hello`
- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing config test failure unrelated)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)