### PR TITLE
Add whoami command

### DIFF
--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dustinlange/agent-minder/internal/db"
+	"github.com/spf13/cobra"
+)
+
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Print the current project name based on working directory",
+	Args:  cobra.NoArgs,
+	RunE:  runWhoami,
+}
+
+func init() {
+	rootCmd.AddCommand(whoamiCmd)
+}
+
+func runWhoami(cmd *cobra.Command, _ []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return fmt.Errorf("resolving symlinks: %w", err)
+	}
+
+	conn, err := db.Open(db.DefaultDBPath())
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	store := db.NewStore(conn)
+
+	projects, err := store.ListProjects()
+	if err != nil {
+		return fmt.Errorf("listing projects: %w", err)
+	}
+
+	for _, p := range projects {
+		repos, _ := store.GetRepos(p.ID)
+		for _, r := range repos {
+			resolved, err := filepath.EvalSymlinks(r.Path)
+			if err != nil {
+				resolved = r.Path
+			}
+			if isSubpath(cwd, resolved) {
+				fmt.Fprintln(cmd.OutOrStdout(), p.Name)
+				return nil
+			}
+
+			wts, _ := store.GetWorktrees(r.ID)
+			for _, wt := range wts {
+				resolved, err := filepath.EvalSymlinks(wt.Path)
+				if err != nil {
+					resolved = wt.Path
+				}
+				if isSubpath(cwd, resolved) {
+					fmt.Fprintln(cmd.OutOrStdout(), p.Name)
+					return nil
+				}
+			}
+		}
+	}
+
+	return fmt.Errorf("no project found for directory %s", cwd)
+}
+
+// isSubpath reports whether child is equal to or under parent.
+func isSubpath(child, parent string) bool {
+	child = filepath.Clean(child)
+	parent = filepath.Clean(parent)
+	if child == parent {
+		return true
+	}
+	return strings.HasPrefix(child, parent+string(filepath.Separator))
+}


### PR DESCRIPTION
## Summary
- Adds a `whoami` CLI command that prints the current project name based on the working directory
- Matches cwd against repo paths and worktree paths in the database

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing config test failure unrelated)
- [x] Pre-commit hooks (fmt, vet, build) pass

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)