### PR TITLE
Add whoami command with --verbose flag

### DIFF
--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dustinlange/agent-minder/internal/db"
+	gitpkg "github.com/dustinlange/agent-minder/internal/git"
+	"github.com/spf13/cobra"
+)
+
+var whoamiVerbose bool
+
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Print the project name for the current directory",
+	Args:  cobra.NoArgs,
+	RunE:  runWhoami,
+}
+
+func init() {
+	whoamiCmd.Flags().BoolVarP(&whoamiVerbose, "verbose", "v", false, "Also print repo list and goal")
+	rootCmd.AddCommand(whoamiCmd)
+}
+
+func runWhoami(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+
+	repoRoot, err := gitpkg.TopLevel(cwd)
+	if err != nil {
+		return fmt.Errorf("not inside a git repository")
+	}
+
+	conn, err := db.Open(db.DefaultDBPath())
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	store := db.NewStore(conn)
+
+	project, err := store.GetProjectByRepoPath(repoRoot)
+	if err != nil {
+		return fmt.Errorf("no project found for this directory")
+	}
+
+	fmt.Println(project.Name)
+
+	if whoamiVerbose {
+		fmt.Printf("Goal: %s — %s\n", project.GoalType, project.GoalDescription)
+
+		repos, _ := store.GetRepos(project.ID)
+		if len(repos) > 0 {
+			fmt.Println("Repos:")
+			for _, r := range repos {
+				fmt.Printf("  %s (%s)\n", r.ShortName, r.Path)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -830,6 +830,35 @@ func parseDependencies(deps string) []int {
 	return result
 }
 
+// GetProjectByRepoPath finds the project that owns a repo or worktree at the given path.
+func (s *Store) GetProjectByRepoPath(path string) (*Project, error) {
+	// Try repos first.
+	var p Project
+	err := s.db.Get(&p, `
+		SELECT p.* FROM projects p
+		JOIN repos r ON r.project_id = p.id
+		WHERE r.path = ?
+		LIMIT 1
+	`, path)
+	if err == nil {
+		return &p, nil
+	}
+
+	// Try worktrees.
+	err = s.db.Get(&p, `
+		SELECT p.* FROM projects p
+		JOIN repos r ON r.project_id = p.id
+		JOIN worktrees w ON w.repo_id = r.id
+		WHERE w.path = ?
+		LIMIT 1
+	`, path)
+	if err == nil {
+		return &p, nil
+	}
+
+	return nil, fmt.Errorf("no project found for path %q", path)
+}
+
 // LastPoll returns the most recent poll for a project, or nil if none.
 func (s *Store) LastPoll(projectID int64) (*Poll, error) {
 	polls, err := s.RecentPolls(projectID, 1)


### PR DESCRIPTION
## Summary
- Adds `whoami` CLI command that prints the current project name by matching the git repo root against enrolled repos/worktrees in the database
- `--verbose` (`-v`) flag additionally prints the project goal and list of enrolled repos with paths
- Adds `GetProjectByRepoPath()` DB query that checks both repos and worktrees tables

Fixes #119

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing config test failure unrelated)
- [x] `golangci-lint run` clean
- [x] Pre-commit hooks pass (fmt, vet, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)