### PR TITLE
Add TUI UX consistency guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Each poll cycle with new activity runs two sequential LLM calls:
 
 ### TUI (internal/tui)
 
+**UX patterns: see [TUI-UX-GUIDE.md](TUI-UX-GUIDE.md)** — all new/modified interactions must follow those conventions.
+
 Bubbletea v2 dashboard. Key bindings: `p` pause, `r` poll now, `e` expand, `u` user msg, `m` broadcast, `o` onboard, `a` autopilot, `A` stop autopilot (with confirmation), `t` theme, `q` quit.
 
 - Spinner (bubbles/v2/spinner MiniDot) shown during manual poll (`r`), broadcast, and onboard generation

--- a/TUI-UX-GUIDE.md
+++ b/TUI-UX-GUIDE.md
@@ -1,0 +1,75 @@
+# TUI UX Consistency Guide
+
+Reference for agents modifying the TUI (`internal/tui/`). Follow these patterns for all new and modified interactions.
+
+## Core Principles
+
+1. **Lists use arrow navigation, not letter keys.** Any time the user picks from a set of options, use `up/down` (+ `j/k`) with `enter` to select and `esc` to go back.
+2. **Confirmations use `enter/esc`, not `y/n`.** Prompt text should read "Press enter to confirm, esc to cancel" (or similar).
+3. **`esc` always means cancel/back.** Never require a different key to go back. Every modal, wizard step, and confirmation must respond to `esc`.
+4. **`enter` always means proceed/submit** in single-line contexts.
+5. **`ctrl+d` submits multiline textareas** (enter inserts newlines). This is the one exception to rule 4.
+6. **Vim keys (`j/k`) are supported wherever arrow keys navigate lists.** Do not add them to free-form text inputs.
+
+## Interaction Patterns
+
+### List/Menu Selection
+Use for: picking from a set of options (repos, filter types, conflict resolution, settings fields).
+
+```
+Navigation:  up/k, down/j
+Select:      enter
+Cancel:      esc
+```
+
+All list items should have a visual cursor/highlight on the focused item.
+
+### Confirmation Prompt
+Use for: any yes/no decision before an action (autopilot launch/stop, analysis, cleanup).
+
+```
+Confirm:  enter
+Cancel:   esc
+Prompt:   "Do X? (enter to confirm, esc to cancel)"
+```
+
+### Single-Line Text Input
+Use for: issue numbers, setting values, filter text input.
+
+```
+Submit:   enter
+Cancel:   esc
+```
+
+### Multiline Textarea
+Use for: broadcast messages, user messages, onboarding, analyzer focus.
+
+```
+Submit:   ctrl+d
+Cancel:   esc
+```
+
+### Multi-Step Wizards
+Use for: filter flow, track/untrack flow.
+
+- Each step follows one of the patterns above.
+- `esc` goes back one step (or exits on the first step).
+- Maintain consistent navigation within the wizard — don't switch between arrow-nav and letter-key-nav between steps.
+
+## Known Issues (To Fix)
+
+| Location | Current | Should Be |
+|----------|---------|-----------|
+| `filter.go` filterStepSelectType | Letter keys `l/m/p/a` | Arrow-nav list |
+| `filter.go` filterStepConflict | Letter keys `u/a/c` | Arrow-nav list |
+| `app.go` pollConfirm | `y/n` | `enter/esc` |
+| `app.go` autopilot scan-confirm | `y/n` | `enter/esc` |
+| `app.go` autopilot confirm (launch) | `y/n` | `enter/esc` |
+| `app.go` autopilot stop-confirm | `y/n` | `enter/esc` |
+| `app.go` track cleanup confirm | `y/n` | `enter/esc` |
+
+## Style Notes
+
+- Spinner: `spinner.MiniDot` for all async operations.
+- Help overlay (`?`): update when adding new keybindings.
+- Bottom bar: show context-appropriate key hints for the current mode.


### PR DESCRIPTION
## Summary
- Adds `TUI-UX-GUIDE.md` with standard interaction patterns for the TUI (arrow-nav for lists, enter/esc for confirmations, ctrl+d for textareas)
- References the guide from the TUI section in `CLAUDE.md`
- Documents 7 known inconsistencies to fix (tracked in #126)

## Test plan
- [ ] Verify `TUI-UX-GUIDE.md` renders correctly on GitHub
- [ ] Verify `CLAUDE.md` link to the guide works

🤖 Generated with [Claude Code](https://claude.com/claude-code)