### PR TITLE
Improve error messages in OpenWithRecovery

### DIFF
--- a/internal/sqliteutil/recover.go
+++ b/internal/sqliteutil/recover.go
@@ -28,12 +28,13 @@ func CheckAndRecover(db *sqlx.DB, dbPath string) (bool, error) {
 	if err := db.Ping(); err != nil {
 		if isIOError(err) {
 			_ = db.Close()
-			if removeErr := removeStaleFiles(dbPath); removeErr != nil {
-				return false, fmt.Errorf("WAL recovery failed for %s: %w (original: %v)", dbPath, removeErr, err)
+			removed, removeErr := removeStaleFiles(dbPath)
+			if removeErr != nil {
+				return false, fmt.Errorf("WAL recovery failed for %s (removed %v): %w", dbPath, removed, removeErr)
 			}
 			return false, nil
 		}
-		return false, fmt.Errorf("ping failed: %w", err)
+		return false, fmt.Errorf("ping failed for %s: %w", dbPath, err)
 	}
 
 	// Deeper check: integrity_check catches corrupted WAL state that ping misses.
@@ -41,16 +42,17 @@ func CheckAndRecover(db *sqlx.DB, dbPath string) (bool, error) {
 	if err := db.Get(&result, "PRAGMA integrity_check"); err != nil {
 		if isIOError(err) {
 			_ = db.Close()
-			if removeErr := removeStaleFiles(dbPath); removeErr != nil {
-				return false, fmt.Errorf("WAL recovery failed for %s: %w (original: %v)", dbPath, removeErr, err)
+			removed, removeErr := removeStaleFiles(dbPath)
+			if removeErr != nil {
+				return false, fmt.Errorf("WAL recovery failed for %s (removed %v): %w", dbPath, removed, removeErr)
 			}
 			return false, nil
 		}
-		return false, fmt.Errorf("integrity check failed: %w", err)
+		return false, fmt.Errorf("integrity check failed for %s: %w", dbPath, err)
 	}
 
 	if result != "ok" {
-		return false, fmt.Errorf("integrity check returned: %s", result)
+		return false, fmt.Errorf("integrity check for %s returned: %s", dbPath, result)
 	}
 
 	return true, nil
@@ -59,20 +61,24 @@ func CheckAndRecover(db *sqlx.DB, dbPath string) (bool, error) {
 // removeStaleFiles removes -shm and -wal files for a database path.
 // These files are safe to remove when no process has the database open,
 // and their removal allows SQLite to rebuild them on next connection.
-func removeStaleFiles(dbPath string) error {
+// Returns the list of files that were detected and removed.
+func removeStaleFiles(dbPath string) ([]string, error) {
+	var removed []string
 	var errs []string
 	for _, suffix := range []string{"-shm", "-wal"} {
 		path := dbPath + suffix
 		if _, err := os.Stat(path); err == nil {
 			if err := os.Remove(path); err != nil {
 				errs = append(errs, fmt.Sprintf("remove %s: %v", path, err))
+			} else {
+				removed = append(removed, suffix)
 			}
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "; "))
+		return removed, fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
-	return nil
+	return removed, nil
 }
 
 // isIOError checks if an error is a SQLite disk I/O error (code 10).

--- a/internal/sqliteutil/recover_test.go
+++ b/internal/sqliteutil/recover_test.go
@@ -77,8 +77,12 @@ func TestRemoveStaleFiles(t *testing.T) {
 		}
 	}
 
-	if err := removeStaleFiles(dbPath); err != nil {
+	removed, err := removeStaleFiles(dbPath)
+	if err != nil {
 		t.Fatalf("removeStaleFiles: %v", err)
+	}
+	if len(removed) != 2 {
+		t.Errorf("removed = %v, want both -shm and -wal", removed)
 	}
 
 	// Both should be gone.
@@ -94,8 +98,12 @@ func TestRemoveStaleFilesNoFiles(t *testing.T) {
 	dbPath := filepath.Join(dir, "nonexistent.db")
 
 	// Should not error when files don't exist.
-	if err := removeStaleFiles(dbPath); err != nil {
+	removed, err := removeStaleFiles(dbPath)
+	if err != nil {
 		t.Fatalf("removeStaleFiles on missing files: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Errorf("removed = %v, want empty", removed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Include database path in all error returns from `CheckAndRecover` (previously missing from `ping failed`, `integrity check failed`, and `integrity check returned` errors)
- `removeStaleFiles` now reports which files (`-shm`, `-wal`) were detected and removed
- Use `fmt.Errorf` with `%w` wrapping consistently (removed `%v` for original errors)

Fixes #140

## Test plan
- [x] All existing `sqliteutil` tests pass (5/5)
- [x] Added assertions for `removeStaleFiles` return values in both existing test cases
- [x] Pre-commit hooks (fmt, vet, build) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)