### PR TITLE
Add String() method to TaskStatus type

### DIFF
--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1,0 +1,36 @@
+package autopilot
+
+// TaskStatus represents the lifecycle status of an autopilot task.
+type TaskStatus string
+
+const (
+	TaskQueued  TaskStatus = "queued"
+	TaskRunning TaskStatus = "running"
+	TaskReview  TaskStatus = "review"
+	TaskDone    TaskStatus = "done"
+	TaskBailed  TaskStatus = "bailed"
+	TaskStopped TaskStatus = "stopped"
+	TaskBlocked TaskStatus = "blocked"
+)
+
+// String returns a human-readable string for the task status.
+func (s TaskStatus) String() string {
+	switch s {
+	case TaskQueued:
+		return "Queued"
+	case TaskRunning:
+		return "Running"
+	case TaskReview:
+		return "In Review"
+	case TaskDone:
+		return "Done"
+	case TaskBailed:
+		return "Bailed"
+	case TaskStopped:
+		return "Stopped"
+	case TaskBlocked:
+		return "Blocked"
+	default:
+		return string(s)
+	}
+}

--- a/internal/autopilot/types_test.go
+++ b/internal/autopilot/types_test.go
@@ -1,0 +1,32 @@
+package autopilot
+
+import "testing"
+
+func TestTaskStatusString(t *testing.T) {
+	tests := []struct {
+		status TaskStatus
+		want   string
+	}{
+		{TaskQueued, "Queued"},
+		{TaskRunning, "Running"},
+		{TaskReview, "In Review"},
+		{TaskDone, "Done"},
+		{TaskBailed, "Bailed"},
+		{TaskStopped, "Stopped"},
+		{TaskBlocked, "Blocked"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("TaskStatus(%q).String() = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskStatusStringUnknown(t *testing.T) {
+	unknown := TaskStatus("unknown")
+	if got := unknown.String(); got != "unknown" {
+		t.Errorf("TaskStatus(%q).String() = %q, want %q", unknown, got, "unknown")
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces a `TaskStatus` type in `internal/autopilot/types.go` with constants for all autopilot task lifecycle states (`queued`, `running`, `review`, `done`, `bailed`, `stopped`, `blocked`)
- Adds a `String()` method returning human-readable labels (e.g., `"In Review"` for `review`)
- Includes comprehensive tests covering all statuses plus unknown value fallback

## Test plan
- [x] `go test ./internal/autopilot/... -run TestTaskStatus -v` — all 9 subtests pass
- [x] Pre-commit hooks (fmt, vet, build) pass

Fixes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)