### PR TITLE
Add multi-provider failover with cost optimization

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -44,7 +44,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("project %q not found — run 'agent-minder init' first", projectName)
 	}
 
-	// Create LLM provider, using config-sourced API key if available.
+	// Create LLM provider(s), using config-sourced API key if available.
 	var providerOpts []llm.Option
 	if apiKey := config.GetProviderAPIKey(project.LLMProvider); apiKey != "" {
 		providerOpts = append(providerOpts, llm.WithAPIKey(apiKey))
@@ -52,10 +52,29 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if baseURL := config.GetProviderBaseURL(project.LLMProvider); baseURL != "" {
 		providerOpts = append(providerOpts, llm.WithBaseURL(baseURL))
 	}
-	provider, err := llm.NewProvider(project.LLMProvider, providerOpts...)
+	primaryProvider, err := llm.NewProvider(project.LLMProvider, providerOpts...)
 	if err != nil {
 		return fmt.Errorf("creating LLM provider: %w", err)
 	}
+
+	// Build failover chain: primary + optional fallback provider.
+	providers := []llm.Provider{primaryProvider}
+	if project.LLMFallbackProvider != "" && project.LLMFallbackProvider != project.LLMProvider {
+		var fbOpts []llm.Option
+		if apiKey := config.GetProviderAPIKey(project.LLMFallbackProvider); apiKey != "" {
+			fbOpts = append(fbOpts, llm.WithAPIKey(apiKey))
+		}
+		if baseURL := config.GetProviderBaseURL(project.LLMFallbackProvider); baseURL != "" {
+			fbOpts = append(fbOpts, llm.WithBaseURL(baseURL))
+		}
+		fbProvider, fbErr := llm.NewProvider(project.LLMFallbackProvider, fbOpts...)
+		if fbErr != nil {
+			log.Printf("Warning: fallback provider %q unavailable: %v", project.LLMFallbackProvider, fbErr)
+		} else {
+			providers = append(providers, fbProvider)
+		}
+	}
+	provider := llm.NewFailoverProvider(providers, store, project.ID)
 
 	// Create bus publisher (non-fatal if unavailable).
 	var publisher *msgbus.Publisher

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -31,6 +31,7 @@ type Project struct {
 	AutopilotMaxBudgetUSD float64 `db:"autopilot_max_budget_usd"`
 	AutopilotSkipLabel    string  `db:"autopilot_skip_label"`
 	AutopilotBaseBranch   string  `db:"autopilot_base_branch"`
+	LLMFallbackProvider   string  `db:"llm_fallback_provider"`
 	CreatedAt             string  `db:"created_at"`
 }
 
@@ -187,6 +188,38 @@ type AutopilotTask struct {
 	AgentLog     string `db:"agent_log"`
 	StartedAt    string `db:"started_at"`
 	CompletedAt  string `db:"completed_at"`
+}
+
+// ProviderStat tracks per-provider, per-model success/error rates and latency.
+type ProviderStat struct {
+	ID              int64  `db:"id"`
+	ProjectID       int64  `db:"project_id"`
+	Provider        string `db:"provider"`
+	Model           string `db:"model"`
+	SuccessCount    int    `db:"success_count"`
+	ErrorCount      int    `db:"error_count"`
+	TotalLatencyMs  int64  `db:"total_latency_ms"`
+	TotalInputToks  int64  `db:"total_input_toks"`
+	TotalOutputToks int64  `db:"total_output_toks"`
+	LastError       string `db:"last_error"`
+	UpdatedAt       string `db:"updated_at"`
+}
+
+// ErrorRate returns the fraction of calls that failed (0.0–1.0).
+func (s *ProviderStat) ErrorRate() float64 {
+	total := s.SuccessCount + s.ErrorCount
+	if total == 0 {
+		return 0
+	}
+	return float64(s.ErrorCount) / float64(total)
+}
+
+// AvgLatencyMs returns the average latency per successful call.
+func (s *ProviderStat) AvgLatencyMs() float64 {
+	if s.SuccessCount == 0 {
+		return 0
+	}
+	return float64(s.TotalLatencyMs) / float64(s.SuccessCount)
 }
 
 // LLMResponse returns the best available response: tier 2 if present, else tier 1, else raw.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -33,14 +33,14 @@ func (s *Store) CreateProject(p *Project) error {
 			idle_pause_sec, analyzer_focus,
 			autopilot_filter_type, autopilot_filter_value, autopilot_max_agents,
 			autopilot_max_turns, autopilot_max_budget_usd, autopilot_skip_label,
-			autopilot_base_branch)
+			autopilot_base_branch, llm_fallback_provider)
 		VALUES (:name, :goal_type, :goal_description, :refresh_interval_sec,
 			:message_ttl_sec, :auto_enroll_worktrees, :minder_identity, :llm_provider, :llm_model,
 			:llm_summarizer_model, :llm_analyzer_model, :status_interval_sec, :analysis_interval_sec,
 			:idle_pause_sec, :analyzer_focus,
 			:autopilot_filter_type, :autopilot_filter_value, :autopilot_max_agents,
 			:autopilot_max_turns, :autopilot_max_budget_usd, :autopilot_skip_label,
-			:autopilot_base_branch)
+			:autopilot_base_branch, :llm_fallback_provider)
 	`, p)
 	if err != nil {
 		return fmt.Errorf("insert project: %w", err)
@@ -104,7 +104,8 @@ func (s *Store) UpdateProject(p *Project) error {
 			autopilot_max_turns = :autopilot_max_turns,
 			autopilot_max_budget_usd = :autopilot_max_budget_usd,
 			autopilot_skip_label = :autopilot_skip_label,
-			autopilot_base_branch = :autopilot_base_branch
+			autopilot_base_branch = :autopilot_base_branch,
+			llm_fallback_provider = :llm_fallback_provider
 		WHERE id = :id
 	`, p)
 	return err
@@ -839,6 +840,52 @@ func parseDependencies(deps string) []int {
 		}
 	}
 	return result
+}
+
+// --- Provider Stats ---
+
+// RecordProviderCall upserts a provider stat row after an LLM call.
+func (s *Store) RecordProviderCall(projectID int64, provider, model string, latencyMs int64, inputToks, outputToks int, callErr error) error {
+	errMsg := ""
+	if callErr != nil {
+		errMsg = callErr.Error()
+	}
+
+	// Use INSERT OR REPLACE with computed values. SQLite UPSERT via ON CONFLICT.
+	_, err := s.db.Exec(`
+		INSERT INTO provider_stats (project_id, provider, model, success_count, error_count,
+			total_latency_ms, total_input_toks, total_output_toks, last_error, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+		ON CONFLICT(project_id, provider, model) DO UPDATE SET
+			success_count = provider_stats.success_count + excluded.success_count,
+			error_count = provider_stats.error_count + excluded.error_count,
+			total_latency_ms = provider_stats.total_latency_ms + excluded.total_latency_ms,
+			total_input_toks = provider_stats.total_input_toks + excluded.total_input_toks,
+			total_output_toks = provider_stats.total_output_toks + excluded.total_output_toks,
+			last_error = CASE WHEN excluded.last_error != '' THEN excluded.last_error ELSE provider_stats.last_error END,
+			updated_at = datetime('now')
+	`, projectID, provider, model,
+		boolToInt(callErr == nil), boolToInt(callErr != nil),
+		latencyMs, int64(inputToks), int64(outputToks), errMsg)
+	return err
+}
+
+// GetProviderStats returns all provider stats for a project.
+func (s *Store) GetProviderStats(projectID int64) ([]ProviderStat, error) {
+	var stats []ProviderStat
+	if err := s.db.Select(&stats, `
+		SELECT * FROM provider_stats WHERE project_id = ? ORDER BY provider, model
+	`, projectID); err != nil {
+		return nil, fmt.Errorf("get provider stats: %w", err)
+	}
+	return stats, nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // LastPoll returns the most recent poll for a project, or nil if none.

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -9,7 +9,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 11
+const currentVersion = 12
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS projects (
 	autopilot_max_budget_usd REAL DEFAULT 3.00,
 	autopilot_skip_label   TEXT DEFAULT 'no-agent',
 	autopilot_base_branch  TEXT DEFAULT '',
+	llm_fallback_provider  TEXT DEFAULT '',
 	created_at            TEXT DEFAULT (datetime('now'))
 );
 
@@ -141,6 +142,21 @@ CREATE TABLE IF NOT EXISTS completed_items (
 	summary      TEXT NOT NULL DEFAULT '',
 	completed_at TEXT DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS provider_stats (
+	id              INTEGER PRIMARY KEY,
+	project_id      INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+	provider        TEXT NOT NULL,
+	model           TEXT NOT NULL,
+	success_count   INTEGER NOT NULL DEFAULT 0,
+	error_count     INTEGER NOT NULL DEFAULT 0,
+	total_latency_ms INTEGER NOT NULL DEFAULT 0,
+	total_input_toks  INTEGER NOT NULL DEFAULT 0,
+	total_output_toks INTEGER NOT NULL DEFAULT 0,
+	last_error      TEXT NOT NULL DEFAULT '',
+	updated_at      TEXT DEFAULT (datetime('now')),
+	UNIQUE(project_id, provider, model)
+);
 `
 
 // Open opens (or creates) the agent-minder SQLite database and runs migrations,
@@ -235,6 +251,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 11 {
 		if err := migrateV11(db); err != nil {
 			return fmt.Errorf("apply migration v11: %w", err)
+		}
+	}
+
+	if version < 12 {
+		if err := migrateV12(db); err != nil {
+			return fmt.Errorf("apply migration v12: %w", err)
 		}
 	}
 
@@ -449,6 +471,38 @@ func migrateV11(db *sqlx.DB) error {
 	// Copy existing refresh_interval_sec into analysis_interval_sec for migration continuity.
 	if _, err := db.Exec(`UPDATE projects SET analysis_interval_sec = refresh_interval_sec WHERE refresh_interval_sec > 0`); err != nil {
 		return fmt.Errorf("copy refresh_interval to analysis_interval: %w", err)
+	}
+	return nil
+}
+
+func migrateV12(db *sqlx.DB) error {
+	// Create provider_stats table.
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS provider_stats (
+			id              INTEGER PRIMARY KEY,
+			project_id      INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			provider        TEXT NOT NULL,
+			model           TEXT NOT NULL,
+			success_count   INTEGER NOT NULL DEFAULT 0,
+			error_count     INTEGER NOT NULL DEFAULT 0,
+			total_latency_ms INTEGER NOT NULL DEFAULT 0,
+			total_input_toks  INTEGER NOT NULL DEFAULT 0,
+			total_output_toks INTEGER NOT NULL DEFAULT 0,
+			last_error      TEXT NOT NULL DEFAULT '',
+			updated_at      TEXT DEFAULT (datetime('now')),
+			UNIQUE(project_id, provider, model)
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create provider_stats table: %w", err)
+	}
+
+	// Add fallback provider column to projects.
+	if _, err := db.Exec(`ALTER TABLE projects ADD COLUMN llm_fallback_provider TEXT DEFAULT ''`); err != nil {
+		return fmt.Errorf("add llm_fallback_provider: %w", err)
+	}
+	if _, err := db.Exec(`UPDATE projects SET llm_fallback_provider = '' WHERE llm_fallback_provider IS NULL`); err != nil {
+		return fmt.Errorf("null-fill llm_fallback_provider: %w", err)
 	}
 	return nil
 }

--- a/internal/llm/costs.go
+++ b/internal/llm/costs.go
@@ -1,0 +1,35 @@
+package llm
+
+// ModelCost holds per-token cost in USD for a model.
+type ModelCost struct {
+	InputPerMTok  float64 // cost per million input tokens
+	OutputPerMTok float64 // cost per million output tokens
+}
+
+// Cost returns the total cost for a given token usage.
+func (c ModelCost) Cost(inputToks, outputToks int) float64 {
+	return float64(inputToks)*c.InputPerMTok/1e6 + float64(outputToks)*c.OutputPerMTok/1e6
+}
+
+// knownCosts maps model IDs to their per-token costs.
+// Prices as of early 2026; update as needed.
+var knownCosts = map[string]ModelCost{
+	// Anthropic
+	"claude-haiku-4-5":  {InputPerMTok: 0.80, OutputPerMTok: 4.00},
+	"claude-sonnet-4-6": {InputPerMTok: 3.00, OutputPerMTok: 15.00},
+	"claude-opus-4-6":   {InputPerMTok: 15.00, OutputPerMTok: 75.00},
+	// OpenAI
+	"gpt-4o":       {InputPerMTok: 2.50, OutputPerMTok: 10.00},
+	"gpt-4o-mini":  {InputPerMTok: 0.15, OutputPerMTok: 0.60},
+	"gpt-4.1":      {InputPerMTok: 2.00, OutputPerMTok: 8.00},
+	"gpt-4.1-mini": {InputPerMTok: 0.40, OutputPerMTok: 1.60},
+	"gpt-4.1-nano": {InputPerMTok: 0.10, OutputPerMTok: 0.40},
+}
+
+// LookupCost returns the cost info for a model, or a zero-cost fallback if unknown.
+func LookupCost(model string) ModelCost {
+	if c, ok := knownCosts[model]; ok {
+		return c
+	}
+	return ModelCost{}
+}

--- a/internal/llm/failover.go
+++ b/internal/llm/failover.go
@@ -1,0 +1,163 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// StatsRecorder persists call statistics. Implemented by db.Store.
+type StatsRecorder interface {
+	RecordProviderCall(projectID int64, provider, model string, latencyMs int64, inputToks, outputToks int, callErr error) error
+}
+
+// ProviderScore holds runtime stats for a provider used in dynamic reordering.
+type ProviderScore struct {
+	Provider     string
+	SuccessCount int
+	ErrorCount   int
+	TotalCostUSD float64
+}
+
+// score returns a composite score (lower is better).
+// Weighs error rate heavily, then cost.
+func (ps ProviderScore) score() float64 {
+	total := ps.SuccessCount + ps.ErrorCount
+	if total == 0 {
+		return 0 // untested providers get neutral score
+	}
+	errorRate := float64(ps.ErrorCount) / float64(total)
+	avgCost := 0.0
+	if ps.SuccessCount > 0 {
+		avgCost = ps.TotalCostUSD / float64(ps.SuccessCount)
+	}
+	// Error rate dominates: 1 error = equivalent of $10 in cost penalty.
+	return errorRate*10.0 + avgCost
+}
+
+// FailoverProvider wraps multiple providers and tries them in order.
+// It tracks per-provider stats and dynamically reorders based on cost/reliability.
+type FailoverProvider struct {
+	providers []Provider
+	recorder  StatsRecorder
+	projectID int64
+
+	mu     sync.Mutex
+	scores map[string]*ProviderScore // keyed by provider name
+}
+
+// NewFailoverProvider creates a failover provider from one or more providers.
+// The first provider is the primary; others are fallbacks tried in order.
+// If recorder is non-nil, call stats are persisted to the database.
+func NewFailoverProvider(providers []Provider, recorder StatsRecorder, projectID int64) *FailoverProvider {
+	scores := make(map[string]*ProviderScore, len(providers))
+	for _, p := range providers {
+		scores[p.Name()] = &ProviderScore{Provider: p.Name()}
+	}
+	return &FailoverProvider{
+		providers: providers,
+		recorder:  recorder,
+		projectID: projectID,
+		scores:    scores,
+	}
+}
+
+// Name returns a composite name.
+func (f *FailoverProvider) Name() string {
+	if len(f.providers) == 1 {
+		return f.providers[0].Name()
+	}
+	return f.providers[0].Name() + "+failover"
+}
+
+// Complete tries each provider in order until one succeeds.
+// Providers are dynamically reordered by their cost/reliability score.
+func (f *FailoverProvider) Complete(ctx context.Context, req *Request) (*Response, error) {
+	ordered := f.orderedProviders()
+
+	var lastErr error
+	for i, prov := range ordered {
+		start := time.Now()
+		resp, err := prov.Complete(ctx, req)
+		latencyMs := time.Since(start).Milliseconds()
+
+		if err == nil {
+			f.recordSuccess(prov.Name(), req.Model, latencyMs, resp.InputToks, resp.OutputToks)
+			return resp, nil
+		}
+
+		lastErr = err
+		f.recordError(prov.Name(), req.Model, latencyMs, err)
+
+		// Don't retry on context cancellation.
+		if ctx.Err() != nil {
+			break
+		}
+
+		// Last provider — don't retry.
+		if i == len(ordered)-1 {
+			break
+		}
+	}
+
+	return nil, fmt.Errorf("all providers failed: %w", lastErr)
+}
+
+// Stats returns a snapshot of current provider scores.
+func (f *FailoverProvider) Stats() []ProviderScore {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make([]ProviderScore, 0, len(f.scores))
+	for _, s := range f.scores {
+		result = append(result, *s)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].score() < result[j].score()
+	})
+	return result
+}
+
+// orderedProviders returns providers sorted by score (best first).
+func (f *FailoverProvider) orderedProviders() []Provider {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Copy and sort by score.
+	ordered := make([]Provider, len(f.providers))
+	copy(ordered, f.providers)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		si := f.scores[ordered[i].Name()]
+		sj := f.scores[ordered[j].Name()]
+		return si.score() < sj.score()
+	})
+	return ordered
+}
+
+func (f *FailoverProvider) recordSuccess(provider, model string, latencyMs int64, inputToks, outputToks int) {
+	cost := LookupCost(model).Cost(inputToks, outputToks)
+
+	f.mu.Lock()
+	if s, ok := f.scores[provider]; ok {
+		s.SuccessCount++
+		s.TotalCostUSD += cost
+	}
+	f.mu.Unlock()
+
+	if f.recorder != nil {
+		_ = f.recorder.RecordProviderCall(f.projectID, provider, model, latencyMs, inputToks, outputToks, nil)
+	}
+}
+
+func (f *FailoverProvider) recordError(provider, model string, latencyMs int64, err error) {
+	f.mu.Lock()
+	if s, ok := f.scores[provider]; ok {
+		s.ErrorCount++
+	}
+	f.mu.Unlock()
+
+	if f.recorder != nil {
+		_ = f.recorder.RecordProviderCall(f.projectID, provider, model, latencyMs, 0, 0, err)
+	}
+}

--- a/internal/llm/failover_test.go
+++ b/internal/llm/failover_test.go
@@ -1,0 +1,202 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockProvider implements Provider for testing.
+type mockProvider struct {
+	name  string
+	resp  *Response
+	err   error
+	calls int
+}
+
+func (m *mockProvider) Name() string { return m.name }
+func (m *mockProvider) Complete(_ context.Context, _ *Request) (*Response, error) {
+	m.calls++
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.resp, nil
+}
+
+// mockRecorder captures RecordProviderCall invocations.
+type mockRecorder struct {
+	calls []recordCall
+}
+type recordCall struct {
+	provider string
+	model    string
+	err      error
+}
+
+func (r *mockRecorder) RecordProviderCall(_ int64, provider, model string, _ int64, _, _ int, callErr error) error {
+	r.calls = append(r.calls, recordCall{provider, model, callErr})
+	return nil
+}
+
+func TestFailoverProvider_PrimarySucceeds(t *testing.T) {
+	primary := &mockProvider{name: "primary", resp: &Response{Content: "hello", InputToks: 10, OutputToks: 5}}
+	fallback := &mockProvider{name: "fallback", resp: &Response{Content: "fallback-hello"}}
+	rec := &mockRecorder{}
+
+	fp := NewFailoverProvider([]Provider{primary, fallback}, rec, 1)
+	resp, err := fp.Complete(context.Background(), &Request{Model: "test-model"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "hello" {
+		t.Errorf("got %q, want %q", resp.Content, "hello")
+	}
+	if primary.calls != 1 {
+		t.Errorf("primary calls = %d, want 1", primary.calls)
+	}
+	if fallback.calls != 0 {
+		t.Errorf("fallback calls = %d, want 0", fallback.calls)
+	}
+	if len(rec.calls) != 1 || rec.calls[0].provider != "primary" || rec.calls[0].err != nil {
+		t.Errorf("recorder calls = %+v, want 1 success for primary", rec.calls)
+	}
+}
+
+func TestFailoverProvider_PrimaryFails(t *testing.T) {
+	primary := &mockProvider{name: "primary", err: errors.New("rate limited")}
+	fallback := &mockProvider{name: "fallback", resp: &Response{Content: "fallback-ok"}}
+	rec := &mockRecorder{}
+
+	fp := NewFailoverProvider([]Provider{primary, fallback}, rec, 1)
+	resp, err := fp.Complete(context.Background(), &Request{Model: "test-model"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "fallback-ok" {
+		t.Errorf("got %q, want %q", resp.Content, "fallback-ok")
+	}
+	if primary.calls != 1 {
+		t.Errorf("primary calls = %d, want 1", primary.calls)
+	}
+	if fallback.calls != 1 {
+		t.Errorf("fallback calls = %d, want 1", fallback.calls)
+	}
+	// Should have 2 recorder calls: error for primary, success for fallback.
+	if len(rec.calls) != 2 {
+		t.Fatalf("recorder calls = %d, want 2", len(rec.calls))
+	}
+	if rec.calls[0].err == nil {
+		t.Error("expected error recorded for primary")
+	}
+	if rec.calls[1].err != nil {
+		t.Error("expected success recorded for fallback")
+	}
+}
+
+func TestFailoverProvider_AllFail(t *testing.T) {
+	primary := &mockProvider{name: "primary", err: errors.New("err1")}
+	fallback := &mockProvider{name: "fallback", err: errors.New("err2")}
+
+	fp := NewFailoverProvider([]Provider{primary, fallback}, nil, 1)
+	_, err := fp.Complete(context.Background(), &Request{Model: "test-model"})
+	if err == nil {
+		t.Fatal("expected error when all providers fail")
+	}
+	if !errors.Is(err, fallback.err) {
+		t.Errorf("got %v, want wrapped %v", err, fallback.err)
+	}
+}
+
+func TestFailoverProvider_DynamicReorder(t *testing.T) {
+	// After primary accumulates errors, fallback should be tried first.
+	primary := &mockProvider{name: "primary", err: errors.New("always fails")}
+	fallback := &mockProvider{name: "fallback", resp: &Response{Content: "ok"}}
+
+	fp := NewFailoverProvider([]Provider{primary, fallback}, nil, 1)
+
+	// First call: primary fails, fallback succeeds.
+	_, _ = fp.Complete(context.Background(), &Request{Model: "m"})
+
+	// Now primary has 1 error, fallback has 1 success.
+	// Fix primary so we can see reordering.
+	primary.err = nil
+	primary.resp = &Response{Content: "primary-ok"}
+
+	// Reset call counts.
+	primary.calls = 0
+	fallback.calls = 0
+
+	// Second call: fallback should be tried first (lower score).
+	resp, err := fp.Complete(context.Background(), &Request{Model: "m"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Fallback should be first because primary has worse score.
+	if resp.Content != "ok" {
+		t.Errorf("expected fallback to be tried first, got %q", resp.Content)
+	}
+	if fallback.calls != 1 {
+		t.Errorf("fallback calls = %d, want 1", fallback.calls)
+	}
+	if primary.calls != 0 {
+		t.Errorf("primary calls = %d, want 0 (should not be reached)", primary.calls)
+	}
+}
+
+func TestFailoverProvider_SingleProvider(t *testing.T) {
+	p := &mockProvider{name: "solo", resp: &Response{Content: "ok"}}
+	fp := NewFailoverProvider([]Provider{p}, nil, 1)
+
+	if fp.Name() != "solo" {
+		t.Errorf("name = %q, want %q", fp.Name(), "solo")
+	}
+
+	resp, err := fp.Complete(context.Background(), &Request{Model: "m"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Errorf("got %q, want %q", resp.Content, "ok")
+	}
+}
+
+func TestFailoverProvider_Stats(t *testing.T) {
+	primary := &mockProvider{name: "primary", resp: &Response{Content: "ok", InputToks: 100, OutputToks: 50}}
+	fp := NewFailoverProvider([]Provider{primary}, nil, 1)
+
+	_, _ = fp.Complete(context.Background(), &Request{Model: "claude-haiku-4-5"})
+	_, _ = fp.Complete(context.Background(), &Request{Model: "claude-haiku-4-5"})
+
+	stats := fp.Stats()
+	if len(stats) != 1 {
+		t.Fatalf("stats len = %d, want 1", len(stats))
+	}
+	if stats[0].SuccessCount != 2 {
+		t.Errorf("success count = %d, want 2", stats[0].SuccessCount)
+	}
+	if stats[0].TotalCostUSD <= 0 {
+		t.Errorf("total cost should be > 0, got %f", stats[0].TotalCostUSD)
+	}
+}
+
+func TestLookupCost(t *testing.T) {
+	c := LookupCost("claude-haiku-4-5")
+	if c.InputPerMTok == 0 {
+		t.Error("expected non-zero cost for claude-haiku-4-5")
+	}
+
+	// Unknown model returns zero cost.
+	c2 := LookupCost("unknown-model")
+	if c2.InputPerMTok != 0 || c2.OutputPerMTok != 0 {
+		t.Error("expected zero cost for unknown model")
+	}
+}
+
+func TestModelCost_Cost(t *testing.T) {
+	c := ModelCost{InputPerMTok: 1.0, OutputPerMTok: 2.0}
+	cost := c.Cost(1_000_000, 500_000)
+	expected := 1.0 + 1.0 // 1M input * $1/M + 500K output * $2/M
+	if cost != expected {
+		t.Errorf("cost = %f, want %f", cost, expected)
+	}
+}

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/dustinlange/agent-minder/internal/db"
+	"github.com/dustinlange/agent-minder/internal/llm"
 )
 
 // View renders the TUI dashboard with height-budgeted sections.
@@ -116,6 +117,12 @@ func (m Model) renderOperationsTab() string {
 		}
 	}
 
+	// Provider stats (if any).
+	if stats := m.renderProviderStats(); stats != "" {
+		b.WriteString(stats)
+		b.WriteString("\n")
+	}
+
 	// Event log section.
 	b.WriteString(headerStyle().Render("Event Log"))
 	scrollHint := ""
@@ -129,6 +136,45 @@ func (m Model) renderOperationsTab() string {
 	b.WriteString("\n")
 	b.WriteString(m.eventLogVP.View())
 	b.WriteString("\n")
+
+	return b.String()
+}
+
+// renderProviderStats renders a compact line of provider stats if available.
+func (m Model) renderProviderStats() string {
+	stats, err := m.store.GetProviderStats(m.project.ID)
+	if err != nil || len(stats) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(headerStyle().Render("Provider Stats"))
+	b.WriteString("\n")
+
+	for _, s := range stats {
+		total := s.SuccessCount + s.ErrorCount
+		if total == 0 {
+			continue
+		}
+		cost := llm.LookupCost(s.Model)
+		totalCost := cost.Cost(int(s.TotalInputToks), int(s.TotalOutputToks))
+
+		line := fmt.Sprintf("  %s/%s: %d calls, %.1f%% err, %.0fms avg, $%.4f total",
+			s.Provider, s.Model,
+			total,
+			s.ErrorRate()*100,
+			s.AvgLatencyMs(),
+			totalCost,
+		)
+		if s.ErrorRate() > 0.5 {
+			b.WriteString(concernDangerStyle().Render(line))
+		} else if s.ErrorRate() > 0.1 {
+			b.WriteString(concernWarningStyle().Render(line))
+		} else {
+			b.WriteString(mutedStyle().Render(line))
+		}
+		b.WriteString("\n")
+	}
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary
- Add `FailoverProvider` in `internal/llm` that wraps multiple LLM providers and retries with fallback providers on failure
- Track per-provider, per-model stats (latency, error rates, token usage, cost) with dynamic reordering based on composite score (error rate + cost)
- Persist stats to new `provider_stats` table (schema v12) and display them in the TUI operations tab with color-coded error rate indicators

## Test plan
- [x] Unit tests for FailoverProvider: primary success, primary fail + fallback, all fail, dynamic reorder, single provider, stats tracking
- [x] Unit tests for model cost lookup
- [x] All existing tests pass (db, llm, poller, msgbus)
- [x] Build compiles cleanly
- [x] Pre-commit hooks (fmt, vet, build) pass
- [ ] Manual test: configure `llm_fallback_provider` on a project and verify failover behavior
- [ ] Manual test: verify provider stats appear in TUI after LLM calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)