### PR TITLE
Add complexity pre-check to agent prompt

### DIFF
--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -29,6 +29,19 @@ func renderPrompt(task *db.AutopilotTask, baseBranch, owner, repo string) string
 	b.WriteString("3. Read the full issue and any linked issues for context\n")
 	b.WriteString("4. Explore the codebase to understand the relevant code\n\n")
 
+	b.WriteString("## Pre-check: assess complexity before writing any code\n\n")
+	b.WriteString("After exploring the codebase but BEFORE making any changes, assess this task:\n")
+	b.WriteString("- How many files will need to change?\n")
+	b.WriteString("- Does this require architectural decisions or design trade-offs?\n")
+	b.WriteString("- Is this a cross-cutting refactor that touches many subsystems?\n\n")
+	b.WriteString("If ANY of the following are true, do NOT proceed with implementation:\n")
+	b.WriteString("- The change requires modifying more than 8 files\n")
+	b.WriteString("- The task requires significant architectural decisions not specified in the issue\n")
+	b.WriteString("- You are unsure how the pieces fit together after exploring the code\n\n")
+	b.WriteString("Instead, bail immediately: skip to the \"If you cannot proceed\" section below.\n")
+	b.WriteString("In your bail comment, include a detailed implementation plan with the specific files and changes needed,\n")
+	b.WriteString("so a human (or a future agent session with more context) can pick it up.\n\n")
+
 	b.WriteString("## Your decision\n\n")
 	b.WriteString("After exploring, decide:\n\n")
 

--- a/internal/autopilot/prompt_test.go
+++ b/internal/autopilot/prompt_test.go
@@ -32,6 +32,12 @@ func TestRenderPrompt(t *testing.T) {
 		"--add-label \"in-progress\"",
 		"--add-label \"blocked\"",
 		"-R myorg/myrepo",
+		"Pre-check: assess complexity",
+		"BEFORE making any changes",
+		"more than 8 files",
+		"architectural decisions",
+		"bail immediately",
+		"detailed implementation plan",
 	}
 
 	for _, check := range checks {


### PR DESCRIPTION
## Summary
- Agents now assess task complexity after exploring the codebase but before writing any code
- If the task exceeds thresholds (>8 files, unspecified architectural decisions, unclear fit), the agent bails immediately with a detailed implementation plan
- Prevents wasted turns on tasks too complex for autonomous work (ref: #122 incident)

Fixes #123

## Test plan
- [x] Existing prompt tests updated with 6 new assertions — all pass
- [x] Full test suite passes
- [x] Verify in a live autopilot run that agents bail on complex tasks with useful plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)