### PR TITLE
Agent log viewer overlay (#131)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -220,6 +220,15 @@ type Model struct {
 	// Help overlay.
 	showHelp bool
 
+	// Log viewer overlay.
+	showLogViewer     bool
+	logViewerTask     *db.AutopilotTask
+	logViewerVP       viewport.Model
+	logViewerContent  string
+	logViewerFileSize int64
+	logViewerAtBottom bool
+	logViewerStatus   string
+
 	// Warning banner (persistent, dismissible with 'w').
 	warningBanner string
 }
@@ -329,6 +338,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.resizeViewports()
+		if m.showLogViewer {
+			m.logViewerVP.SetWidth(m.width)
+			m.logViewerVP.SetHeight(m.height - 4)
+		}
 		return m, nil
 
 	case tea.KeyPressMsg:
@@ -345,6 +358,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 			m.rebuildEventLogContent()
 			// Fall through to handle the keypress normally.
+		}
+
+		// Log viewer overlay captures all keys when open.
+		if m.showLogViewer {
+			return m.updateLogViewer(msg)
 		}
 
 		switch m.mode {
@@ -594,6 +612,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case clearAutopilotStatusMsg:
 		m.autopilotStatus = ""
+		return m, nil
+
+	case logRefreshMsg:
+		if !m.showLogViewer {
+			return m, nil
+		}
+		m.refreshLogContent()
+		// Check if task is still running (refresh task status from our list).
+		stillRunning := false
+		if m.logViewerTask != nil {
+			for _, t := range m.autopilotTasks {
+				if t.IssueNumber == m.logViewerTask.IssueNumber {
+					m.logViewerTask.Status = t.Status
+					stillRunning = t.Status == "running"
+					break
+				}
+			}
+		}
+		if stillRunning {
+			return m, logRefreshTick()
+		}
+		return m, nil
+
+	case clearLogViewerStatusMsg:
+		m.logViewerStatus = ""
 		return m, nil
 
 	case filterChoicesMsg:
@@ -1092,13 +1135,18 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		task := m.selectedAutopilotTask()
-		if task == nil || task.AgentLog == "" {
+		if task == nil {
 			return m, nil
 		}
-		m.autopilotStatus = "Log viewer coming soon — log at: " + task.AgentLog
-		return m, tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
-			return clearAutopilotStatusMsg{}
-		})
+		if task.AgentLog == "" {
+			m.autopilotStatus = "No log available for this task"
+			return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+				return clearAutopilotStatusMsg{}
+			})
+		}
+		taskCopy := *task
+		cmd := m.openLogViewer(&taskCopy)
+		return m, cmd
 
 	case "D":
 		if m.activeTab != tabAutopilot || (m.autopilotMode != "running" && m.autopilotMode != "completed") {
@@ -1118,6 +1166,26 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return clearAutopilotStatusMsg{}
 		})
 	}
+	return m, nil
+}
+
+func (m Model) updateLogViewer(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.closeLogViewer()
+		m.resizeViewports()
+		return m, nil
+	case "c":
+		cmd := m.copyLogPath()
+		return m, cmd
+	case "up", "down", "pgup", "pgdown":
+		var cmd tea.Cmd
+		m.logViewerVP, cmd = m.logViewerVP.Update(msg)
+		// Track whether user is at the bottom for auto-scroll.
+		m.logViewerAtBottom = m.logViewerVP.AtBottom()
+		return m, cmd
+	}
+	// Swallow all other keys — modal overlay.
 	return m, nil
 }
 

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -38,6 +38,14 @@ func (m Model) View() tea.View {
 		b.WriteString("\n")
 	}
 
+	// Log viewer overlay: full-screen modal that replaces all tab content.
+	if m.showLogViewer {
+		b.WriteString(m.renderLogViewerOverlay())
+		v := tea.NewView(b.String())
+		v.AltScreen = true
+		return v
+	}
+
 	// Tab content: modal modes overlay tab content.
 	if m.mode == "settings" {
 		b.WriteString(m.renderSettingsView())

--- a/internal/tui/logviewer.go
+++ b/internal/tui/logviewer.go
@@ -1,0 +1,395 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/dustinlange/agent-minder/internal/db"
+)
+
+// logRefreshMsg triggers periodic re-read of the agent log file.
+type logRefreshMsg struct{}
+
+// openLogViewer opens the log viewer overlay for the given task.
+func (m *Model) openLogViewer(task *db.AutopilotTask) tea.Cmd {
+	if task == nil || task.AgentLog == "" {
+		return nil
+	}
+
+	m.showLogViewer = true
+	m.logViewerTask = task
+
+	// Create viewport for the log content.
+	vp := viewport.New()
+	vp.KeyMap = safeViewportKeyMap()
+	vp.SoftWrap = true
+	vp.FillHeight = true
+	vp.SetWidth(m.width)
+	vp.SetHeight(m.height - 4) // header + separator + footer
+	m.logViewerVP = vp
+
+	// Read the initial log content.
+	m.loadLogContent()
+
+	// Auto-scroll to bottom.
+	m.logViewerVP.GotoBottom()
+	m.logViewerAtBottom = true
+
+	// Start auto-refresh tick if task is running.
+	if task.Status == "running" {
+		return logRefreshTick()
+	}
+	return nil
+}
+
+// closeLogViewer closes the log viewer overlay.
+func (m *Model) closeLogViewer() {
+	m.showLogViewer = false
+	m.logViewerTask = nil
+	m.logViewerContent = ""
+	m.logViewerFileSize = 0
+	m.logViewerAtBottom = true
+}
+
+// loadLogContent reads the log file and sets viewport content.
+func (m *Model) loadLogContent() {
+	if m.logViewerTask == nil || m.logViewerTask.AgentLog == "" {
+		m.logViewerContent = "No log available"
+		m.logViewerVP.SetContent(m.logViewerContent)
+		return
+	}
+
+	data, err := os.ReadFile(m.logViewerTask.AgentLog)
+	if err != nil {
+		m.logViewerContent = fmt.Sprintf("Error reading log: %v", err)
+		m.logViewerVP.SetContent(m.logViewerContent)
+		return
+	}
+
+	m.logViewerFileSize = int64(len(data))
+	content := string(data)
+
+	// Auto-detect format and render.
+	if isJSONL(content) {
+		m.logViewerContent = renderJSONL(content)
+	} else {
+		m.logViewerContent = renderPlainLog(content)
+	}
+	m.logViewerVP.SetContent(m.logViewerContent)
+}
+
+// refreshLogContent incrementally reads new content if the file has grown.
+func (m *Model) refreshLogContent() {
+	if m.logViewerTask == nil || m.logViewerTask.AgentLog == "" {
+		return
+	}
+
+	info, err := os.Stat(m.logViewerTask.AgentLog)
+	if err != nil {
+		return
+	}
+
+	// No change in size — skip.
+	if info.Size() == m.logViewerFileSize {
+		return
+	}
+
+	// Track scroll position before refresh.
+	wasAtBottom := m.logViewerAtBottom
+
+	// Re-read the full file (simpler than offset-based for formatted output).
+	m.loadLogContent()
+
+	// Restore scroll position.
+	if wasAtBottom {
+		m.logViewerVP.GotoBottom()
+	}
+}
+
+// logRefreshTick returns a command that fires a logRefreshMsg after 2 seconds.
+func logRefreshTick() tea.Cmd {
+	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+		return logRefreshMsg{}
+	})
+}
+
+// copyLogPath copies the log file path to the clipboard.
+func (m *Model) copyLogPath() tea.Cmd {
+	if m.logViewerTask == nil || m.logViewerTask.AgentLog == "" {
+		return nil
+	}
+
+	cmd := exec.Command("pbcopy")
+	cmd.Stdin = strings.NewReader(m.logViewerTask.AgentLog)
+	if err := cmd.Run(); err != nil {
+		m.logViewerStatus = fmt.Sprintf("Copy failed: %v", err)
+	} else {
+		m.logViewerStatus = fmt.Sprintf("Copied: %s", m.logViewerTask.AgentLog)
+	}
+	return tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+		return clearLogViewerStatusMsg{}
+	})
+}
+
+// clearLogViewerStatusMsg clears the log viewer status flash.
+type clearLogViewerStatusMsg struct{}
+
+// isJSONL checks if the content looks like JSONL by trying to parse the first non-empty line.
+func isJSONL(content string) bool {
+	for _, line := range strings.SplitN(content, "\n", 10) {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var obj map[string]any
+		return json.Unmarshal([]byte(line), &obj) == nil
+	}
+	return false
+}
+
+// renderPlainLog renders plain text log with basic styling.
+// Dims timestamp-like prefixes and highlights error lines.
+func renderPlainLog(content string) string {
+	lines := strings.Split(content, "\n")
+	var b strings.Builder
+	errorStyle := lipgloss.NewStyle().Foreground(currentTheme().Error)
+	dimStyle := lipgloss.NewStyle().Foreground(currentTheme().Muted)
+
+	for _, line := range lines {
+		if line == "" {
+			b.WriteString("\n")
+			continue
+		}
+
+		// Highlight error-like lines.
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "error") || strings.Contains(lower, "panic") ||
+			strings.Contains(lower, "fatal") || strings.Contains(lower, "failed") {
+			b.WriteString(errorStyle.Render(line))
+			b.WriteString("\n")
+			continue
+		}
+
+		// Dim timestamp prefixes (e.g., "2024-01-15T10:30:00Z" or "[10:30:00]").
+		styled := dimTimestamp(line, dimStyle)
+		b.WriteString(styled)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// dimTimestamp dims a leading timestamp in a log line.
+func dimTimestamp(line string, dimStyle lipgloss.Style) string {
+	// ISO timestamp: "2024-01-15T10:30:00Z ..." or "2024-01-15T10:30:00.123Z ..."
+	if len(line) > 20 && (line[4] == '-' && line[7] == '-' && line[10] == 'T') {
+		// Find the end of the timestamp (space after it).
+		for i := 10; i < len(line) && i < 35; i++ {
+			if line[i] == ' ' {
+				return dimStyle.Render(line[:i]) + line[i:]
+			}
+		}
+	}
+
+	// Bracketed time: "[10:30:00] ..."
+	if len(line) > 10 && line[0] == '[' {
+		for i := 1; i < len(line) && i < 25; i++ {
+			if line[i] == ']' {
+				return dimStyle.Render(line[:i+1]) + line[i+1:]
+			}
+		}
+	}
+
+	return line
+}
+
+// jsonlEvent represents a parsed JSONL log event from stream-json output.
+type jsonlEvent struct {
+	Type      string  `json:"type"`       // "assistant", "result", "system", etc.
+	Subtype   string  `json:"subtype"`    // "tool_use", "text", etc.
+	Tool      string  `json:"tool"`       // tool name for tool_use events
+	Input     string  `json:"input"`      // tool input summary
+	Text      string  `json:"text"`       // text content
+	Turns     int     `json:"num_turns"`  // for result events
+	Cost      float64 `json:"total_cost"` // for result events
+	Duration  int     `json:"duration_s"` // for result events
+	Timestamp string  `json:"timestamp"`  // ISO timestamp
+	Error     string  `json:"error"`      // error message
+}
+
+// renderJSONL renders JSONL log content with formatted, color-coded display.
+func renderJSONL(content string) string {
+	lines := strings.Split(content, "\n")
+	theme := currentTheme()
+
+	toolStyle := lipgloss.NewStyle().Foreground(theme.Secondary)
+	textStyle := lipgloss.NewStyle().Foreground(theme.Text)
+	resultStyle := lipgloss.NewStyle().Foreground(theme.Success)
+	errorStyle := lipgloss.NewStyle().Foreground(theme.Error)
+	dimStyle := lipgloss.NewStyle().Foreground(theme.Muted)
+	turnStyle := lipgloss.NewStyle().Foreground(theme.Muted).Width(4).Align(lipgloss.Right)
+
+	var b strings.Builder
+	turnNum := 0
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var evt jsonlEvent
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			// Malformed line — render dimmed.
+			b.WriteString(dimStyle.Render(truncateLine(line, 120)))
+			b.WriteString("\n")
+			continue
+		}
+
+		ts := formatTimestamp(evt.Timestamp)
+
+		switch evt.Type {
+		case "assistant":
+			if evt.Subtype == "tool_use" || evt.Tool != "" {
+				turnNum++
+				toolName := evt.Tool
+				if toolName == "" {
+					toolName = "tool"
+				}
+				detail := evt.Input
+				if len(detail) > 80 {
+					detail = detail[:77] + "..."
+				}
+				fmt.Fprintf(&b, "%s  %s  %s  %s\n",
+					dimStyle.Render(ts),
+					turnStyle.Render(fmt.Sprintf("%d", turnNum)),
+					toolStyle.Render(fmt.Sprintf("%-12s", toolName)),
+					textStyle.Render(detail))
+			} else if evt.Text != "" {
+				text := evt.Text
+				if len(text) > 80 {
+					text = text[:77] + "..."
+				}
+				fmt.Fprintf(&b, "%s       %s\n",
+					dimStyle.Render(ts),
+					textStyle.Render(text))
+			}
+
+		case "result":
+			fmt.Fprintf(&b, "%s       %s\n",
+				dimStyle.Render(ts),
+				resultStyle.Render(fmt.Sprintf("✓ Completed — %d turns, $%.2f, %ds",
+					evt.Turns, evt.Cost, evt.Duration)))
+
+		case "error":
+			msg := evt.Error
+			if msg == "" {
+				msg = evt.Text
+			}
+			if msg == "" {
+				msg = "unknown error"
+			}
+			fmt.Fprintf(&b, "%s       %s\n",
+				dimStyle.Render(ts),
+				errorStyle.Render("✗ "+msg))
+
+		default:
+			// Other event types — single dim line.
+			summary := evt.Type
+			if evt.Subtype != "" {
+				summary += "/" + evt.Subtype
+			}
+			if evt.Text != "" {
+				text := evt.Text
+				if len(text) > 60 {
+					text = text[:57] + "..."
+				}
+				summary += ": " + text
+			}
+			fmt.Fprintf(&b, "%s       %s\n",
+				dimStyle.Render(ts),
+				dimStyle.Render(summary))
+		}
+	}
+
+	return b.String()
+}
+
+// formatTimestamp extracts a compact time from an ISO timestamp.
+func formatTimestamp(ts string) string {
+	if ts == "" {
+		return "        "
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		// Try other common formats.
+		t, err = time.Parse("2006-01-02T15:04:05.000Z", ts)
+		if err != nil {
+			if len(ts) > 8 {
+				return ts[:8]
+			}
+			return ts
+		}
+	}
+	return t.Format("15:04:05")
+}
+
+// renderLogViewerOverlay renders the full-screen log viewer.
+func (m Model) renderLogViewerOverlay() string {
+	if m.logViewerTask == nil {
+		return ""
+	}
+
+	var b strings.Builder
+
+	// Header.
+	title := fmt.Sprintf("Agent Log: #%d — %s",
+		m.logViewerTask.IssueNumber,
+		truncateLine(m.logViewerTask.IssueTitle, m.width-40))
+	closeHint := mutedStyle().Render("[q: close]")
+
+	headerText := headerStyle().Render(title)
+	// Right-align close hint.
+	padding := m.width - lipgloss.Width(headerText) - lipgloss.Width(closeHint) - 2
+	if padding < 2 {
+		padding = 2
+	}
+	b.WriteString(headerText)
+	b.WriteString(strings.Repeat(" ", padding))
+	b.WriteString(closeHint)
+	b.WriteString("\n")
+
+	// Separator.
+	sep := strings.Repeat("─", m.width)
+	b.WriteString(mutedStyle().Render(sep))
+	b.WriteString("\n")
+
+	// Viewport content.
+	b.WriteString(m.logViewerVP.View())
+	b.WriteString("\n")
+
+	// Footer.
+	var footer strings.Builder
+	path := mutedStyle().Render(m.logViewerTask.AgentLog)
+	footer.WriteString("  ")
+	footer.WriteString(path)
+
+	hints := mutedStyle().Render("  c: copy path  ↑/↓/pgup/pgdn: scroll")
+	footer.WriteString(hints)
+
+	if m.logViewerStatus != "" {
+		footer.WriteString("  ")
+		footer.WriteString(broadcastStyle().Render(m.logViewerStatus))
+	}
+
+	b.WriteString(footer.String())
+
+	return b.String()
+}

--- a/internal/tui/logviewer_test.go
+++ b/internal/tui/logviewer_test.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsJSONL(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"empty", "", false},
+		{"plain text", "hello world\nfoo bar", false},
+		{"single json line", `{"type":"assistant","tool":"Read"}`, true},
+		{"jsonl with blank lines", "\n" + `{"type":"result"}` + "\n", true},
+		{"invalid json", `{not json}`, false},
+		{"mixed content starting with json", `{"type":"system"}` + "\nplain text", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isJSONL(tt.content); got != tt.want {
+				t.Errorf("isJSONL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatTimestamp(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "        "},
+		{"2024-01-15T10:30:00Z", "10:30:00"},
+		{"2024-01-15T10:30:00+00:00", "10:30:00"},
+		{"short", "short"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := formatTimestamp(tt.input); got != tt.want {
+				t.Errorf("formatTimestamp(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderPlainLog(t *testing.T) {
+	content := "normal line\nERROR: something failed\n\nanother line"
+	result := renderPlainLog(content)
+
+	// Should contain all lines.
+	if !strings.Contains(result, "normal line") {
+		t.Error("expected normal line in output")
+	}
+	if !strings.Contains(result, "something failed") {
+		t.Error("expected error line in output")
+	}
+	if !strings.Contains(result, "another line") {
+		t.Error("expected another line in output")
+	}
+}
+
+func TestRenderJSONL(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","subtype":"tool_use","tool":"Read","input":"internal/foo.go","timestamp":"2024-01-15T10:30:00Z"}`,
+		`{"type":"assistant","text":"Looking at the code...","timestamp":"2024-01-15T10:30:05Z"}`,
+		`{"type":"result","num_turns":12,"total_cost":0.08,"duration_s":180,"timestamp":"2024-01-15T10:35:00Z"}`,
+		`{"type":"error","error":"rate limited","timestamp":"2024-01-15T10:36:00Z"}`,
+		`not json at all`,
+	}
+	content := strings.Join(lines, "\n")
+
+	result := renderJSONL(content)
+
+	if !strings.Contains(result, "Read") {
+		t.Error("expected tool name 'Read' in output")
+	}
+	if !strings.Contains(result, "Looking at the code") {
+		t.Error("expected text content in output")
+	}
+	if !strings.Contains(result, "Completed") {
+		t.Error("expected result line in output")
+	}
+	if !strings.Contains(result, "rate limited") {
+		t.Error("expected error message in output")
+	}
+}
+
+func TestDimTimestamp(t *testing.T) {
+	// We can't easily test ANSI output, but we can test that the function doesn't panic.
+	dimStyle := mutedStyle()
+
+	tests := []string{
+		"plain text no timestamp",
+		"2024-01-15T10:30:00Z some log line",
+		"[10:30:00] bracketed timestamp",
+		"short",
+		"",
+	}
+
+	for _, input := range tests {
+		result := dimTimestamp(input, dimStyle)
+		if result == "" && input != "" {
+			t.Errorf("dimTimestamp(%q) returned empty string", input)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Full-screen modal overlay for viewing agent logs from the autopilot tab task list
- Auto-detects plain text vs JSONL format with styled, color-coded rendering
- Auto-refreshes every 2s while the agent is running, preserving scroll position
- `c` copies log file path to clipboard for use with `tail -f` or `lnav`

Closes #131
Parent: #122

## Manual test plan

### Setup
```bash
source scripts/test-env.sh <project-name>
go run . start "$MINDER_PROJECT"
```

### Basic overlay
- [x] Navigate to Autopilot tab (press `3`)
- [x] Launch autopilot (`a` → `enter` → `enter`)
- [x] Wait for a task to start running, select it with `↑/↓`
- [x] Press `l` — log viewer overlay should open full-screen
- [x] Verify header shows `Agent Log: #N — Issue Title` with `[q: close]`
- [x] Verify separator line below header
- [x] Verify log content is displayed and auto-scrolled to bottom
- [x] Verify footer shows file path and key hints

### Scrolling
- [ ] Use `↑/↓` and `pgup/pgdn` to scroll through log content
- [ ] Scroll up from bottom — new content should NOT auto-scroll you down
- [ ] Scroll back to bottom — new content SHOULD auto-scroll

### Auto-refresh (running tasks)
- [ ] Open log on a running task — content should update every ~2s
- [ ] When task completes, auto-refresh should stop

### Copy path
- [ ] Press `c` — should show "Copied: ~/.agent-minder/agents/..." flash
- [ ] Verify path is in clipboard (`pbpaste` in another terminal)

### Close
- [ ] Press `q` or `esc` — overlay closes, returns to task list

### Edge cases
- [ ] Select a queued/blocked task with no log → press `l` → should show "No log available" status
- [ ] Select a completed/bailed task with a log → press `l` → should open viewer (no auto-refresh)
- [ ] Press `l` when not on autopilot tab → no effect

### Plain text rendering
- [ ] Lines containing "error", "panic", "fatal", "failed" should be red
- [ ] ISO timestamps at line start should be dimmed

### JSONL rendering (future — when stream-json lands)
- [ ] Tool use events: `HH:MM:SS  N  ToolName    input`
- [ ] Text events: `HH:MM:SS       "text content..."`
- [ ] Result events: `HH:MM:SS       ✓ Completed — N turns, $X.XX, Ns`
- [ ] Error events in red with ✗ prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)