### PR TITLE
Add Doppler config for secrets management

### DIFF
--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,3 @@
+setup:
+  project: agent-minder
+  config: dev_personal


### PR DESCRIPTION
## Summary
- Adds `doppler.yaml` pointing to `agent-minder/dev_personal` config
- Enables `doppler run --` for injecting provider API keys (DeepInfra, etc.) during development and integration testing
- Prerequisite for #70 (OpenAI-compatible provider testing)

## Test plan
- [x] `doppler setup --no-interactive` works from repo root
- [x] `doppler secrets --only-names` shows `DEEPINFRA_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)