### PR TITLE
Add autopilot metrics collection

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -981,9 +981,20 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 	stoppedByUser := s.slots[slotIdx] != nil && s.slots[slotIdx].stoppedByUser
 	s.mu.Unlock()
 
+	// Capture metrics from slot state before it gets cleared by the defer.
+	s.mu.Lock()
+	var durationSec int
+	var costUSD float64
+	if s.slots[slotIdx] != nil {
+		durationSec = int(time.Since(s.slots[slotIdx].startedAt).Seconds())
+		costUSD = s.slots[slotIdx].liveStatus.CostUSD
+	}
+	s.mu.Unlock()
+
 	if stoppedByUser {
 		// User-initiated stop: set stopped status, preserve worktree for investigation.
 		_ = s.store.UpdateAutopilotTaskStatus(task.ID, "stopped")
+		s.recordMetrics(task, durationSec, costUSD, "stopped")
 		s.emitEvent("stopped", fmt.Sprintf("Agent stopped by user on #%d", task.IssueNumber), task)
 		return
 	}
@@ -991,6 +1002,7 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 	// Inspect outcome.
 	status := s.inspectOutcome(ctx, task, exitCode)
 	_ = s.store.UpdateAutopilotTaskStatus(task.ID, status)
+	s.recordMetrics(task, durationSec, costUSD, status)
 
 	if status == "review" {
 		// Swap in-progress → needs-review label on the issue.
@@ -1057,6 +1069,21 @@ func (s *Supervisor) cleanup(task *db.AutopilotTask, deleteBranch bool) {
 	// Delete branch only if bailed (keep if PR opened).
 	if deleteBranch {
 		_ = gitpkg.DeleteBranch(s.repoDir, task.Branch)
+	}
+}
+
+// recordMetrics persists per-task metrics after an agent finishes.
+func (s *Supervisor) recordMetrics(task *db.AutopilotTask, durationSec int, costUSD float64, outcome string) {
+	m := &db.AutopilotMetric{
+		TaskID:      task.ID,
+		ProjectID:   task.ProjectID,
+		DurationSec: durationSec,
+		TokensUsed:  0, // not available from stream-json; reserved for future use
+		CostUSD:     costUSD,
+		Outcome:     outcome,
+	}
+	if err := s.store.RecordAutopilotMetric(m); err != nil {
+		s.emitEvent("error", fmt.Sprintf("Failed to record metrics for #%d: %v", task.IssueNumber, err), task)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1689,3 +1689,137 @@ func TestParseDependencies(t *testing.T) {
 		}
 	}
 }
+
+func TestAutopilotMetrics(t *testing.T) {
+	store := openTestDB(t)
+
+	p := &Project{
+		Name:               "metrics-test",
+		GoalType:           "feature",
+		GoalDescription:    "test",
+		RefreshIntervalSec: 300,
+		MessageTTLSec:      172800,
+		LLMProvider:        "anthropic",
+		LLMModel:           "claude-haiku-4-5",
+		LLMSummarizerModel: "claude-haiku-4-5",
+		LLMAnalyzerModel:   "claude-sonnet-4-6",
+	}
+	if err := store.CreateProject(p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Create a task to attach metrics to.
+	task := &AutopilotTask{
+		ProjectID:    p.ID,
+		IssueNumber:  99,
+		IssueTitle:   "Test task",
+		IssueBody:    "Body",
+		Dependencies: "[]",
+		Status:       "queued",
+	}
+	if err := store.CreateAutopilotTask(task); err != nil {
+		t.Fatalf("CreateAutopilotTask: %v", err)
+	}
+
+	// Record a metric.
+	m := &AutopilotMetric{
+		TaskID:      task.ID,
+		ProjectID:   p.ID,
+		DurationSec: 120,
+		TokensUsed:  0,
+		CostUSD:     1.50,
+		Outcome:     "review",
+	}
+	if err := store.RecordAutopilotMetric(m); err != nil {
+		t.Fatalf("RecordAutopilotMetric: %v", err)
+	}
+	if m.ID == 0 {
+		t.Fatal("expected non-zero metric ID")
+	}
+
+	// Record another metric for a second task.
+	task2 := &AutopilotTask{
+		ProjectID:    p.ID,
+		IssueNumber:  100,
+		IssueTitle:   "Test task 2",
+		IssueBody:    "Body 2",
+		Dependencies: "[]",
+		Status:       "queued",
+	}
+	if err := store.CreateAutopilotTask(task2); err != nil {
+		t.Fatalf("CreateAutopilotTask 2: %v", err)
+	}
+	m2 := &AutopilotMetric{
+		TaskID:      task2.ID,
+		ProjectID:   p.ID,
+		DurationSec: 60,
+		TokensUsed:  0,
+		CostUSD:     0.75,
+		Outcome:     "bailed",
+	}
+	if err := store.RecordAutopilotMetric(m2); err != nil {
+		t.Fatalf("RecordAutopilotMetric 2: %v", err)
+	}
+
+	// GetAutopilotMetrics should return both.
+	metrics, err := store.GetAutopilotMetrics(p.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotMetrics: %v", err)
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("got %d metrics, want 2", len(metrics))
+	}
+
+	// Build a lookup by task ID for order-independent verification.
+	byTask := make(map[int64]AutopilotMetric, len(metrics))
+	for _, met := range metrics {
+		byTask[met.TaskID] = met
+	}
+
+	// Verify metric for task 1.
+	got1 := byTask[task.ID]
+	if got1.DurationSec != 120 {
+		t.Errorf("task1 DurationSec = %d, want 120", got1.DurationSec)
+	}
+	if got1.CostUSD != 1.50 {
+		t.Errorf("task1 CostUSD = %f, want 1.50", got1.CostUSD)
+	}
+	if got1.Outcome != "review" {
+		t.Errorf("task1 Outcome = %q, want review", got1.Outcome)
+	}
+
+	// Verify metric for task 2.
+	got2 := byTask[task2.ID]
+	if got2.DurationSec != 60 {
+		t.Errorf("task2 DurationSec = %d, want 60", got2.DurationSec)
+	}
+	if got2.CostUSD != 0.75 {
+		t.Errorf("task2 CostUSD = %f, want 0.75", got2.CostUSD)
+	}
+	if got2.Outcome != "bailed" {
+		t.Errorf("task2 Outcome = %q, want bailed", got2.Outcome)
+	}
+
+	// Metrics for a different project should be empty.
+	p2 := &Project{
+		Name:               "metrics-test-2",
+		GoalType:           "feature",
+		GoalDescription:    "other",
+		RefreshIntervalSec: 300,
+		MessageTTLSec:      172800,
+		LLMProvider:        "anthropic",
+		LLMModel:           "claude-haiku-4-5",
+		LLMSummarizerModel: "claude-haiku-4-5",
+		LLMAnalyzerModel:   "claude-sonnet-4-6",
+	}
+	if err := store.CreateProject(p2); err != nil {
+		t.Fatalf("CreateProject p2: %v", err)
+	}
+	other, err := store.GetAutopilotMetrics(p2.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotMetrics other: %v", err)
+	}
+	if len(other) != 0 {
+		t.Errorf("got %d metrics for other project, want 0", len(other))
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -191,6 +191,18 @@ type AutopilotTask struct {
 	CompletedAt  string `db:"completed_at"`
 }
 
+// AutopilotMetric records per-task metrics for an autopilot agent run.
+type AutopilotMetric struct {
+	ID          int64   `db:"id"`
+	TaskID      int64   `db:"task_id"`
+	ProjectID   int64   `db:"project_id"`
+	DurationSec int     `db:"duration_sec"`
+	TokensUsed  int     `db:"tokens_used"`
+	CostUSD     float64 `db:"cost_usd"`
+	Outcome     string  `db:"outcome"` // "review", "bailed", "stopped", "done"
+	CreatedAt   string  `db:"created_at"`
+}
+
 // LLMResponse returns the best available response: tier 2 if present, else tier 1, else raw.
 func (p *Poll) LLMResponse() string {
 	if p.Tier2Response != "" {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -841,6 +841,36 @@ func parseDependencies(deps string) []int {
 	return result
 }
 
+// --- Autopilot Metrics ---
+
+// RecordAutopilotMetric inserts a metrics record for a completed autopilot task.
+func (s *Store) RecordAutopilotMetric(m *AutopilotMetric) error {
+	result, err := s.db.NamedExec(`
+		INSERT INTO autopilot_metrics (task_id, project_id, duration_sec, tokens_used, cost_usd, outcome)
+		VALUES (:task_id, :project_id, :duration_sec, :tokens_used, :cost_usd, :outcome)
+	`, m)
+	if err != nil {
+		return fmt.Errorf("insert autopilot metric: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("last insert id: %w", err)
+	}
+	m.ID = id
+	return nil
+}
+
+// GetAutopilotMetrics returns all metrics for a project, ordered by most recent first.
+func (s *Store) GetAutopilotMetrics(projectID int64) ([]AutopilotMetric, error) {
+	var metrics []AutopilotMetric
+	if err := s.db.Select(&metrics, `
+		SELECT * FROM autopilot_metrics WHERE project_id = ? ORDER BY created_at DESC
+	`, projectID); err != nil {
+		return nil, fmt.Errorf("get autopilot metrics: %w", err)
+	}
+	return metrics, nil
+}
+
 // LastPoll returns the most recent poll for a project, or nil if none.
 func (s *Store) LastPoll(projectID int64) (*Poll, error) {
 	polls, err := s.RecentPolls(projectID, 1)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -9,7 +9,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 12
+const currentVersion = 13
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -143,6 +143,17 @@ CREATE TABLE IF NOT EXISTS completed_items (
 	summary      TEXT NOT NULL DEFAULT '',
 	completed_at TEXT DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS autopilot_metrics (
+	id           INTEGER PRIMARY KEY,
+	task_id      INTEGER NOT NULL REFERENCES autopilot_tasks(id) ON DELETE CASCADE,
+	project_id   INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+	duration_sec INTEGER NOT NULL DEFAULT 0,
+	tokens_used  INTEGER NOT NULL DEFAULT 0,
+	cost_usd     REAL NOT NULL DEFAULT 0.0,
+	outcome      TEXT NOT NULL DEFAULT '',
+	created_at   TEXT DEFAULT (datetime('now'))
+);
 `
 
 // Open opens (or creates) the agent-minder SQLite database and runs migrations,
@@ -243,6 +254,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 12 {
 		if err := migrateV12(db); err != nil {
 			return fmt.Errorf("apply migration v12: %w", err)
+		}
+	}
+
+	if version < 13 {
+		if err := migrateV13(db); err != nil {
+			return fmt.Errorf("apply migration v13: %w", err)
 		}
 	}
 
@@ -470,6 +487,25 @@ func migrateV12(db *sqlx.DB) error {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("%s: %w", stmt, err)
 		}
+	}
+	return nil
+}
+
+func migrateV13(db *sqlx.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS autopilot_metrics (
+			id           INTEGER PRIMARY KEY,
+			task_id      INTEGER NOT NULL REFERENCES autopilot_tasks(id) ON DELETE CASCADE,
+			project_id   INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			duration_sec INTEGER NOT NULL DEFAULT 0,
+			tokens_used  INTEGER NOT NULL DEFAULT 0,
+			cost_usd     REAL NOT NULL DEFAULT 0.0,
+			outcome      TEXT NOT NULL DEFAULT '',
+			created_at   TEXT DEFAULT (datetime('now'))
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create autopilot_metrics table: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Add `autopilot_metrics` table (schema v13) with columns: task_id, duration_sec, tokens_used, cost_usd, outcome
- Record metrics when each agent completes in `runAgent`, capturing wall-clock duration and cost from stream-json live status
- Add `GetAutopilotMetrics(projectID)` query method for retrieving metrics by project

## Test plan
- [x] New `TestAutopilotMetrics` test verifies insert and retrieval of metrics records
- [x] All existing DB and autopilot tests continue to pass
- [x] Pre-commit hooks (fmt, vet, build) pass

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)