### PR TITLE
Replace misleading turn/cost metrics with step count

### DIFF
--- a/internal/autopilot/scanner.go
+++ b/internal/autopilot/scanner.go
@@ -9,10 +9,9 @@ import (
 
 // LiveStatus holds real-time agent status parsed from stream-json output.
 type LiveStatus struct {
-	CurrentTool string  // e.g. "Bash", "Read", "Edit"
-	ToolInput   string  // truncated summary of tool input
-	TurnCount   int     // incremented on each assistant message
-	CostUSD     float64 // from result event
+	CurrentTool string // e.g. "Bash", "Read", "Edit"
+	ToolInput   string // truncated summary of tool input
+	StepCount   int    // incremented on each assistant message
 }
 
 // Stream-json event types (unexported, used only by scanner).
@@ -65,8 +64,8 @@ func scanStream(r io.Reader, logFile *os.File, slotIdx int, s *Supervisor) {
 			switch evt.Type {
 			case "assistant":
 				if evt.Message != nil {
-					// Each assistant message = one turn.
-					slot.liveStatus.TurnCount++
+					// Each assistant message = one step.
+					slot.liveStatus.StepCount++
 
 					// Find the last tool_use block for display.
 					for _, block := range evt.Message.Content {
@@ -91,7 +90,6 @@ func scanStream(r io.Reader, logFile *os.File, slotIdx int, s *Supervisor) {
 				}
 
 			case "result":
-				slot.liveStatus.CostUSD = evt.TotalCost
 				slot.liveStatus.CurrentTool = ""
 				slot.liveStatus.ToolInput = ""
 			}

--- a/internal/autopilot/scanner_test.go
+++ b/internal/autopilot/scanner_test.go
@@ -44,8 +44,8 @@ func TestScanStream_AssistantToolUse(t *testing.T) {
 	sup.mu.Lock()
 	defer sup.mu.Unlock()
 
-	if sup.slots[0].liveStatus.TurnCount != 3 {
-		t.Errorf("TurnCount = %d, want 3", sup.slots[0].liveStatus.TurnCount)
+	if sup.slots[0].liveStatus.StepCount != 3 {
+		t.Errorf("StepCount = %d, want 3", sup.slots[0].liveStatus.StepCount)
 	}
 	// After text-only message, tool should be cleared.
 	if sup.slots[0].liveStatus.CurrentTool != "" {
@@ -96,9 +96,6 @@ func TestScanStream_ResultEvent(t *testing.T) {
 	sup.mu.Lock()
 	defer sup.mu.Unlock()
 
-	if sup.slots[0].liveStatus.CostUSD != 0.42 {
-		t.Errorf("CostUSD = %f, want 0.42", sup.slots[0].liveStatus.CostUSD)
-	}
 	// Tool should be cleared after result.
 	if sup.slots[0].liveStatus.CurrentTool != "" {
 		t.Errorf("CurrentTool = %q, want empty after result", sup.slots[0].liveStatus.CurrentTool)
@@ -135,8 +132,8 @@ also not json {{{
 	defer sup.mu.Unlock()
 
 	// Only the valid assistant event should be counted.
-	if sup.slots[0].liveStatus.TurnCount != 1 {
-		t.Errorf("TurnCount = %d, want 1", sup.slots[0].liveStatus.TurnCount)
+	if sup.slots[0].liveStatus.StepCount != 1 {
+		t.Errorf("StepCount = %d, want 1", sup.slots[0].liveStatus.StepCount)
 	}
 	if sup.slots[0].liveStatus.CurrentTool != "Bash" {
 		t.Errorf("CurrentTool = %q, want Bash", sup.slots[0].liveStatus.CurrentTool)

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -40,10 +40,7 @@ type SlotInfo struct {
 	// Live status from stream-json parsing.
 	CurrentTool string
 	ToolInput   string
-	TurnCount   int
-	MaxTurns    int
-	CostUSD     float64
-	MaxBudget   float64
+	StepCount   int
 }
 
 type slotState struct {
@@ -401,14 +398,6 @@ func (s *Supervisor) SlotStatus() []SlotInfo {
 				Paused:  s.paused,
 			}
 		} else {
-			maxTurns := s.project.AutopilotMaxTurns
-			if maxTurns < 1 {
-				maxTurns = 50
-			}
-			maxBudget := s.project.AutopilotMaxBudgetUSD
-			if maxBudget <= 0 {
-				maxBudget = 3.00
-			}
 			infos[i] = SlotInfo{
 				SlotNum:     i + 1,
 				IssueNumber: slot.task.IssueNumber,
@@ -418,10 +407,7 @@ func (s *Supervisor) SlotStatus() []SlotInfo {
 				Status:      "running",
 				CurrentTool: slot.liveStatus.CurrentTool,
 				ToolInput:   slot.liveStatus.ToolInput,
-				TurnCount:   slot.liveStatus.TurnCount,
-				MaxTurns:    maxTurns,
-				CostUSD:     slot.liveStatus.CostUSD,
-				MaxBudget:   maxBudget,
+				StepCount:   slot.liveStatus.StepCount,
 			}
 		}
 	}
@@ -449,9 +435,9 @@ func (s *Supervisor) StatusBlock() string {
 			if slot.liveStatus.CurrentTool != "" {
 				toolInfo = fmt.Sprintf(", using %s", slot.liveStatus.CurrentTool)
 			}
-			fmt.Fprintf(&b, "- Slot %d: #%d %s (%s, running %s, turn %d, $%.2f%s)\n",
+			fmt.Fprintf(&b, "- Slot %d: #%d %s (%s, running %s, step %d%s)\n",
 				i+1, slot.task.IssueNumber, slot.task.IssueTitle, slot.task.Branch,
-				elapsed, slot.liveStatus.TurnCount, slot.liveStatus.CostUSD, toolInfo)
+				elapsed, slot.liveStatus.StepCount, toolInfo)
 		}
 	}
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1753,17 +1753,9 @@ func (m Model) confirmAutopilot() (tea.Model, tea.Cmd) {
 	if maxAgents < 1 {
 		maxAgents = 3
 	}
-	maxTurns := m.project.AutopilotMaxTurns
-	if maxTurns < 1 {
-		maxTurns = 50
-	}
-	maxBudget := m.project.AutopilotMaxBudgetUSD
-	if maxBudget <= 0 {
-		maxBudget = 3.00
-	}
 	m.autopilotStatus = fmt.Sprintf(
-		"Autopilot running in background — %d agents, %d turns, $%.2f/agent max — press A to stop",
-		maxAgents, maxTurns, maxBudget,
+		"Autopilot running in background — %d agents max — press A to stop",
+		maxAgents,
 	)
 
 	return m, tea.Batch(

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -288,13 +288,7 @@ func (m Model) renderAutopilotRunningContent() string {
 				b.WriteString(mutedStyle().Render(fmt.Sprintf("  Slot %d: %s", slot.SlotNum, label)))
 			} else {
 				elapsed := slot.RunningFor.Round(time.Second)
-				line := fmt.Sprintf("  Slot %d: #%d  %s", slot.SlotNum, slot.IssueNumber, elapsed)
-				if slot.MaxTurns > 0 {
-					line += fmt.Sprintf("  %d/%d turns", slot.TurnCount, slot.MaxTurns)
-				}
-				if slot.CostUSD > 0 || slot.MaxBudget > 0 {
-					line += fmt.Sprintf("  $%.2f/$%.2f", slot.CostUSD, slot.MaxBudget)
-				}
+				line := fmt.Sprintf("  Slot %d: #%d  %s  %d steps", slot.SlotNum, slot.IssueNumber, elapsed, slot.StepCount)
 				b.WriteString(statusRunningStyle().Render(line))
 				if slot.CurrentTool != "" {
 					b.WriteString("\n")


### PR DESCRIPTION
## Summary
- Autopilot TUI showed `72/50 turns` and `$0/$3.00` — both misleading because our "turn" count didn't match Claude CLI's internal count, and cost was only available at session end
- Replaced with a simple step counter (counts assistant stream events) that doesn't pretend to track CLI internals
- `--max-turns` and `--max-budget-usd` are still passed to the CLI for enforcement under the hood

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./internal/autopilot/... ./internal/tui/...` passes
- [x] Run autopilot and verify slot display shows `N steps` instead of turn/cost ratios

🤖 Generated with [Claude Code](https://claude.com/claude-code)