### PR TITLE
Add autopilot metrics collection

### DIFF
--- a/internal/autopilot/scanner.go
+++ b/internal/autopilot/scanner.go
@@ -12,6 +12,11 @@ type LiveStatus struct {
 	CurrentTool string // e.g. "Bash", "Read", "Edit"
 	ToolInput   string // truncated summary of tool input
 	StepCount   int    // incremented on each assistant message
+
+	// Populated from the "result" event when the agent finishes.
+	TotalCostUSD float64 // total cost reported by Claude CLI
+	DurationMs   int     // duration reported by Claude CLI
+	NumTurns     int     // number of turns reported by Claude CLI
 }
 
 // Stream-json event types (unexported, used only by scanner).
@@ -92,6 +97,9 @@ func scanStream(r io.Reader, logFile *os.File, slotIdx int, s *Supervisor) {
 			case "result":
 				slot.liveStatus.CurrentTool = ""
 				slot.liveStatus.ToolInput = ""
+				slot.liveStatus.TotalCostUSD = evt.TotalCost
+				slot.liveStatus.DurationMs = evt.Duration
+				slot.liveStatus.NumTurns = evt.NumTurns
 			}
 		}
 		s.mu.Unlock()

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -848,6 +848,8 @@ func (s *Supervisor) launchAgent(ctx context.Context, slotIdx int, task *db.Auto
 }
 
 func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.AutopilotTask) {
+	taskStartedAt := time.Now()
+
 	defer func() {
 		s.mu.Lock()
 		s.slots[slotIdx] = nil
@@ -962,14 +964,25 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 		}
 	}
 
-	// Check if this agent was stopped by the user.
+	// Capture live status metrics before slot is cleared.
 	s.mu.Lock()
 	stoppedByUser := s.slots[slotIdx] != nil && s.slots[slotIdx].stoppedByUser
+	var liveStatus LiveStatus
+	if s.slots[slotIdx] != nil {
+		liveStatus = s.slots[slotIdx].liveStatus
+	}
 	s.mu.Unlock()
+
+	// Compute duration from wall clock (fallback if stream didn't report it).
+	durationSec := time.Since(taskStartedAt).Seconds()
+	if liveStatus.DurationMs > 0 {
+		durationSec = float64(liveStatus.DurationMs) / 1000.0
+	}
 
 	if stoppedByUser {
 		// User-initiated stop: set stopped status, preserve worktree for investigation.
 		_ = s.store.UpdateAutopilotTaskStatus(task.ID, "stopped")
+		s.recordMetrics(task, durationSec, liveStatus.NumTurns, liveStatus.TotalCostUSD, "stopped")
 		s.emitEvent("stopped", fmt.Sprintf("Agent stopped by user on #%d", task.IssueNumber), task)
 		return
 	}
@@ -977,6 +990,7 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 	// Inspect outcome.
 	status := s.inspectOutcome(ctx, task, exitCode)
 	_ = s.store.UpdateAutopilotTaskStatus(task.ID, status)
+	s.recordMetrics(task, durationSec, liveStatus.NumTurns, liveStatus.TotalCostUSD, status)
 
 	if status == "review" {
 		// Swap in-progress → needs-review label on the issue.
@@ -1043,6 +1057,22 @@ func (s *Supervisor) cleanup(task *db.AutopilotTask, deleteBranch bool) {
 	// Delete branch only if bailed (keep if PR opened).
 	if deleteBranch {
 		_ = gitpkg.DeleteBranch(s.repoDir, task.Branch)
+	}
+}
+
+// recordMetrics writes an autopilot_metrics row for a completed agent run.
+func (s *Supervisor) recordMetrics(task *db.AutopilotTask, durationSec float64, tokensUsed int, costUSD float64, outcome string) {
+	m := &db.AutopilotMetric{
+		TaskID:      task.ID,
+		ProjectID:   task.ProjectID,
+		IssueNumber: task.IssueNumber,
+		DurationSec: durationSec,
+		TokensUsed:  tokensUsed,
+		CostUSD:     costUSD,
+		Outcome:     outcome,
+	}
+	if err := s.store.RecordAutopilotMetric(m); err != nil {
+		s.emitEvent("error", fmt.Sprintf("Failed to record metrics for #%d: %v", task.IssueNumber, err), task)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1689,3 +1689,115 @@ func TestParseDependencies(t *testing.T) {
 		}
 	}
 }
+
+func TestAutopilotMetricsCRUD(t *testing.T) {
+	store := openTestDB(t)
+
+	p := &Project{
+		Name:               "metrics-test",
+		GoalType:           "feature",
+		GoalDescription:    "test metrics",
+		RefreshIntervalSec: 300,
+		MessageTTLSec:      172800,
+		LLMProvider:        "anthropic",
+		LLMModel:           "claude-haiku-4-5",
+		LLMSummarizerModel: "claude-haiku-4-5",
+		LLMAnalyzerModel:   "claude-sonnet-4-6",
+	}
+	if err := store.CreateProject(p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Create a task (metrics reference it).
+	task := &AutopilotTask{
+		ProjectID:    p.ID,
+		IssueNumber:  99,
+		IssueTitle:   "Test issue",
+		IssueBody:    "Body",
+		Dependencies: "[]",
+		Status:       "done",
+	}
+	if err := store.CreateAutopilotTask(task); err != nil {
+		t.Fatalf("CreateAutopilotTask: %v", err)
+	}
+
+	// Record a metric.
+	m := &AutopilotMetric{
+		TaskID:      task.ID,
+		ProjectID:   p.ID,
+		IssueNumber: 99,
+		DurationSec: 123.45,
+		TokensUsed:  5000,
+		CostUSD:     0.42,
+		Outcome:     "review",
+	}
+	if err := store.RecordAutopilotMetric(m); err != nil {
+		t.Fatalf("RecordAutopilotMetric: %v", err)
+	}
+	if m.ID == 0 {
+		t.Fatal("expected non-zero metric ID")
+	}
+
+	// Record a second metric for a different task.
+	task2 := &AutopilotTask{
+		ProjectID:    p.ID,
+		IssueNumber:  100,
+		IssueTitle:   "Second issue",
+		IssueBody:    "Body2",
+		Dependencies: "[]",
+		Status:       "bailed",
+	}
+	if err := store.CreateAutopilotTask(task2); err != nil {
+		t.Fatalf("CreateAutopilotTask 2: %v", err)
+	}
+	m2 := &AutopilotMetric{
+		TaskID:      task2.ID,
+		ProjectID:   p.ID,
+		IssueNumber: 100,
+		DurationSec: 60.0,
+		TokensUsed:  1200,
+		CostUSD:     0.10,
+		Outcome:     "bailed",
+	}
+	if err := store.RecordAutopilotMetric(m2); err != nil {
+		t.Fatalf("RecordAutopilotMetric 2: %v", err)
+	}
+
+	// Query metrics.
+	metrics, err := store.GetAutopilotMetrics(p.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotMetrics: %v", err)
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("got %d metrics, want 2", len(metrics))
+	}
+
+	// Most recent first.
+	if metrics[0].IssueNumber != 100 {
+		t.Errorf("metrics[0].IssueNumber = %d, want 100", metrics[0].IssueNumber)
+	}
+	if metrics[0].Outcome != "bailed" {
+		t.Errorf("metrics[0].Outcome = %q, want %q", metrics[0].Outcome, "bailed")
+	}
+	if metrics[1].IssueNumber != 99 {
+		t.Errorf("metrics[1].IssueNumber = %d, want 99", metrics[1].IssueNumber)
+	}
+	if metrics[1].DurationSec != 123.45 {
+		t.Errorf("metrics[1].DurationSec = %f, want 123.45", metrics[1].DurationSec)
+	}
+	if metrics[1].TokensUsed != 5000 {
+		t.Errorf("metrics[1].TokensUsed = %d, want 5000", metrics[1].TokensUsed)
+	}
+	if metrics[1].CostUSD != 0.42 {
+		t.Errorf("metrics[1].CostUSD = %f, want 0.42", metrics[1].CostUSD)
+	}
+
+	// Metrics for a different project should be empty.
+	otherMetrics, err := store.GetAutopilotMetrics(999)
+	if err != nil {
+		t.Fatalf("GetAutopilotMetrics for other: %v", err)
+	}
+	if len(otherMetrics) != 0 {
+		t.Errorf("got %d metrics for other project, want 0", len(otherMetrics))
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -191,6 +191,19 @@ type AutopilotTask struct {
 	CompletedAt  string `db:"completed_at"`
 }
 
+// AutopilotMetric records performance data for a completed autopilot agent run.
+type AutopilotMetric struct {
+	ID          int64   `db:"id"`
+	TaskID      int64   `db:"task_id"`
+	ProjectID   int64   `db:"project_id"`
+	IssueNumber int     `db:"issue_number"`
+	DurationSec float64 `db:"duration_sec"`
+	TokensUsed  int     `db:"tokens_used"`
+	CostUSD     float64 `db:"cost_usd"`
+	Outcome     string  `db:"outcome"` // "review", "bailed", "stopped"
+	RecordedAt  string  `db:"recorded_at"`
+}
+
 // LLMResponse returns the best available response: tier 2 if present, else tier 1, else raw.
 func (p *Poll) LLMResponse() string {
 	if p.Tier2Response != "" {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -841,6 +841,36 @@ func parseDependencies(deps string) []int {
 	return result
 }
 
+// --- Autopilot Metrics ---
+
+// RecordAutopilotMetric inserts a metrics record for a completed agent run.
+func (s *Store) RecordAutopilotMetric(m *AutopilotMetric) error {
+	result, err := s.db.NamedExec(`
+		INSERT INTO autopilot_metrics (task_id, project_id, issue_number, duration_sec, tokens_used, cost_usd, outcome)
+		VALUES (:task_id, :project_id, :issue_number, :duration_sec, :tokens_used, :cost_usd, :outcome)
+	`, m)
+	if err != nil {
+		return fmt.Errorf("insert autopilot metric: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("last insert id: %w", err)
+	}
+	m.ID = id
+	return nil
+}
+
+// GetAutopilotMetrics returns all metrics for a project, ordered by most recent first.
+func (s *Store) GetAutopilotMetrics(projectID int64) ([]AutopilotMetric, error) {
+	var metrics []AutopilotMetric
+	if err := s.db.Select(&metrics, `
+		SELECT * FROM autopilot_metrics WHERE project_id = ? ORDER BY recorded_at DESC, id DESC
+	`, projectID); err != nil {
+		return nil, fmt.Errorf("get autopilot metrics: %w", err)
+	}
+	return metrics, nil
+}
+
 // LastPoll returns the most recent poll for a project, or nil if none.
 func (s *Store) LastPoll(projectID int64) (*Poll, error) {
 	polls, err := s.RecentPolls(projectID, 1)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -9,7 +9,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 12
+const currentVersion = 13
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -143,6 +143,18 @@ CREATE TABLE IF NOT EXISTS completed_items (
 	summary      TEXT NOT NULL DEFAULT '',
 	completed_at TEXT DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS autopilot_metrics (
+	id           INTEGER PRIMARY KEY,
+	task_id      INTEGER NOT NULL REFERENCES autopilot_tasks(id) ON DELETE CASCADE,
+	project_id   INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+	issue_number INTEGER NOT NULL DEFAULT 0,
+	duration_sec REAL NOT NULL DEFAULT 0,
+	tokens_used  INTEGER NOT NULL DEFAULT 0,
+	cost_usd     REAL NOT NULL DEFAULT 0,
+	outcome      TEXT NOT NULL DEFAULT '',
+	recorded_at  TEXT DEFAULT (datetime('now'))
+);
 `
 
 // Open opens (or creates) the agent-minder SQLite database and runs migrations,
@@ -243,6 +255,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 12 {
 		if err := migrateV12(db); err != nil {
 			return fmt.Errorf("apply migration v12: %w", err)
+		}
+	}
+
+	if version < 13 {
+		if err := migrateV13(db); err != nil {
+			return fmt.Errorf("apply migration v13: %w", err)
 		}
 	}
 
@@ -470,6 +488,26 @@ func migrateV12(db *sqlx.DB) error {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("%s: %w", stmt, err)
 		}
+	}
+	return nil
+}
+
+func migrateV13(db *sqlx.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS autopilot_metrics (
+			id           INTEGER PRIMARY KEY,
+			task_id      INTEGER NOT NULL REFERENCES autopilot_tasks(id) ON DELETE CASCADE,
+			project_id   INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			issue_number INTEGER NOT NULL DEFAULT 0,
+			duration_sec REAL NOT NULL DEFAULT 0,
+			tokens_used  INTEGER NOT NULL DEFAULT 0,
+			cost_usd     REAL NOT NULL DEFAULT 0,
+			outcome      TEXT NOT NULL DEFAULT '',
+			recorded_at  TEXT DEFAULT (datetime('now'))
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create autopilot_metrics table: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- New `autopilot_metrics` table (schema v13 migration) with `task_id`, `duration_sec`, `tokens_used`, `cost_usd`, and `outcome` columns
- `RecordAutopilotMetric()` and `GetAutopilotMetrics(projectID)` Store methods for writing and querying metrics
- Scanner captures cost, duration, and turn count from Claude CLI stream-json `result` events
- Metrics are automatically recorded in `runAgent` when each agent completes (review, bailed, or stopped)

## Test plan
- [x] New `TestAutopilotMetricsCRUD` test verifies insert, query ordering, and project isolation
- [x] All existing DB tests pass
- [x] Build and pre-commit hooks pass

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)