### PR TITLE
Add dependency graph options carousel for autopilot

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -19,6 +19,14 @@ import (
 	"github.com/dustinlange/agent-minder/internal/llm"
 )
 
+// DepOption represents one ranked dependency graph option produced by the LLM.
+type DepOption struct {
+	Name      string                     // e.g., "Conservative — minimal deps"
+	Rationale string                     // why this ordering makes sense
+	Graph     map[string]json.RawMessage // issue# → deps array or "skip"
+	Unblocked int                        // pre-computed count of unblocked tasks
+}
+
 // Event is emitted by the supervisor for the TUI to consume.
 type Event struct {
 	Time    time.Time
@@ -98,19 +106,19 @@ func (s *Supervisor) Events() <-chan Event {
 	return s.events
 }
 
+// IsActive returns true if the supervisor has been launched and is running.
+func (s *Supervisor) IsActive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active
+}
+
 // TriggerDiscovery signals the supervisor to check for new tracked items immediately.
 func (s *Supervisor) TriggerDiscovery() {
 	select {
 	case s.discovery <- struct{}{}:
 	default: // already pending
 	}
-}
-
-// IsActive returns whether the supervisor is currently running.
-func (s *Supervisor) IsActive() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.active
 }
 
 // StopAgent cancels a single agent slot, leaving other agents running.
@@ -322,12 +330,12 @@ func (s *Supervisor) IsPaused() bool {
 // Prepare fetches tracked issues, creates autopilot tasks, and builds a dependency graph.
 // Always starts fresh — clears previous tasks, cleans up orphaned worktrees.
 // Optional guidance is passed to the LLM during dependency analysis.
-func (s *Supervisor) Prepare(ctx context.Context, guidance string) (total, unblocked int, err error) {
+func (s *Supervisor) Prepare(ctx context.Context, guidance string) (total int, options []DepOption, err error) {
 	// Validate configured base branch exists in at least one enrolled repo.
 	if s.project.AutopilotBaseBranch != "" {
 		repos, err := s.store.GetRepos(s.project.ID)
 		if err != nil {
-			return 0, 0, fmt.Errorf("get enrolled repos: %w", err)
+			return 0, nil, fmt.Errorf("get enrolled repos: %w", err)
 		}
 		found := false
 		for _, r := range repos {
@@ -337,49 +345,137 @@ func (s *Supervisor) Prepare(ctx context.Context, guidance string) (total, unblo
 			}
 		}
 		if !found {
-			return 0, 0, fmt.Errorf("configured base branch %q not found in any enrolled repo", s.project.AutopilotBaseBranch)
+			return 0, nil, fmt.Errorf("configured base branch %q not found in any enrolled repo", s.project.AutopilotBaseBranch)
 		}
 	}
 
 	// Clean up any leftovers from a previous run.
 	if err := s.store.ClearAutopilotTasks(s.project.ID); err != nil {
-		return 0, 0, fmt.Errorf("clear autopilot tasks: %w", err)
+		return 0, nil, fmt.Errorf("clear autopilot tasks: %w", err)
 	}
 	s.cleanOrphanedWorktrees()
 
 	// Convert tracked items to autopilot tasks.
 	tasks, err := s.convertTrackedItems(ctx)
 	if err != nil {
-		return 0, 0, fmt.Errorf("convert tracked items: %w", err)
+		return 0, nil, fmt.Errorf("convert tracked items: %w", err)
 	}
 	if len(tasks) == 0 {
-		return 0, 0, nil
+		return 0, nil, nil
 	}
 
-	// Build dependency graph.
-	if err := s.buildDependencyGraph(ctx, tasks, guidance); err != nil {
-		s.emitEvent("error", fmt.Sprintf("Dependency graph failed: %v — falling back to sequential order", err), nil)
-		s.setSequentialDeps(tasks)
-	}
-
-	// Refresh tasks to get accurate counts (some may have been skipped).
-	allTasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	// Build dependency graph options.
+	options, err = s.buildDepOptions(ctx, tasks, guidance)
 	if err != nil {
-		return 0, 0, fmt.Errorf("refresh tasks: %w", err)
+		s.emitEvent("error", fmt.Sprintf("Dependency graph failed: %v — falling back to sequential order", err), nil)
+		// Build a single sequential fallback option.
+		graph := make(map[string]json.RawMessage, len(tasks))
+		for i, t := range tasks {
+			key := strconv.Itoa(t.IssueNumber)
+			if i == 0 {
+				graph[key] = json.RawMessage("[]")
+			} else {
+				deps, _ := json.Marshal([]int{tasks[i-1].IssueNumber})
+				graph[key] = json.RawMessage(deps)
+			}
+		}
+		options = []DepOption{{
+			Name:      "Sequential (fallback)",
+			Rationale: "LLM analysis failed; tasks will run one at a time in order.",
+			Graph:     graph,
+			Unblocked: 1,
+		}}
 	}
-	activeTasks := 0
-	for _, t := range allTasks {
-		if t.Status != "skipped" {
-			activeTasks++
+
+	return len(tasks), options, nil
+}
+
+// ApplyDepOption applies the selected dependency option to the DB tasks.
+// Call this after the user picks an option from the dep-select screen.
+func (s *Supervisor) ApplyDepOption(ctx context.Context, opt DepOption) error {
+	tasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return fmt.Errorf("get tasks: %w", err)
+	}
+
+	for _, t := range tasks {
+		key := strconv.Itoa(t.IssueNumber)
+		rawDeps, ok := opt.Graph[key]
+		if !ok {
+			continue
+		}
+
+		// Check for "skip" directive.
+		var skipStr string
+		if json.Unmarshal(rawDeps, &skipStr) == nil && skipStr == "skip" {
+			_ = s.store.UpdateAutopilotTaskStatus(t.ID, "skipped")
+			s.emitEvent("warning", fmt.Sprintf("Task #%d excluded from autopilot", t.IssueNumber), &t)
+			continue
+		}
+
+		// Parse deps array.
+		var deps []int
+		if err := json.Unmarshal(rawDeps, &deps); err != nil {
+			var strDeps []string
+			if err2 := json.Unmarshal(rawDeps, &strDeps); err2 != nil {
+				continue
+			}
+			for _, sd := range strDeps {
+				if n, err3 := strconv.Atoi(sd); err3 == nil {
+					deps = append(deps, n)
+				}
+			}
+		}
+
+		if len(deps) > 0 {
+			depsJSON, _ := json.Marshal(deps)
+			if err := s.store.UpdateAutopilotTaskDeps(t.ID, string(depsJSON)); err != nil {
+				return fmt.Errorf("update deps for #%d: %w", t.IssueNumber, err)
+			}
+			// Block tasks that have unsatisfied deps.
+			_ = s.store.UpdateAutopilotTaskStatus(t.ID, "blocked")
 		}
 	}
 
-	unblockedTasks, err := s.store.QueuedUnblockedTasks(s.project.ID)
+	// Re-evaluate: unblock tasks whose deps are all satisfied.
+	freshTasks, err := s.store.GetAutopilotTasks(s.project.ID)
 	if err != nil {
-		return activeTasks, 0, fmt.Errorf("count unblocked: %w", err)
+		return fmt.Errorf("refresh tasks: %w", err)
+	}
+	statusMap := make(map[int]string, len(freshTasks))
+	for _, t := range freshTasks {
+		statusMap[t.IssueNumber] = t.Status
+	}
+	trackedItems, _ := s.store.GetTrackedItems(s.project.ID)
+	trackedState := make(map[int]string, len(trackedItems))
+	for _, item := range trackedItems {
+		trackedState[item.Number] = item.State
+	}
+	for _, t := range freshTasks {
+		if t.Status != "blocked" {
+			continue
+		}
+		deps := parseDeps(t.Dependencies)
+		allSatisfied := true
+		for _, dep := range deps {
+			if taskStatus, ok := statusMap[dep]; ok {
+				if taskStatus != "done" {
+					allSatisfied = false
+					break
+				}
+			} else if state, ok := trackedState[dep]; ok {
+				if state == "open" {
+					allSatisfied = false
+					break
+				}
+			}
+		}
+		if allSatisfied {
+			_ = s.store.UpdateAutopilotTaskStatus(t.ID, "queued")
+		}
 	}
 
-	return activeTasks, len(unblockedTasks), nil
+	return nil
 }
 
 // cleanOrphanedWorktrees removes worktrees left behind by interrupted agents.
@@ -675,9 +771,17 @@ func hasLabel(labels []string, target string) bool {
 	return false
 }
 
-func (s *Supervisor) buildDependencyGraph(ctx context.Context, tasks []*db.AutopilotTask, guidance string) error {
+func (s *Supervisor) buildDepOptions(ctx context.Context, tasks []*db.AutopilotTask, guidance string) ([]DepOption, error) {
 	if len(tasks) <= 1 {
-		return nil // No dependencies possible with 0-1 tasks.
+		// Single task: return one option with no deps.
+		graph := make(map[string]json.RawMessage, 1)
+		graph[strconv.Itoa(tasks[0].IssueNumber)] = json.RawMessage("[]")
+		return []DepOption{{
+			Name:      "No dependencies",
+			Rationale: "Only one task — no dependencies possible.",
+			Graph:     graph,
+			Unblocked: 1,
+		}}, nil
 	}
 
 	// Build task issue numbers set for quick lookup.
@@ -726,18 +830,29 @@ A dependency means issue B cannot start until issue A is completed (e.g., B buil
 Dependencies can include issues from BOTH sections — an agent task can depend on a non-agent issue if that issue's work must be done first.
 
 %s%s
-Respond with ONLY a JSON object. Keys are issue numbers (only for issues being worked on by agents), values are arrays of integer issue numbers that must complete first. Issues with no dependencies get an empty array.
+Respond with ONLY a JSON array of exactly 3 dependency graph options, ranked from most likely correct to least likely. Each option has a "name", "rationale", and "graph" field.
+
+The "graph" is an object where keys are issue numbers (only for issues being worked on by agents), values are arrays of integer issue numbers that must complete first. Issues with no dependencies get an empty array.
 
 If the user asks to skip or exclude an issue, set its value to the string "skip" instead of an array.
 
 IMPORTANT: Use integer values in dependency arrays, not strings.
-Example: {"42": [], "38": [42], "15": "skip"}
 
-Be conservative — only add a dependency if the work truly cannot proceed without the other issue being done first.`, issueList.String(), guidanceSection)
+The 3 options should represent meaningfully different dependency strategies:
+- Option 1: Your best analysis of actual dependencies
+- Option 2: An alternative interpretation (e.g., more conservative or more parallel)
+- Option 3: A different trade-off (e.g., maximum parallelism or stricter ordering)
+
+Example response:
+[
+  {"name": "Conservative — minimal deps", "rationale": "Only blocks issues that truly depend on schema changes.", "graph": {"42": [], "38": [42], "15": []}},
+  {"name": "Moderate — logical grouping", "rationale": "Groups related features; UI issues wait on API changes.", "graph": {"42": [], "38": [42], "15": [42]}},
+  {"name": "Maximum parallelism", "rationale": "All issues can start independently.", "graph": {"42": [], "38": [], "15": []}}
+]`, issueList.String(), guidanceSection)
 
 	messages := []llm.Message{{Role: "user", Content: prompt}}
 
-	var rawGraph map[string]json.RawMessage
+	var options []DepOption
 	var content string
 
 	for attempt := 0; attempt < 2; attempt++ {
@@ -745,11 +860,11 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 			Model:       s.project.LLMAnalyzerModel,
 			System:      "You are analyzing issue dependencies. Respond with ONLY valid JSON, no explanation or preamble.",
 			Messages:    messages,
-			MaxTokens:   512,
+			MaxTokens:   1536,
 			Temperature: 0,
 		})
 		if err != nil {
-			return fmt.Errorf("LLM call: %w", err)
+			return nil, fmt.Errorf("LLM call: %w", err)
 		}
 
 		content = strings.TrimSpace(resp.Content)
@@ -760,77 +875,81 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 				content = strings.Join(lines[1:len(lines)-1], "\n")
 			}
 		}
-		// Extract JSON object — trim any leading/trailing non-JSON text.
-		if start := strings.Index(content, "{"); start >= 0 {
-			if end := strings.LastIndex(content, "}"); end > start {
+		// Extract JSON array — trim any leading/trailing non-JSON text.
+		if start := strings.Index(content, "["); start >= 0 {
+			if end := strings.LastIndex(content, "]"); end > start {
 				content = content[start : end+1]
 			}
 		}
 
-		if err := json.Unmarshal([]byte(content), &rawGraph); err != nil {
+		var rawOptions []struct {
+			Name      string                     `json:"name"`
+			Rationale string                     `json:"rationale"`
+			Graph     map[string]json.RawMessage `json:"graph"`
+		}
+
+		if err := json.Unmarshal([]byte(content), &rawOptions); err != nil {
 			if attempt == 0 {
-				// Retry with error feedback.
 				messages = append(messages,
 					llm.Message{Role: "assistant", Content: resp.Content},
-					llm.Message{Role: "user", Content: fmt.Sprintf("That was not valid JSON: %v\n\nPlease respond with ONLY the JSON object, no text before or after.", err)},
+					llm.Message{Role: "user", Content: fmt.Sprintf("That was not valid JSON array: %v\n\nPlease respond with ONLY the JSON array of 3 options, no text before or after.", err)},
 				)
 				continue
 			}
-			return fmt.Errorf("parse dep graph: %w", err)
+			return nil, fmt.Errorf("parse dep options: %w", err)
+		}
+
+		for _, ro := range rawOptions {
+			opt := DepOption{
+				Name:      ro.Name,
+				Rationale: ro.Rationale,
+				Graph:     ro.Graph,
+				Unblocked: countUnblocked(ro.Graph, tasks),
+			}
+			options = append(options, opt)
 		}
 		break
 	}
 
-	// Update each task's dependencies.
+	if len(options) == 0 {
+		return nil, fmt.Errorf("LLM returned no options")
+	}
+
+	return options, nil
+}
+
+// countUnblocked counts how many tasks have no unsatisfied dependencies in a graph.
+func countUnblocked(graph map[string]json.RawMessage, tasks []*db.AutopilotTask) int {
+	count := 0
 	for _, t := range tasks {
 		key := strconv.Itoa(t.IssueNumber)
-		rawDeps, ok := rawGraph[key]
+		rawDeps, ok := graph[key]
 		if !ok {
+			count++ // not in graph = no deps
 			continue
 		}
-
-		// Check for "skip" directive — mark as skipped so discoverNewTasks won't re-add.
+		// Check for "skip".
 		var skipStr string
 		if json.Unmarshal(rawDeps, &skipStr) == nil && skipStr == "skip" {
-			_ = s.store.UpdateAutopilotTaskStatus(t.ID, "skipped")
-			s.emitEvent("warning", fmt.Sprintf("Task #%d excluded from autopilot", t.IssueNumber), t)
-			continue
+			continue // skipped tasks don't count as unblocked
 		}
-
-		// Try []int first, then []string, then []any.
 		var deps []int
 		if err := json.Unmarshal(rawDeps, &deps); err != nil {
+			// Try string array.
 			var strDeps []string
-			if err2 := json.Unmarshal(rawDeps, &strDeps); err2 != nil {
-				continue
-			}
-			for _, sd := range strDeps {
-				if n, err3 := strconv.Atoi(sd); err3 == nil {
-					deps = append(deps, n)
+			if json.Unmarshal(rawDeps, &strDeps) == nil {
+				for _, sd := range strDeps {
+					if n, err2 := strconv.Atoi(sd); err2 == nil {
+						deps = append(deps, n)
+					}
 				}
 			}
 		}
-
-		if len(deps) > 0 {
-			depsJSON, _ := json.Marshal(deps)
-			if err := s.store.UpdateAutopilotTaskDeps(t.ID, string(depsJSON)); err != nil {
-				return fmt.Errorf("update deps for #%d: %w", t.IssueNumber, err)
-			}
+		if len(deps) == 0 {
+			count++
 		}
 	}
-
-	return nil
-}
-
-// setSequentialDeps creates a simple chain: each task depends on the previous one (by issue number).
-// This is the safe fallback when the LLM dep graph fails — tasks run one at a time in order.
-func (s *Supervisor) setSequentialDeps(tasks []*db.AutopilotTask) {
-	// Tasks are already sorted by issue number from the DB query.
-	for i := 1; i < len(tasks); i++ {
-		deps := []int{tasks[i-1].IssueNumber}
-		depsJSON, _ := json.Marshal(deps)
-		_ = s.store.UpdateAutopilotTaskDeps(tasks[i].ID, string(depsJSON))
-	}
+	return count
 }
 
 func (s *Supervisor) fillSlots(ctx context.Context) {
@@ -1274,10 +1393,10 @@ type RebuildResult struct {
 
 // RebuildDependencies re-analyzes the dependency graph for queued and blocked tasks,
 // incorporating user guidance. Running/done/review tasks are untouched.
-func (s *Supervisor) RebuildDependencies(ctx context.Context, userComment string) (RebuildResult, error) {
+func (s *Supervisor) RebuildDependencies(ctx context.Context, userComment string) ([]DepOption, error) {
 	allTasks, err := s.store.GetAutopilotTasks(s.project.ID)
 	if err != nil {
-		return RebuildResult{}, fmt.Errorf("get tasks: %w", err)
+		return nil, fmt.Errorf("get tasks: %w", err)
 	}
 
 	// Partition tasks: rebuildable (queued + blocked + skipped) vs context-only (running, done, bailed, stopped, review).
@@ -1294,13 +1413,7 @@ func (s *Supervisor) RebuildDependencies(ctx context.Context, userComment string
 	}
 
 	if len(rebuildable) == 0 {
-		return RebuildResult{}, nil
-	}
-
-	// Build issue numbers set for rebuildable tasks.
-	rebuildIssues := make(map[int]bool, len(rebuildable))
-	for _, t := range rebuildable {
-		rebuildIssues[t.IssueNumber] = true
+		return nil, nil
 	}
 
 	// Build issue list for the LLM.
@@ -1371,19 +1484,30 @@ Dependencies can include issues from ALL sections — a queued task can depend o
 		promptParts = append(promptParts, fmt.Sprintf("User feedback on dependencies:\n  %q\n\nRe-analyze and update the dependency graph considering this feedback.", userComment))
 	}
 
-	promptParts = append(promptParts, `Respond with ONLY a JSON object. Keys are issue numbers (only for issues being re-analyzed), values are arrays of integer issue numbers that must complete first. Issues with no dependencies get an empty array.
+	promptParts = append(promptParts, `Respond with ONLY a JSON array of exactly 3 dependency graph options, ranked from most likely correct to least likely. Each option has a "name", "rationale", and "graph" field.
+
+The "graph" is an object where keys are issue numbers (only for issues being re-analyzed), values are arrays of integer issue numbers that must complete first. Issues with no dependencies get an empty array.
 
 If the user asks to skip or exclude an issue from autopilot, set its value to the string "skip" instead of an array.
 
 IMPORTANT: Use integer values in dependency arrays, not strings.
-Example: {"42": [], "38": [42], "15": "skip"}
 
-Be conservative — only add a dependency if the work truly cannot proceed without the other issue being done first.`)
+The 3 options should represent meaningfully different dependency strategies:
+- Option 1: Your best analysis of actual dependencies
+- Option 2: An alternative interpretation (e.g., more conservative or more parallel)
+- Option 3: A different trade-off (e.g., maximum parallelism or stricter ordering)
+
+Example response:
+[
+  {"name": "Conservative — minimal deps", "rationale": "Only blocks issues that truly depend on schema changes.", "graph": {"42": [], "38": [42], "15": []}},
+  {"name": "Moderate — logical grouping", "rationale": "Groups related features; UI issues wait on API changes.", "graph": {"42": [], "38": [42], "15": [42]}},
+  {"name": "Maximum parallelism", "rationale": "All issues can start independently.", "graph": {"42": [], "38": [], "15": []}}
+]`)
 
 	prompt := strings.Join(promptParts, "\n\n")
 	messages := []llm.Message{{Role: "user", Content: prompt}}
 
-	var rawGraph map[string]json.RawMessage
+	var options []DepOption
 	var content string
 
 	for attempt := 0; attempt < 2; attempt++ {
@@ -1391,11 +1515,11 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 			Model:       s.project.LLMAnalyzerModel,
 			System:      "You are analyzing issue dependencies. Respond with ONLY valid JSON, no explanation or preamble.",
 			Messages:    messages,
-			MaxTokens:   512,
+			MaxTokens:   1536,
 			Temperature: 0,
 		})
 		if err != nil {
-			return RebuildResult{}, fmt.Errorf("LLM call: %w", err)
+			return nil, fmt.Errorf("LLM call: %w", err)
 		}
 
 		content = strings.TrimSpace(resp.Content)
@@ -1406,33 +1530,72 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 				content = strings.Join(lines[1:len(lines)-1], "\n")
 			}
 		}
-		// Extract JSON object.
-		if start := strings.Index(content, "{"); start >= 0 {
-			if end := strings.LastIndex(content, "}"); end > start {
+		// Extract JSON array.
+		if start := strings.Index(content, "["); start >= 0 {
+			if end := strings.LastIndex(content, "]"); end > start {
 				content = content[start : end+1]
 			}
 		}
 
-		if err := json.Unmarshal([]byte(content), &rawGraph); err != nil {
+		var rawOptions []struct {
+			Name      string                     `json:"name"`
+			Rationale string                     `json:"rationale"`
+			Graph     map[string]json.RawMessage `json:"graph"`
+		}
+
+		if err := json.Unmarshal([]byte(content), &rawOptions); err != nil {
 			if attempt == 0 {
 				messages = append(messages,
 					llm.Message{Role: "assistant", Content: resp.Content},
-					llm.Message{Role: "user", Content: fmt.Sprintf("That was not valid JSON: %v\n\nPlease respond with ONLY the JSON object, no text before or after.", err)},
+					llm.Message{Role: "user", Content: fmt.Sprintf("That was not valid JSON array: %v\n\nPlease respond with ONLY the JSON array of 3 options, no text before or after.", err)},
 				)
 				continue
 			}
-			return RebuildResult{}, fmt.Errorf("parse dep graph: %w", err)
+			return nil, fmt.Errorf("parse dep options: %w", err)
+		}
+
+		for _, ro := range rawOptions {
+			opt := DepOption{
+				Name:      ro.Name,
+				Rationale: ro.Rationale,
+				Graph:     ro.Graph,
+				Unblocked: countUnblocked(ro.Graph, rebuildable),
+			}
+			options = append(options, opt)
 		}
 		break
 	}
 
-	// Update deps for rebuildable tasks.
+	if len(options) == 0 {
+		return nil, fmt.Errorf("LLM returned no options")
+	}
+
+	return options, nil
+}
+
+// ApplyRebuildDepOption applies a dep option during a running autopilot session,
+// handling the additional concerns of un-skipping, re-evaluating blocked status,
+// and filling slots with newly unblocked tasks.
+func (s *Supervisor) ApplyRebuildDepOption(ctx context.Context, opt DepOption) (RebuildResult, error) {
+	allTasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return RebuildResult{}, fmt.Errorf("get tasks: %w", err)
+	}
+
+	// Only update rebuildable tasks (queued, blocked, skipped).
 	var skipped int
-	for _, t := range rebuildable {
+	for _, t := range allTasks {
+		switch t.Status {
+		case "queued", "blocked", "skipped":
+			// proceed
+		default:
+			continue
+		}
+
 		key := strconv.Itoa(t.IssueNumber)
-		rawDeps, ok := rawGraph[key]
+		rawDeps, ok := opt.Graph[key]
 		if !ok {
-			// LLM didn't mention this task — clear its deps and un-skip if needed.
+			// LLM didn't mention this task — clear deps, un-skip if needed.
 			_ = s.store.UpdateAutopilotTaskDeps(t.ID, "[]")
 			if t.Status == "skipped" {
 				_ = s.store.UpdateAutopilotTaskStatus(t.ID, "queued")
@@ -1440,11 +1603,11 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 			continue
 		}
 
-		// Check for "skip" directive — mark as skipped so discoverNewTasks won't re-add.
+		// Check for "skip" directive.
 		var skipStr string
 		if json.Unmarshal(rawDeps, &skipStr) == nil && skipStr == "skip" {
 			_ = s.store.UpdateAutopilotTaskStatus(t.ID, "skipped")
-			s.emitEvent("warning", fmt.Sprintf("Task #%d excluded from autopilot", t.IssueNumber), t)
+			s.emitEvent("warning", fmt.Sprintf("Task #%d excluded from autopilot", t.IssueNumber), &t)
 			skipped++
 			continue
 		}
@@ -1469,14 +1632,13 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 		}
 		_ = s.store.UpdateAutopilotTaskDeps(t.ID, string(depsJSON))
 
-		// Un-skip: if task was skipped but LLM now gave it deps, restore to queued.
+		// Un-skip if needed.
 		if t.Status == "skipped" {
 			_ = s.store.UpdateAutopilotTaskStatus(t.ID, "queued")
 		}
 	}
 
-	// Re-evaluate blocked status: check all queued/blocked tasks for unblocked deps.
-	// Rebuild status map from fresh DB state.
+	// Re-evaluate blocked status.
 	freshTasks, err := s.store.GetAutopilotTasks(s.project.ID)
 	if err != nil {
 		return RebuildResult{}, fmt.Errorf("refresh tasks: %w", err)
@@ -1485,6 +1647,7 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 	for _, t := range freshTasks {
 		statusMap[t.IssueNumber] = t.Status
 	}
+	trackedItems, _ := s.store.GetTrackedItems(s.project.ID)
 	trackedState := make(map[int]string, len(trackedItems))
 	for _, item := range trackedItems {
 		trackedState[item.Number] = item.State
@@ -1495,7 +1658,6 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 		if t.Status != "queued" && t.Status != "blocked" {
 			continue
 		}
-
 		deps := parseDeps(t.Dependencies)
 		allSatisfied := true
 		anyDep := false
@@ -1513,7 +1675,6 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 				}
 			}
 		}
-
 		if allSatisfied && t.Status == "blocked" {
 			_ = s.store.UpdateAutopilotTaskStatus(t.ID, "queued")
 			unblocked++
@@ -1528,7 +1689,6 @@ Be conservative — only add a dependency if the work truly cannot proceed witho
 	}
 
 	s.emitEvent("completed", fmt.Sprintf("Dep graph rebuilt — %d unblocked, %d skipped", unblocked, skipped), nil)
-
 	return RebuildResult{Unblocked: unblocked, Skipped: skipped}, nil
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -103,9 +103,9 @@ type clearTrackStatusMsg struct{}
 
 // autopilotPrepareResultMsg is sent when autopilot issue fetch completes.
 type autopilotPrepareResultMsg struct {
-	total     int
-	unblocked int
-	err       error
+	total   int
+	options []autopilot.DepOption
+	err     error
 }
 
 // autopilotEventMsg wraps an autopilot supervisor event.
@@ -116,8 +116,21 @@ type clearAutopilotStatusMsg struct{}
 
 // rebuildDepsResultMsg is sent when a dep graph rebuild completes.
 type rebuildDepsResultMsg struct {
+	options []autopilot.DepOption
+	err     error
+}
+
+// applyDepOptionResultMsg is sent when a dep option is applied (during running rebuild).
+type applyDepOptionResultMsg struct {
 	result autopilot.RebuildResult
 	err    error
+}
+
+// autopilotApplyResultMsg is sent when a dep option is applied during initial prepare flow.
+type autopilotApplyResultMsg struct {
+	total     int
+	unblocked int
+	err       error
 }
 
 // reviewSessionResultMsg is sent when a review session launch completes.
@@ -211,7 +224,7 @@ type Model struct {
 
 	// Autopilot.
 	autopilotSupervisor       *autopilot.Supervisor
-	autopilotMode             string // "", "scan-confirm", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "review-confirm", "completed"
+	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "review-confirm", "completed"
 	autopilotModeBeforeReview string // saved mode to restore on review-confirm cancel
 	autopilotStatus           string
 	autopilotTotal            int
@@ -221,11 +234,13 @@ type Model struct {
 	autopilotTaskVP           viewport.Model
 
 	// Autopilot task list cursor and navigation.
-	autopilotTasks         []db.AutopilotTask // sorted task list for navigation
-	autopilotCursor        int                // index into autopilotTasks
-	autopilotSelectedIssue int                // issue number for pinning cursor across refreshes
-	autopilotPaused        bool               // tracks pause state for display
-	autopilotDepGuidance   string             // user guidance for dep graph analysis
+	autopilotTasks         []db.AutopilotTask    // sorted task list for navigation
+	autopilotCursor        int                   // index into autopilotTasks
+	autopilotSelectedIssue int                   // issue number for pinning cursor across refreshes
+	autopilotPaused        bool                  // tracks pause state for display
+	autopilotDepGuidance   string                // user guidance for dep graph analysis
+	autopilotDepOptions    []autopilot.DepOption // dep graph options from LLM
+	autopilotDepSelection  int                   // 0-2, index into autopilotDepOptions
 
 	// Rebuild deps mode.
 	rebuildDepsInput  textarea.Model
@@ -503,7 +518,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		return m, nil
 
-	case rebuildDepsResultMsg:
+	case applyDepOptionResultMsg:
 		if msg.err != nil {
 			m.rebuildDepsStatus = fmt.Sprintf("Error: %v", msg.err)
 		} else {
@@ -521,26 +536,44 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.rebuildAutopilotTaskContent()
-		// Update confirm screen counts if still on confirm.
-		if m.autopilotMode == "confirm" && m.autopilotSupervisor != nil {
-			allTasks, err := m.store.GetAutopilotTasks(m.project.ID)
-			if err == nil {
-				active := 0
-				for _, t := range allTasks {
-					if t.Status != "skipped" {
-						active++
-					}
-				}
-				m.autopilotTotal = active
-			}
-			unblockedTasks, err := m.store.QueuedUnblockedTasks(m.project.ID)
-			if err == nil {
-				m.autopilotUnblocked = len(unblockedTasks)
-			}
+		return m, nil
+
+	case rebuildDepsResultMsg:
+		if msg.err != nil {
+			m.rebuildDepsStatus = fmt.Sprintf("Error: %v", msg.err)
+			return m, nil
 		}
-		return m, tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
-			return clearRebuildDepsStatusMsg{}
-		})
+		// Got new options — enter dep-select mode.
+		m.autopilotDepOptions = msg.options
+		m.autopilotDepSelection = 0
+		m.rebuildDepsStatus = ""
+		if len(msg.options) > 0 {
+			m.autopilotUnblocked = msg.options[0].Unblocked
+		}
+		// If we were in running/completed mode, go to dep-select for rebuild.
+		if m.autopilotMode == "running" || m.autopilotMode == "completed" || m.autopilotMode == "confirm" {
+			m.autopilotMode = "dep-select"
+		}
+		m.rebuildAutopilotTaskContent()
+		return m, nil
+
+	case autopilotApplyResultMsg:
+		m.polling = false
+		if msg.err != nil {
+			m.autopilotStatus = fmt.Sprintf("Error applying deps: %v", msg.err)
+			m.autopilotMode = ""
+			m.autopilotSupervisor = nil
+			return m, tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+				return clearAutopilotStatusMsg{}
+			})
+		}
+		m.autopilotTotal = msg.total
+		m.autopilotUnblocked = msg.unblocked
+		m.autopilotMode = "confirm"
+		m.autopilotStatus = ""
+		m.autopilotDepOptions = nil
+		m.rebuildAutopilotTaskContent()
+		return m, nil
 
 	case clearRebuildDepsStatusMsg:
 		m.rebuildDepsStatus = ""
@@ -652,8 +685,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 		}
 		m.autopilotTotal = msg.total
-		m.autopilotUnblocked = msg.unblocked
-		m.autopilotMode = "confirm"
+		m.autopilotDepOptions = msg.options
+		m.autopilotDepSelection = 0
+		if len(msg.options) > 0 {
+			m.autopilotUnblocked = msg.options[0].Unblocked
+		}
+		m.autopilotMode = "dep-select"
 		m.autopilotStatus = ""
 		m.rebuildAutopilotTaskContent() // populate task list for dep graph display
 		if m.activeTab != tabAutopilot {
@@ -887,6 +924,39 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			m.resizeViewports()
 			return m, m.rebuildDepsInput.Focus()
+		}
+	}
+	if m.autopilotMode == "dep-select" && m.activeTab == tabAutopilot {
+		switch msg.String() {
+		case "left":
+			if n := len(m.autopilotDepOptions); n > 0 {
+				m.autopilotDepSelection = (m.autopilotDepSelection - 1 + n) % n
+				m.autopilotUnblocked = m.autopilotDepOptions[m.autopilotDepSelection].Unblocked
+			}
+			return m, nil
+		case "right":
+			if n := len(m.autopilotDepOptions); n > 0 {
+				m.autopilotDepSelection = (m.autopilotDepSelection + 1) % n
+				m.autopilotUnblocked = m.autopilotDepOptions[m.autopilotDepSelection].Unblocked
+			}
+			return m, nil
+		case "enter":
+			return m.applyDepSelection()
+		case "G":
+			m.mode = "dep-guidance"
+			m.rebuildDepsStatus = ""
+			m.rebuildDepsInput.Reset()
+			if m.width > 4 {
+				m.rebuildDepsInput.SetWidth(m.width - 4)
+			}
+			m.resizeViewports()
+			return m, m.rebuildDepsInput.Focus()
+		case "esc":
+			m.autopilotMode = ""
+			m.autopilotSupervisor = nil
+			m.autopilotStatus = ""
+			m.autopilotDepOptions = nil
+			return m, nil
 		}
 	}
 	if m.autopilotMode == "confirm" && m.activeTab == tabAutopilot {
@@ -1440,6 +1510,10 @@ func (m Model) updateDepGuidance(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.rebuildDepsInput.Blur()
 		m.resizeViewports()
 		if strings.TrimSpace(m.autopilotDepGuidance) != "" {
+			// If we're in dep-select or scan-confirm with options, regenerate immediately.
+			if m.autopilotMode == "dep-select" && m.autopilotSupervisor != nil {
+				return m.prepareAutopilot()
+			}
 			m.autopilotStatus = "Guidance saved — will apply during analysis"
 		} else {
 			m.autopilotStatus = ""
@@ -1467,8 +1541,8 @@ func (m Model) updateRebuildDeps(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.rebuildDepsInput.Blur()
 		sup := m.autopilotSupervisor
 		return m, func() tea.Msg {
-			result, err := sup.RebuildDependencies(context.Background(), guidance)
-			return rebuildDepsResultMsg{result: result, err: err}
+			options, err := sup.RebuildDependencies(context.Background(), guidance)
+			return rebuildDepsResultMsg{options: options, err: err}
 		}
 	}
 
@@ -1918,8 +1992,59 @@ func (m Model) prepareAutopilot() (tea.Model, tea.Cmd) {
 	guidance := m.autopilotDepGuidance
 
 	return m, tea.Batch(m.spinner.Tick, func() tea.Msg {
-		total, unblocked, err := sup.Prepare(context.Background(), guidance)
-		return autopilotPrepareResultMsg{total: total, unblocked: unblocked, err: err}
+		total, options, err := sup.Prepare(context.Background(), guidance)
+		return autopilotPrepareResultMsg{total: total, options: options, err: err}
+	})
+}
+
+// applyDepSelection applies the selected dep option and transitions to confirm.
+func (m Model) applyDepSelection() (tea.Model, tea.Cmd) {
+	sup := m.autopilotSupervisor
+	if sup == nil || len(m.autopilotDepOptions) == 0 {
+		m.autopilotMode = ""
+		return m, nil
+	}
+
+	idx := m.autopilotDepSelection
+	if idx >= len(m.autopilotDepOptions) {
+		idx = 0
+	}
+	opt := m.autopilotDepOptions[idx]
+
+	// If we came from a running rebuild, use ApplyRebuildDepOption.
+	if m.autopilotSupervisor != nil && m.autopilotSupervisor.IsActive() {
+		m.autopilotMode = "running"
+		m.autopilotDepOptions = nil
+		return m, func() tea.Msg {
+			result, err := sup.ApplyRebuildDepOption(context.Background(), opt)
+			return applyDepOptionResultMsg{result: result, err: err}
+		}
+	}
+
+	// Initial prepare flow — apply and go to confirm.
+	m.autopilotStatus = "Applying dependencies..."
+	m.polling = true
+	return m, tea.Batch(m.spinner.Tick, func() tea.Msg {
+		err := sup.ApplyDepOption(context.Background(), opt)
+		if err != nil {
+			return autopilotApplyResultMsg{err: err}
+		}
+		// Count active and unblocked tasks.
+		allTasks, err := m.store.GetAutopilotTasks(m.project.ID)
+		if err != nil {
+			return autopilotApplyResultMsg{err: err}
+		}
+		active := 0
+		for _, t := range allTasks {
+			if t.Status != "skipped" {
+				active++
+			}
+		}
+		unblockedTasks, err := m.store.QueuedUnblockedTasks(m.project.ID)
+		if err != nil {
+			return autopilotApplyResultMsg{err: err}
+		}
+		return autopilotApplyResultMsg{total: active, unblocked: len(unblockedTasks)}
 	})
 }
 

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1,12 +1,14 @@
 package tui
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/dustinlange/agent-minder/internal/autopilot"
 	"github.com/dustinlange/agent-minder/internal/db"
 )
 
@@ -233,6 +235,49 @@ func (m Model) renderAutopilotTab() string {
 			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  Guidance: %q", m.autopilotDepGuidance)))
 			b.WriteString("\n")
 		}
+		return b.String()
+	}
+
+	// Dep-select state: carousel through dependency graph options.
+	if m.autopilotMode == "dep-select" && len(m.autopilotDepOptions) > 0 {
+		idx := m.autopilotDepSelection
+		opt := m.autopilotDepOptions[idx]
+		n := len(m.autopilotDepOptions)
+
+		// Page indicator: ● ○ ○
+		var dots strings.Builder
+		for i := 0; i < n; i++ {
+			if i == idx {
+				dots.WriteString("\u25cf") // ●
+			} else {
+				dots.WriteString("\u25cb") // ○
+			}
+			if i < n-1 {
+				dots.WriteString(" ")
+			}
+		}
+
+		b.WriteString("\n")
+		b.WriteString(headerStyle().Render(fmt.Sprintf("  Autopilot — %s", opt.Name)))
+		b.WriteString("  ")
+		b.WriteString(mutedStyle().Render(fmt.Sprintf("(%d/%d  %s)", idx+1, n, dots.String())))
+		b.WriteString("\n\n")
+		// Wrap rationale to terminal width minus indent.
+		rationaleWidth := m.width - 4
+		if rationaleWidth < 40 {
+			rationaleWidth = 40
+		}
+		b.WriteString(mutedStyle().Width(rationaleWidth).Render(fmt.Sprintf("  %s", opt.Rationale)))
+		b.WriteString("\n")
+		b.WriteString(textStyle().Render(fmt.Sprintf("  %d unblocked of %d issues", opt.Unblocked, m.autopilotTotal)))
+		b.WriteString("\n")
+
+		depTree := m.renderDepGraphFromOption(opt)
+		if depTree != "" {
+			b.WriteString("\n")
+			b.WriteString(depTree)
+		}
+		b.WriteString("\n")
 		return b.String()
 	}
 
@@ -827,6 +872,189 @@ func (m Model) renderDepGraph() string {
 	return b.String()
 }
 
+// renderDepGraphFromOption renders a dependency tree preview from a DepOption's graph data.
+func (m Model) renderDepGraphFromOption(opt autopilot.DepOption) string {
+	if len(opt.Graph) == 0 {
+		return ""
+	}
+
+	type taskDep struct {
+		issueNumber int
+		title       string
+		status      string
+		deps        []int
+	}
+
+	// Build task data from autopilotTasks (for titles) + option graph (for deps).
+	taskTitles := make(map[int]string)
+	for _, t := range m.autopilotTasks {
+		taskTitles[t.IssueNumber] = t.IssueTitle
+	}
+
+	tasks := make([]taskDep, 0, len(opt.Graph))
+	hasDeps := false
+	taskMap := make(map[int]*taskDep)
+
+	for key, rawDeps := range opt.Graph {
+		var issueNum int
+		if _, err := fmt.Sscanf(key, "%d", &issueNum); err != nil {
+			continue
+		}
+
+		// Check for skip.
+		var skipStr string
+		if json.Unmarshal(rawDeps, &skipStr) == nil && skipStr == "skip" {
+			td := taskDep{issueNumber: issueNum, title: taskTitles[issueNum], status: "skipped"}
+			tasks = append(tasks, td)
+			taskMap[issueNum] = &tasks[len(tasks)-1]
+			continue
+		}
+
+		var deps []int
+		if err := json.Unmarshal(rawDeps, &deps); err != nil {
+			var strDeps []string
+			if json.Unmarshal(rawDeps, &strDeps) == nil {
+				for _, sd := range strDeps {
+					var n int
+					if _, err2 := fmt.Sscanf(sd, "%d", &n); err2 == nil {
+						deps = append(deps, n)
+					}
+				}
+			}
+		}
+		if len(deps) > 0 {
+			hasDeps = true
+		}
+
+		td := taskDep{issueNumber: issueNum, title: taskTitles[issueNum], status: "queued", deps: deps}
+		tasks = append(tasks, td)
+		taskMap[issueNum] = &tasks[len(tasks)-1]
+	}
+
+	// Sort tasks by issue number for stable rendering.
+	for i := 0; i < len(tasks); i++ {
+		for j := i + 1; j < len(tasks); j++ {
+			if tasks[i].issueNumber > tasks[j].issueNumber {
+				tasks[i], tasks[j] = tasks[j], tasks[i]
+			}
+		}
+	}
+	// Rebuild taskMap pointers after sort.
+	for i := range tasks {
+		taskMap[tasks[i].issueNumber] = &tasks[i]
+	}
+
+	statusIconFor := func(status string) string {
+		switch status {
+		case "skipped":
+			return "\u2298" // ⊘
+		case "blocked":
+			return "\u25cc" // ◌
+		default:
+			return "\u25cb" // ○
+		}
+	}
+
+	var b strings.Builder
+
+	if !hasDeps {
+		b.WriteString(headerStyle().Render("  Tasks"))
+		b.WriteString("  ")
+		b.WriteString(mutedStyle().Render("(no dependencies)"))
+		b.WriteString("\n")
+		for _, t := range tasks {
+			icon := statusIconFor(t.status)
+			title := t.title
+			if len(title) > 50 {
+				title = title[:47] + "..."
+			}
+			suffix := ""
+			if t.status == "skipped" {
+				suffix = " [SKIPPED]"
+			}
+			line := fmt.Sprintf("    %s #%d  %s%s", icon, t.issueNumber, title, suffix)
+			b.WriteString(mutedStyle().Render(line))
+			b.WriteString("\n")
+		}
+		return b.String()
+	}
+
+	// Build children map.
+	children := make(map[int][]int)
+	hasParent := make(map[int]bool)
+	for _, t := range tasks {
+		for _, dep := range t.deps {
+			children[dep] = append(children[dep], t.issueNumber)
+			hasParent[t.issueNumber] = true
+		}
+	}
+
+	var roots []int
+	for _, t := range tasks {
+		if !hasParent[t.issueNumber] {
+			roots = append(roots, t.issueNumber)
+		}
+	}
+
+	b.WriteString(headerStyle().Render("  Dependencies"))
+	b.WriteString("\n")
+
+	visited := make(map[int]bool)
+	var renderNode func(issue int, prefix string, isLast bool)
+	renderNode = func(issue int, prefix string, isLast bool) {
+		if visited[issue] {
+			return
+		}
+		visited[issue] = true
+
+		connector := "\u251c\u2500 " // ├─
+		if isLast {
+			connector = "\u2514\u2500 " // └─
+		}
+
+		td := taskMap[issue]
+		status := "queued"
+		if td != nil {
+			status = td.status
+		}
+		icon := statusIconFor(status)
+
+		title := ""
+		if td != nil {
+			title = td.title
+			if len(title) > 50 {
+				title = title[:47] + "..."
+			}
+		}
+
+		suffix := ""
+		if td != nil && td.status == "skipped" {
+			suffix = " [SKIPPED]"
+		}
+		line := fmt.Sprintf("    %s%s%s #%d  %s%s", prefix, connector, icon, issue, title, suffix)
+		b.WriteString(mutedStyle().Render(line))
+		b.WriteString("\n")
+
+		childPrefix := prefix
+		if isLast {
+			childPrefix += "   "
+		} else {
+			childPrefix += "\u2502  " // │
+		}
+
+		kids := children[issue]
+		for i, kid := range kids {
+			renderNode(kid, childPrefix, i == len(kids)-1)
+		}
+	}
+
+	for i, root := range roots {
+		renderNode(root, "", i == len(roots)-1)
+	}
+
+	return b.String()
+}
+
 // renderHeader returns the compact 2-line header with inline repo/topic counts.
 func (m Model) renderHeader() string {
 	var b strings.Builder
@@ -1348,6 +1576,16 @@ func (m Model) bottomBarHeight() int {
 		if m.showHelp {
 			return 2 + helpOverlayHeight() + 2 // blank + header + body + close hint + blank
 		}
+		// Autopilot action modes have an extra padding line above the controls.
+		if m.activeTab == tabAutopilot {
+			switch m.autopilotMode {
+			case "scan-confirm", "dep-select", "confirm":
+				if (m.autopilotMode == "scan-confirm" || m.autopilotMode == "dep-select") && m.polling {
+					return 2 // blank + spinner row
+				}
+				return 3 // blank + padding + help row
+			}
+		}
 		return 2 // blank + 1 help row
 	}
 }
@@ -1529,10 +1767,45 @@ func (m Model) renderBottomBar() string {
 			b.WriteString(helpStyle().Render("y: analyze • n: cancel"))
 			b.WriteString("\n")
 		} else if m.activeTab == tabAutopilot && m.autopilotMode == "scan-confirm" {
-			b.WriteString(helpStyle().Render("enter: analyze • esc: cancel"))
-			b.WriteString("\n")
+			if m.polling {
+				b.WriteString("  ")
+				b.WriteString(m.spinner.View())
+				b.WriteString(" ")
+				b.WriteString(mutedStyle().Render("Analyzing tracked items..."))
+				b.WriteString("\n")
+			} else {
+				b.WriteString("\n")
+				b.WriteString(helpKeyStyle().Render("enter"))
+				b.WriteString(helpStyle().Render(": analyze • "))
+				b.WriteString(helpKeyStyle().Render("esc"))
+				b.WriteString(helpStyle().Render(": cancel"))
+				b.WriteString("\n")
+			}
+		} else if m.activeTab == tabAutopilot && m.autopilotMode == "dep-select" {
+			if m.polling {
+				b.WriteString("  ")
+				b.WriteString(m.spinner.View())
+				b.WriteString(" ")
+				b.WriteString(mutedStyle().Render("Analyzing tracked items..."))
+				b.WriteString("\n")
+			} else {
+				b.WriteString("\n")
+				b.WriteString(helpKeyStyle().Render("\u2190/\u2192"))
+				b.WriteString(helpStyle().Render(": flip • "))
+				b.WriteString(helpKeyStyle().Render("enter"))
+				b.WriteString(helpStyle().Render(": select • "))
+				b.WriteString(helpKeyStyle().Render("G"))
+				b.WriteString(helpStyle().Render(": regenerate with comments • "))
+				b.WriteString(helpKeyStyle().Render("esc"))
+				b.WriteString(helpStyle().Render(": cancel"))
+				b.WriteString("\n")
+			}
 		} else if m.activeTab == tabAutopilot && m.autopilotMode == "confirm" {
-			b.WriteString(helpStyle().Render("enter: launch • esc: cancel"))
+			b.WriteString("\n")
+			b.WriteString(helpKeyStyle().Render("enter"))
+			b.WriteString(helpStyle().Render(": launch • "))
+			b.WriteString(helpKeyStyle().Render("esc"))
+			b.WriteString(helpStyle().Render(": cancel"))
 			b.WriteString("\n")
 		} else if m.activeTab == tabAutopilot && m.autopilotMode == "stop-confirm" {
 			b.WriteString(warningStyle().Render("  ⚠ Stop all running agents? "))


### PR DESCRIPTION
## Summary
- LLM now generates 3 ranked dependency graph options in a single call instead of one graph
- New carousel UI (`←`/`→` arrow keys, wrapping) shows full dep tree + rationale per option
- User selects an option before launching autopilot; `G` regenerates with comments
- Improved bottom bar: highlighted key bindings, padding from persistent controls, spinner replaces stale controls during analysis

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] `golangci-lint run ./...` clean
- [ ] Manual: `source scripts/test-env.sh <project> && go run . start "$MINDER_PROJECT"` → `a` → enter → see 3 options carousel → flip with arrows → select → confirm → launches
- [ ] Verify `G` from carousel opens guidance textarea, regenerates on ctrl+d
- [ ] Verify rebuild deps (`G` from running mode) also shows carousel

🤖 Generated with [Claude Code](https://claude.com/claude-code)