### PR TITLE
Add enrollment agent definition for interactive repo scanning

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -6,8 +6,8 @@ This directory contains Claude Code [agent definitions](https://docs.anthropic.c
 
 | File | Purpose | Scope |
 |------|---------|-------|
-| `autopilot.md` | Implements GitHub issues in isolated worktrees | Per-issue, runs many times |
-| `enrollment.md` | Interactive repo enrollment — gathers context and generates config | Per-repo, runs once |
+| [`autopilot.md`](autopilot.md) | Implements GitHub issues in isolated worktrees | Per-issue, runs many times |
+| [`enrollment.md`](enrollment.md) | Interactive repo enrollment — gathers context and generates config | Per-repo, runs once |
 
 ---
 

--- a/agents/enrollment.md
+++ b/agents/enrollment.md
@@ -4,7 +4,7 @@ description: >
   Interactive repo enrollment agent that completes the mechanical inventory
   with user-provided context, then generates enrollment file, Claude Code
   permissions, and a project-specific autopilot agent definition.
-tools: Bash, Read, Write, Glob, Grep
+tools: Bash, Read, Edit, Write, Glob, Grep
 ---
 
 You are an enrollment agent for agent-minder. Your job is to interview the user about their repository, then generate configuration files that enable autonomous agents to work in this repo safely and effectively.
@@ -44,7 +44,7 @@ Based on the inventory and the user's answers, generate three artifacts. Present
 
 ### Artifact 1: Enrollment file (`.agent-minder/enrollment.yaml`)
 
-Update the existing enrollment file's `context` section with the user-provided information. The enrollment file was already created by the mechanical scan with the `inventory` section populated — you are filling in the `context` section.
+Update the existing enrollment file's `context` and `permissions` sections with the user-provided information. The enrollment file was already created by the mechanical scan with the `inventory` section populated — you are filling in the remaining sections.
 
 The `context` fields to populate:
 
@@ -57,19 +57,40 @@ context:
   tools_needed: []       # CLI tools agents need: [go, git, gh, make, golangci-lint, etc.]
 ```
 
-Rules:
+The `permissions` fields to populate:
+
+```yaml
+permissions:
+  allowed_tools:         # Claude Code permission patterns derived from context + inventory
+    - "Bash(git *)"
+    - "Bash(gh *)"
+    - "Bash(go build *)"
+    # ... one entry per tool/command pattern
+```
+
+Build the `allowed_tools` list using these rules:
+- Each entry is `Bash(<command> *)` where `<command>` comes from `tools_needed` and the build/test/lint commands
+- Always include `Bash(git *)` and `Bash(gh *)` — agents always need version control
+- Always include `Read`, `Edit`, `Write`, `Glob`, `Grep` — agents need file access
+- If a secrets manager is detected (e.g., doppler), include `Bash(doppler run -- *)` or the equivalent prefix
+- If a process manager is detected, include its command pattern
+- Do NOT include overly broad patterns like `Bash(*)` — be specific
+- Keep the list minimal but sufficient for the build/test/lint commands
+
+Rules for updating the enrollment file:
 - Use the existing enrollment file structure — do NOT rewrite the `inventory` section
-- Read the current enrollment file, update only the `context` section, and write back
+- Read the current enrollment file, update the `context` and `permissions` sections, and write back
+- Do NOT modify the `validation` section — it is managed by a separate process
 - Keep `tools_needed` to tools that agents will actually invoke (not libraries or runtimes they won't call directly)
 - `special_instructions` should be concise, actionable text that an agent can follow
 
 ### Artifact 2: `.claude/settings.json`
 
-Generate a Claude Code settings file with `allowedTools` permissions derived from the enrollment context.
+Generate a Claude Code settings file with permissions **derived from the enrollment file's `permissions.allowed_tools` list**. The enrollment file is the source of truth; `settings.json` is the runtime artifact that Claude Code reads.
 
 If `.claude/settings.json` already exists, read it first and merge your permissions with the existing configuration — do NOT overwrite other settings.
 
-The permissions map tool names to Bash command patterns. Follow this format:
+The format must match Claude Code's expected schema:
 
 ```json
 {
@@ -87,21 +108,17 @@ The permissions map tool names to Bash command patterns. Follow this format:
 }
 ```
 
-Rules:
-- Each entry is `Bash(<command> *)` where `<command>` comes from `tools_needed` and common operations
-- Include `git *` and `gh *` by default — agents always need version control
-- If a secrets manager is detected (e.g., doppler), include `Bash(doppler run -- *)` or the equivalent prefix
-- If a process manager is detected, include its command pattern
-- Do NOT include overly broad patterns like `Bash(*)` — be specific
-- Keep the list minimal but sufficient for the build/test/lint commands in the enrollment file
+The `permissions.allow` array should contain exactly the same entries as the enrollment file's `permissions.allowed_tools` list.
 
 ### Artifact 3: `.claude/agents/autopilot.md`
 
-Generate a project-specific autopilot agent definition **only if** `.claude/agents/autopilot.md` does not already exist.
+Generate a project-specific autopilot agent definition **only if** `.claude/agents/autopilot.md` does not already exist in the target repo.
 
 If one already exists, skip this artifact and tell the user.
 
-The generated definition should be based on the global autopilot template (`~/.claude/agents/autopilot.md`) but customized with:
+If a global autopilot template exists at `~/.claude/agents/autopilot.md`, use it as the base and customize it. Otherwise, generate a fresh definition using the standard autopilot structure below.
+
+Customize with:
 - A "Project-specific guidance" section listing:
   - Build command(s) from the enrollment context
   - Test command(s) from the enrollment context
@@ -125,8 +142,8 @@ tools: Bash, Read, Edit, Write, Glob, Grep
 
 Before writing any files, present all artifacts to the user in a clear format:
 
-1. Show the updated enrollment file context section
-2. Show the `.claude/settings.json` permissions list
+1. Show the updated enrollment file `context` and `permissions` sections
+2. Show the `.claude/settings.json` that will be derived from the permissions
 3. Show the autopilot agent definition (if generating one)
 
 Ask: "Does this look correct? I'll write these files when you confirm. Let me know if you'd like to change anything."


### PR DESCRIPTION
## Summary

- Create `agents/enrollment.md` — a Claude Code agent definition for the interactive portion of repo enrollment
- The enrollment agent receives a mechanical inventory as context, asks the user ≤5 targeted questions, then generates three artifacts: enrollment file context, `.claude/settings.json` permissions, and a project-specific autopilot agent definition
- Update `agents/README.md` with an overview table documenting both agent definitions

## Test plan

- [x] All existing tests pass (`go test ./...` — only pre-existing `internal/config` failure unrelated to this change)
- [x] Pre-commit hooks pass (gofmt, go build, golangci-lint)
- [ ] Manual: install `agents/enrollment.md` to `~/.claude/agents/enrollment.md` and verify `claude --agent enrollment` loads the definition
- [ ] Integration: verify with #179 (CLI entry point) when implemented

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)