### PR TITLE
Detect and recover from agent permission/limit failures (#77)

### DIFF
--- a/.claude/agents/autopilot.md
+++ b/.claude/agents/autopilot.md
@@ -75,3 +75,4 @@ After exploring, decide:
 - Do not keep retrying if you are stuck — bail early with good context
 - Do not over-engineer. Implement exactly what the issue asks for.
 - Quality gates: this repo has pre-commit hooks (gofmt, go build, golangci-lint) via lefthook. Respect them.
+- **Permission failures**: If a tool call is denied, you may try 2-3 alternative approaches. If those are also denied, bail immediately — do not keep trying workarounds. Post a comment explaining which tools/permissions are needed.

--- a/agents/autopilot.md
+++ b/agents/autopilot.md
@@ -61,3 +61,4 @@ After exploring, decide:
 - Do not keep retrying if you are stuck — bail early with good context
 - Do not over-engineer. Implement exactly what the issue asks for.
 - Quality gates: this repo may have pre-commit hooks, linters, or test suites. Respect them.
+- **Permission failures**: If a tool call is denied, you may try 2-3 alternative approaches. If those are also denied, bail immediately — do not keep trying workarounds. Post a comment explaining which tools/permissions are needed.

--- a/internal/autopilot/outcome.go
+++ b/internal/autopilot/outcome.go
@@ -1,0 +1,96 @@
+package autopilot
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// AgentResult holds parsed fields from the stream-json result event.
+type AgentResult struct {
+	SubType           string            `json:"subtype"`
+	IsError           bool              `json:"is_error"`
+	NumTurns          int               `json:"num_turns"`
+	TotalCost         float64           `json:"total_cost_usd"`
+	StopReason        json.RawMessage   `json:"stop_reason"`
+	Result            string            `json:"result"`
+	PermissionDenials []json.RawMessage `json:"permission_denials"`
+	SessionID         string            `json:"session_id"`
+}
+
+// resultEvent is the full stream-json event; we only care about type=="result".
+type resultEvent struct {
+	Type string `json:"type"`
+	AgentResult
+}
+
+// parseAgentLog reads the agent log file and extracts the result event.
+// Returns nil if the log is missing, empty, or contains no result event.
+func parseAgentLog(logPath string) (*AgentResult, error) {
+	if logPath == "" {
+		return nil, nil
+	}
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("open agent log: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024) // 1MB max line
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		var evt resultEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+
+		if evt.Type == "result" {
+			result := evt.AgentResult
+			return &result, nil
+		}
+	}
+
+	return nil, nil // no result event found
+}
+
+// classifyOutcome determines failure reason from the result event + config.
+// Returns (status, failureReason, failureDetail).
+// Empty status means no failure detected — caller should continue with PR check.
+func classifyOutcome(result *AgentResult, maxTurns int, maxBudget float64) (string, string, string) {
+	if result == nil {
+		return "", "", ""
+	}
+
+	// 1. Permission denials (non-empty array).
+	if len(result.PermissionDenials) > 0 {
+		detail, _ := json.Marshal(result.PermissionDenials)
+		return "failed", "permissions", string(detail)
+	}
+
+	// 2. Turn limit exhaustion.
+	if maxTurns > 0 && result.NumTurns >= maxTurns {
+		return "failed", "max_turns", fmt.Sprintf("used %d of %d turns", result.NumTurns, maxTurns)
+	}
+
+	// 3. Budget exhaustion (>= 95% of limit).
+	if maxBudget > 0 && result.TotalCost >= maxBudget*0.95 {
+		return "failed", "max_budget", fmt.Sprintf("spent $%.2f of $%.2f budget", result.TotalCost, maxBudget)
+	}
+
+	// 4. Explicit error flag.
+	if result.IsError {
+		detail := result.Result
+		if len(detail) > 500 {
+			detail = detail[:500] + "..."
+		}
+		return "failed", "error", detail
+	}
+
+	// No failure detected.
+	return "", "", ""
+}

--- a/internal/autopilot/outcome_test.go
+++ b/internal/autopilot/outcome_test.go
@@ -1,0 +1,226 @@
+package autopilot
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseAgentLog_ResultEvent(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+
+	content := `{"type":"system","subtype":"init","session_id":"abc-123"}
+{"type":"assistant","message":{"model":"claude-sonnet-4-6","content":[{"type":"text","text":"Working on it..."}]}}
+{"type":"result","subtype":"success","is_error":false,"num_turns":5,"total_cost_usd":0.42,"stop_reason":null,"result":"Done!","permission_denials":[],"session_id":"abc-123"}
+`
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := parseAgentLog(logPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.NumTurns != 5 {
+		t.Errorf("NumTurns = %d, want 5", result.NumTurns)
+	}
+	if result.TotalCost != 0.42 {
+		t.Errorf("TotalCost = %f, want 0.42", result.TotalCost)
+	}
+	if result.Result != "Done!" {
+		t.Errorf("Result = %q, want %q", result.Result, "Done!")
+	}
+	if result.SessionID != "abc-123" {
+		t.Errorf("SessionID = %q, want %q", result.SessionID, "abc-123")
+	}
+	if result.IsError {
+		t.Error("IsError should be false")
+	}
+	if len(result.PermissionDenials) != 0 {
+		t.Errorf("PermissionDenials should be empty, got %d", len(result.PermissionDenials))
+	}
+}
+
+func TestParseAgentLog_NoResultEvent(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+
+	content := `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"content":[]}}
+`
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := parseAgentLog(logPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil result when no result event present")
+	}
+}
+
+func TestParseAgentLog_EmptyPath(t *testing.T) {
+	result, err := parseAgentLog("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil for empty path")
+	}
+}
+
+func TestParseAgentLog_MissingFile(t *testing.T) {
+	_, err := parseAgentLog("/nonexistent/path/agent.log")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestParseAgentLog_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+
+	content := `not json at all
+{"type":"result","subtype":"success","num_turns":3,"total_cost_usd":0.10,"result":"ok","permission_denials":[]}
+more garbage
+`
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := parseAgentLog(logPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("should still find result event among garbage lines")
+	}
+	if result.NumTurns != 3 {
+		t.Errorf("NumTurns = %d, want 3", result.NumTurns)
+	}
+}
+
+func TestClassifyOutcome_PermissionDenials(t *testing.T) {
+	result := &AgentResult{
+		NumTurns:          5,
+		TotalCost:         0.10,
+		PermissionDenials: []json.RawMessage{json.RawMessage(`"Bash"`), json.RawMessage(`"Edit"`)},
+	}
+	status, reason, detail := classifyOutcome(result, 50, 3.0)
+	if status != "failed" {
+		t.Errorf("status = %q, want %q", status, "failed")
+	}
+	if reason != "permissions" {
+		t.Errorf("reason = %q, want %q", reason, "permissions")
+	}
+	if detail == "" {
+		t.Error("detail should not be empty")
+	}
+}
+
+func TestClassifyOutcome_MaxTurns(t *testing.T) {
+	result := &AgentResult{
+		NumTurns:  50,
+		TotalCost: 1.50,
+	}
+	status, reason, detail := classifyOutcome(result, 50, 3.0)
+	if status != "failed" {
+		t.Errorf("status = %q, want %q", status, "failed")
+	}
+	if reason != "max_turns" {
+		t.Errorf("reason = %q, want %q", reason, "max_turns")
+	}
+	if detail == "" {
+		t.Error("detail should not be empty")
+	}
+}
+
+func TestClassifyOutcome_MaxBudget(t *testing.T) {
+	result := &AgentResult{
+		NumTurns:  10,
+		TotalCost: 2.90, // >= 3.0 * 0.95 = 2.85
+	}
+	status, reason, detail := classifyOutcome(result, 50, 3.0)
+	if status != "failed" {
+		t.Errorf("status = %q, want %q", status, "failed")
+	}
+	if reason != "max_budget" {
+		t.Errorf("reason = %q, want %q", reason, "max_budget")
+	}
+	if detail == "" {
+		t.Error("detail should not be empty")
+	}
+}
+
+func TestClassifyOutcome_Error(t *testing.T) {
+	result := &AgentResult{
+		IsError: true,
+		Result:  "Something went terribly wrong",
+	}
+	status, reason, detail := classifyOutcome(result, 50, 3.0)
+	if status != "failed" {
+		t.Errorf("status = %q, want %q", status, "failed")
+	}
+	if reason != "error" {
+		t.Errorf("reason = %q, want %q", reason, "error")
+	}
+	if detail != "Something went terribly wrong" {
+		t.Errorf("detail = %q, want result text", detail)
+	}
+}
+
+func TestClassifyOutcome_NoFailure(t *testing.T) {
+	result := &AgentResult{
+		NumTurns:  10,
+		TotalCost: 0.50,
+	}
+	status, reason, detail := classifyOutcome(result, 50, 3.0)
+	if status != "" {
+		t.Errorf("status = %q, want empty", status)
+	}
+	if reason != "" {
+		t.Errorf("reason = %q, want empty", reason)
+	}
+	if detail != "" {
+		t.Errorf("detail = %q, want empty", detail)
+	}
+}
+
+func TestClassifyOutcome_Nil(t *testing.T) {
+	status, reason, detail := classifyOutcome(nil, 50, 3.0)
+	if status != "" || reason != "" || detail != "" {
+		t.Error("expected all empty for nil result")
+	}
+}
+
+func TestClassifyOutcome_PriorityOrder(t *testing.T) {
+	// Permission denials should take priority over max_turns.
+	result := &AgentResult{
+		NumTurns:          50,
+		TotalCost:         2.90,
+		IsError:           true,
+		PermissionDenials: []json.RawMessage{json.RawMessage(`"Bash"`)},
+	}
+	_, reason, _ := classifyOutcome(result, 50, 3.0)
+	if reason != "permissions" {
+		t.Errorf("reason = %q, want %q (permissions should take priority)", reason, "permissions")
+	}
+}
+
+func TestClassifyOutcome_BudgetBelowThreshold(t *testing.T) {
+	result := &AgentResult{
+		NumTurns:  10,
+		TotalCost: 2.80, // below 3.0 * 0.95 = 2.85
+	}
+	status, _, _ := classifyOutcome(result, 50, 3.0)
+	if status != "" {
+		t.Error("should not classify as failed when cost is below threshold")
+	}
+}

--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -102,6 +102,7 @@ After exploring, decide:
 - Do not keep retrying if you are stuck — bail early with good context
 - Do not over-engineer. Implement exactly what the issue asks for.
 - Quality gates: this repo may have pre-commit hooks, linters, or test suites. Respect them.
+- **Permission failures**: If a tool call is denied, you may try 2-3 alternative approaches. If those are also denied, bail immediately — do not keep trying workarounds. Post a comment explaining which tools/permissions are needed.
 `
 
 // detectAgentDef probes the three-tier failover chain without writing anything.

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -1519,18 +1519,32 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 	status := s.inspectOutcome(ctx, task, exitCode)
 	_ = s.store.UpdateAutopilotTaskStatus(task.ID, status)
 
-	if status == "review" {
+	switch status {
+	case "review":
 		// Swap in-progress → needs-review label on the issue.
 		ghClient := ghpkg.NewClient(s.ghToken)
 		ghClient.RemoveLabel(ctx, s.owner, s.repo, task.IssueNumber, "in-progress")
 		_ = ghClient.AddLabel(ctx, s.owner, s.repo, task.IssueNumber, "needs-review")
 		s.emitEvent("completed", fmt.Sprintf("Agent completed #%d — PR opened, awaiting review & merge", task.IssueNumber), task)
-	} else {
+	case "failed":
+		// Remove in-progress label since the agent is done.
+		ghClient := ghpkg.NewClient(s.ghToken)
+		ghClient.RemoveLabel(ctx, s.owner, s.repo, task.IssueNumber, "in-progress")
+		// Reload task to get failure_reason populated by inspectOutcome.
+		if updated, err := s.store.GetAutopilotTasks(s.project.ID); err == nil {
+			for _, t := range updated {
+				if t.ID == task.ID {
+					s.emitEvent("failed", fmt.Sprintf("Agent failed on #%d (%s)", task.IssueNumber, t.FailureReason), task)
+					break
+				}
+			}
+		}
+	default:
 		s.emitEvent("bailed", fmt.Sprintf("Agent bailed on #%d (exit code %d)", task.IssueNumber, exitCode), task)
 	}
 
-	// Cleanup: remove worktree, delete branch only if bailed.
-	s.cleanup(task, status == "bailed")
+	// Cleanup: remove worktree, delete branch if bailed or failed.
+	s.cleanup(task, status == "bailed" || status == "failed")
 }
 
 // checkReviewTasks checks if any tasks in "review" status have had their PRs merged.
@@ -1647,6 +1661,22 @@ func (s *Supervisor) checkManualTasks(ctx context.Context) int {
 }
 
 func (s *Supervisor) inspectOutcome(ctx context.Context, task *db.AutopilotTask, exitCode int) string {
+	// Parse agent log for result event to detect structured failures.
+	agentResult, err := parseAgentLog(task.AgentLog)
+	if err != nil {
+		debugLog("inspectOutcome: parse agent log failed",
+			"issue", task.IssueNumber, "error", err.Error())
+	}
+	if agentResult != nil {
+		status, reason, detail := classifyOutcome(agentResult, s.project.AutopilotMaxTurns, s.project.AutopilotMaxBudgetUSD)
+		if status == "failed" {
+			_ = s.store.UpdateAutopilotTaskFailure(task.ID, reason, detail)
+			debugLog("inspectOutcome: classified as failed",
+				"issue", task.IssueNumber, "reason", reason)
+			return "failed"
+		}
+	}
+
 	// Check if a PR was opened for this branch.
 	ghClient := ghpkg.NewClient(s.ghToken)
 	pr, err := ghClient.FetchPRForBranch(ctx, s.owner, s.repo, task.Branch)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -176,21 +176,23 @@ func (c *CompletedItem) DisplayRef() string {
 
 // AutopilotTask represents an issue being worked on by an autopilot agent.
 type AutopilotTask struct {
-	ID           int64  `db:"id"`
-	ProjectID    int64  `db:"project_id"`
-	Owner        string `db:"owner"`
-	Repo         string `db:"repo"`
-	IssueNumber  int    `db:"issue_number"`
-	IssueTitle   string `db:"issue_title"`
-	IssueBody    string `db:"issue_body"`
-	Dependencies string `db:"dependencies"` // JSON array of issue numbers
-	Status       string `db:"status"`       // queued, running, done, bailed, stopped, blocked
-	WorktreePath string `db:"worktree_path"`
-	Branch       string `db:"branch"`
-	PRNumber     int    `db:"pr_number"`
-	AgentLog     string `db:"agent_log"`
-	StartedAt    string `db:"started_at"`
-	CompletedAt  string `db:"completed_at"`
+	ID            int64  `db:"id"`
+	ProjectID     int64  `db:"project_id"`
+	Owner         string `db:"owner"`
+	Repo          string `db:"repo"`
+	IssueNumber   int    `db:"issue_number"`
+	IssueTitle    string `db:"issue_title"`
+	IssueBody     string `db:"issue_body"`
+	Dependencies  string `db:"dependencies"` // JSON array of issue numbers
+	Status        string `db:"status"`       // queued, running, done, bailed, stopped, blocked
+	WorktreePath  string `db:"worktree_path"`
+	Branch        string `db:"branch"`
+	PRNumber      int    `db:"pr_number"`
+	AgentLog      string `db:"agent_log"`
+	StartedAt     string `db:"started_at"`
+	CompletedAt   string `db:"completed_at"`
+	FailureReason string `db:"failure_reason"` // permissions, max_turns, max_budget, error
+	FailureDetail string `db:"failure_detail"` // JSON or text with specifics
 }
 
 // RepoEnrollment represents a cached enrollment file for a repo.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -681,7 +681,7 @@ func (s *Store) GetAutopilotTasks(projectID int64) ([]AutopilotTask, error) {
 
 // UpdateAutopilotTaskStatus updates only the status and completed_at of an autopilot task.
 func (s *Store) UpdateAutopilotTaskStatus(id int64, status string) error {
-	if status == "done" || status == "bailed" || status == "stopped" {
+	if status == "done" || status == "bailed" || status == "stopped" || status == "failed" {
 		_, err := s.db.Exec(`
 			UPDATE autopilot_tasks SET status = ?, completed_at = datetime('now') WHERE id = ?
 		`, status, id)
@@ -703,6 +703,15 @@ func (s *Store) UpdateAutopilotTaskRunning(id int64, worktreePath, branch, agent
 // UpdateAutopilotTaskPR sets the PR number for a completed task.
 func (s *Store) UpdateAutopilotTaskPR(id int64, prNumber int) error {
 	_, err := s.db.Exec(`UPDATE autopilot_tasks SET pr_number = ? WHERE id = ?`, prNumber, id)
+	return err
+}
+
+// UpdateAutopilotTaskFailure sets a task to failed with reason and detail.
+func (s *Store) UpdateAutopilotTaskFailure(id int64, reason, detail string) error {
+	_, err := s.db.Exec(`
+		UPDATE autopilot_tasks SET status = 'failed', failure_reason = ?, failure_detail = ?, completed_at = datetime('now')
+		WHERE id = ?
+	`, reason, detail, id)
 	return err
 }
 
@@ -798,7 +807,7 @@ func (s *Store) ResetStaleAutopilotTasks(projectID int64) (int, error) {
 	result, err := s.db.Exec(`
 		UPDATE autopilot_tasks
 		SET status = 'queued', worktree_path = '', branch = '', agent_log = '',
-		    started_at = '', completed_at = ''
+		    started_at = '', completed_at = '', failure_reason = '', failure_detail = ''
 		WHERE project_id = ? AND (
 			status = 'running'
 			OR (status = 'bailed' AND completed_at IS NULL)
@@ -816,7 +825,8 @@ func (s *Store) ResetAutopilotTask(id int64) error {
 	_, err := s.db.Exec(`
 		UPDATE autopilot_tasks
 		SET status = 'queued', worktree_path = '', branch = '', agent_log = '',
-		    started_at = '', completed_at = '', pr_number = 0
+		    started_at = '', completed_at = '', pr_number = 0,
+		    failure_reason = '', failure_detail = ''
 		WHERE id = ?
 	`, id)
 	return err

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -9,7 +9,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 14
+const currentVersion = 15
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -129,6 +129,8 @@ CREATE TABLE IF NOT EXISTS autopilot_tasks (
 	agent_log      TEXT DEFAULT '',
 	started_at     TEXT DEFAULT '',
 	completed_at   TEXT DEFAULT '',
+	failure_reason TEXT DEFAULT '',
+	failure_detail TEXT DEFAULT '',
 	UNIQUE(project_id, issue_number)
 );
 
@@ -267,6 +269,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 14 {
 		if err := migrateV14(db); err != nil {
 			return fmt.Errorf("apply migration v14: %w", err)
+		}
+	}
+
+	if version < 15 {
+		if err := migrateV15(db); err != nil {
+			return fmt.Errorf("apply migration v15: %w", err)
 		}
 	}
 
@@ -525,6 +533,25 @@ func migrateV14(db *sqlx.DB) error {
 	`)
 	if err != nil {
 		return fmt.Errorf("create repo_enrollments table: %w", err)
+	}
+	return nil
+}
+
+func migrateV15(db *sqlx.DB) error {
+	stmts := []string{
+		`ALTER TABLE autopilot_tasks ADD COLUMN failure_reason TEXT DEFAULT ''`,
+		`ALTER TABLE autopilot_tasks ADD COLUMN failure_detail TEXT DEFAULT ''`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("%s: %w", stmt, err)
+		}
+	}
+	// Null-fill new columns.
+	for _, col := range []string{"failure_reason", "failure_detail"} {
+		if _, err := db.Exec(fmt.Sprintf(`UPDATE autopilot_tasks SET %s = '' WHERE %s IS NULL`, col, col)); err != nil {
+			return fmt.Errorf("null-fill %s: %w", col, err)
+		}
 	}
 	return nil
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -178,9 +178,10 @@ type Model struct {
 
 	// Tracked items (refreshed on poll results).
 	trackedItems     []db.TrackedItem
-	bailedIssues     map[int]bool // issue numbers with bailed autopilot tasks
-	trackedExpanded  bool         // 'x' toggles compact strip vs expanded list with titles
-	concernsExpanded bool         // 'c' toggles capped vs full concern display
+	bailedIssues     map[int]bool   // issue numbers with bailed autopilot tasks
+	failedIssues     map[int]string // issue numbers with failed autopilot tasks → failure reason
+	trackedExpanded  bool           // 'x' toggles compact strip vs expanded list with titles
+	concernsExpanded bool           // 'c' toggles capped vs full concern display
 
 	// Settings dialog.
 	settingsState  *settingsState
@@ -238,6 +239,7 @@ type Model struct {
 	autopilotTasks         []db.AutopilotTask    // sorted task list for navigation
 	autopilotCursor        int                   // index into autopilotTasks
 	autopilotSelectedIssue int                   // issue number for pinning cursor across refreshes
+	failureDetailExpanded  bool                  // toggle full failure detail in task detail panel
 	autopilotPaused        bool                  // tracks pause state for display
 	autopilotDepGuidance   string                // user guidance for dep graph analysis
 	autopilotDepOptions    []autopilot.DepOption // dep graph options from LLM
@@ -743,7 +745,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds := []tea.Cmd{listenForAutopilotEvents(m.autopilotSupervisor)}
 		// Sync operations tab on state-changing events.
 		switch event.Type {
-		case "started", "completed", "bailed", "stopped", "finished":
+		case "started", "completed", "failed", "bailed", "stopped", "finished":
 			p := m.poller
 			cmds = append(cmds, func() tea.Msg {
 				time.Sleep(4 * time.Second)
@@ -1064,7 +1066,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		//   - review → launch review session
 		if m.activeTab == tabAutopilot && (m.autopilotMode == "running" || m.autopilotMode == "completed") {
 			task := m.selectedAutopilotTask()
-			if task != nil && (task.Status == "bailed" || task.Status == "stopped") {
+			if task != nil && (task.Status == "failed" || task.Status == "bailed" || task.Status == "stopped") {
 				m.autopilotMode = "restart-confirm"
 				return m, nil
 			}
@@ -1096,6 +1098,14 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "i":
+		// Toggle failure detail expansion in autopilot task detail.
+		if m.activeTab == tabAutopilot && (m.autopilotMode == "running" || m.autopilotMode == "completed") {
+			task := m.selectedAutopilotTask()
+			if task != nil && task.Status == "failed" && task.FailureDetail != "" {
+				m.failureDetailExpanded = !m.failureDetailExpanded
+				return m, nil
+			}
+		}
 		ghRepos := m.poller.GitHubRepos()
 		if len(ghRepos) == 0 {
 			m.trackStatus = "No GitHub repos enrolled"
@@ -1268,6 +1278,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					}
 				}
 				m.autopilotSelectedIssue = m.autopilotTasks[m.autopilotCursor].IssueNumber
+				m.failureDetailExpanded = false // reset on cursor change
 				m.rebuildAutopilotTaskContent()
 				// Ensure cursor is visible in viewport.
 				m.autopilotTaskVP.SetYOffset(m.autopilotCursor)
@@ -2159,7 +2170,7 @@ func (m Model) confirmStopTask() (tea.Model, tea.Cmd) {
 // confirmRestartTask restarts the selected bailed/stopped task after user confirms.
 func (m Model) confirmRestartTask() (tea.Model, tea.Cmd) {
 	task := m.selectedAutopilotTask()
-	if task == nil || (task.Status != "bailed" && task.Status != "stopped") {
+	if task == nil || (task.Status != "failed" && task.Status != "bailed" && task.Status != "stopped") {
 		m.autopilotMode = "running"
 		return m, nil
 	}
@@ -2245,24 +2256,34 @@ func listenForAutopilotEvents(sup *autopilot.Supervisor) tea.Cmd {
 	}
 }
 
-// refreshTrackedItems reloads tracked items and rebuilds the bailed issues map
+// refreshTrackedItems reloads tracked items and rebuilds the bailed/failed issues map
 // from autopilot tasks.
 func (m *Model) refreshTrackedItems() {
 	m.trackedItems, _ = m.store.GetTrackedItems(m.project.ID)
 	m.bailedIssues = make(map[int]bool)
+	m.failedIssues = make(map[int]string)
 	if tasks, err := m.store.GetAutopilotTasks(m.project.ID); err == nil {
 		for _, t := range tasks {
-			if t.Status == "bailed" {
+			switch t.Status {
+			case "bailed":
 				m.bailedIssues[t.IssueNumber] = true
+			case "failed":
+				m.failedIssues[t.IssueNumber] = t.FailureReason
 			}
 		}
 	}
 }
 
 // effectiveStatus returns the display status for a tracked item, overlaying
-// bailed autopilot status when applicable.
+// bailed/failed autopilot status when applicable.
 func (m Model) effectiveStatus(item db.TrackedItem) string {
-	if m.bailedIssues[item.Number] && item.LastStatus != "Mrgd" && item.LastStatus != "Closd" {
+	if item.LastStatus == "Mrgd" || item.LastStatus == "Closd" {
+		return item.LastStatus
+	}
+	if _, ok := m.failedIssues[item.Number]; ok {
+		return "Faild"
+	}
+	if m.bailedIssues[item.Number] {
 		return "Baild"
 	}
 	return item.LastStatus

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -443,7 +443,7 @@ func (m *Model) rebuildAutopilotTaskContent() {
 		return
 	}
 
-	// Sort tasks by status priority: running → queued → blocked → manual → review → done → bailed → skipped.
+	// Sort tasks by status priority: running → queued → blocked → manual → review → done → failed → bailed → skipped.
 	statusOrder := map[string]int{
 		"running": 0,
 		"queued":  1,
@@ -451,9 +451,10 @@ func (m *Model) rebuildAutopilotTaskContent() {
 		"manual":  3,
 		"review":  4,
 		"done":    5,
-		"bailed":  6,
-		"stopped": 7,
-		"skipped": 8,
+		"failed":  6,
+		"bailed":  7,
+		"stopped": 8,
+		"skipped": 9,
 	}
 	sortedTasks := make([]db.AutopilotTask, len(tasks))
 	copy(sortedTasks, tasks)
@@ -547,7 +548,7 @@ func (m *Model) rebuildAutopilotTaskContent() {
 			styledTitle = title
 		}
 
-		line := fmt.Sprintf("%s%s %s  %s", cursor, issueRef, statusStr, styledTitle)
+		line := fmt.Sprintf("%s%s %s%s  %s", cursor, issueRef, statusStr, taskFailureReasonSuffix(t), styledTitle)
 		if extra != "" {
 			line += "  " + mutedStyle().Render(extra)
 		}
@@ -588,8 +589,33 @@ func (m Model) renderTaskDetail() string {
 	b.WriteString("\n")
 
 	// Status.
-	fmt.Fprintf(&b, "  Status: %s", m.taskStatusDisplay(task.Status))
+	fmt.Fprintf(&b, "  Status: %s%s", m.taskStatusDisplay(task.Status), taskFailureReasonSuffix(*task))
 	b.WriteString("\n")
+
+	// Failure detail.
+	if task.Status == "failed" && task.FailureDetail != "" {
+		if m.failureDetailExpanded {
+			// Full detail, word-wrapped to terminal width.
+			maxW := m.width - 4 // indent
+			if maxW < 20 {
+				maxW = 80
+			}
+			wrapped := wrapTextHard(task.FailureDetail, maxW)
+			for _, line := range wrapped {
+				b.WriteString(errorStyle().Render("  " + line))
+				b.WriteString("\n")
+			}
+			b.WriteString(mutedStyle().Render("  [i: collapse]"))
+			b.WriteString("\n")
+		} else {
+			// Compact: summarize into at most 2 lines.
+			summary := summarizeFailureDetail(task.FailureReason, task.FailureDetail, m.width-12)
+			b.WriteString(errorStyle().Render(fmt.Sprintf("  Detail: %s", summary)))
+			b.WriteString("\n")
+			b.WriteString(mutedStyle().Render("  [i: expand]"))
+			b.WriteString("\n")
+		}
+	}
 
 	// Dependencies.
 	deps := m.taskBlockedContext(*task)
@@ -652,6 +678,8 @@ func (m Model) taskStatusDisplay(status string) string {
 		return broadcastStyle().Render("\u25ce review ")
 	case "done":
 		return statusRunningStyle().Render("\u2713 done   ")
+	case "failed":
+		return errorStyle().Render("\u2717 failed ")
 	case "bailed":
 		return errorStyle().Render("\u2717 bailed ")
 	case "stopped":
@@ -663,6 +691,14 @@ func (m Model) taskStatusDisplay(status string) string {
 	default:
 		return mutedStyle().Render(fmt.Sprintf("  %-7s", status))
 	}
+}
+
+// taskFailureReasonSuffix returns a parenthesized failure reason for display, or empty string.
+func taskFailureReasonSuffix(task db.AutopilotTask) string {
+	if task.Status != "failed" || task.FailureReason == "" {
+		return ""
+	}
+	return fmt.Sprintf(" (%s)", task.FailureReason)
 }
 
 // taskBlockedContext returns a description of what blocks a task.
@@ -778,7 +814,7 @@ func (m Model) renderDepGraph() string {
 		switch status {
 		case "done":
 			return "\u2713" // ✓
-		case "bailed", "stopped":
+		case "failed", "bailed", "stopped":
 			return "\u2717" // ✗
 		case "running":
 			return "\u25cf" // ●
@@ -800,7 +836,7 @@ func (m Model) renderDepGraph() string {
 		switch status {
 		case "done", "running":
 			b.WriteString(statusRunningStyle().Render(line))
-		case "bailed", "stopped", "skipped":
+		case "failed", "bailed", "stopped", "skipped":
 			b.WriteString(errorStyle().Render(line))
 		case "manual":
 			b.WriteString(broadcastStyle().Render(line))
@@ -1994,6 +2030,13 @@ func (m Model) renderHelpBar() string {
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
+				case "failed":
+					condensed = append(condensed,
+						hint{"r", "restart"},
+						hint{"i", "detail"},
+						hint{"l", "log"},
+						hint{"c", "copy path"},
+					)
 				case "bailed", "stopped":
 					condensed = append(condensed,
 						hint{"r", "restart"},
@@ -2027,7 +2070,7 @@ func (m Model) renderHelpBar() string {
 			task := m.selectedAutopilotTask()
 			if task != nil {
 				switch task.Status {
-				case "bailed", "stopped", "done":
+				case "failed", "bailed", "stopped", "done":
 					condensed = append(condensed,
 						hint{"l", "log"},
 						hint{"c", "copy path"},
@@ -2243,4 +2286,60 @@ func truncateLine(s string, maxWidth int) string {
 		return string(runes[:maxWidth])
 	}
 	return string(runes[:maxWidth-3]) + "..."
+}
+
+// summarizeFailureDetail produces a compact 1-line summary of the failure detail.
+// For permission denials, extracts tool names. For other types, truncates the text.
+func summarizeFailureDetail(reason, detail string, maxWidth int) string {
+	if maxWidth < 10 {
+		maxWidth = 40
+	}
+
+	if reason == "permissions" {
+		// Parse the JSON array of denied tool objects and extract tool names.
+		var denials []json.RawMessage
+		if json.Unmarshal([]byte(detail), &denials) == nil && len(denials) > 0 {
+			var toolNames []string
+			seen := make(map[string]bool)
+			for _, d := range denials {
+				var obj map[string]any
+				if json.Unmarshal(d, &obj) == nil {
+					if name, ok := obj["tool_name"].(string); ok && !seen[name] {
+						toolNames = append(toolNames, name)
+						seen[name] = true
+					}
+				}
+			}
+			if len(toolNames) > 0 {
+				summary := fmt.Sprintf("denied tools: %s", strings.Join(toolNames, ", "))
+				if len(summary) > maxWidth {
+					summary = summary[:maxWidth-3] + "..."
+				}
+				return summary
+			}
+		}
+	}
+
+	// Generic: truncate to fit.
+	if len(detail) > maxWidth {
+		return detail[:maxWidth-3] + "..."
+	}
+	return detail
+}
+
+// wrapTextHard wraps a string into lines of at most maxWidth characters (hard break).
+func wrapTextHard(s string, maxWidth int) []string {
+	if maxWidth < 10 {
+		maxWidth = 80
+	}
+	var lines []string
+	for len(s) > 0 {
+		if len(s) <= maxWidth {
+			lines = append(lines, s)
+			break
+		}
+		lines = append(lines, s[:maxWidth])
+		s = s[maxWidth:]
+	}
+	return lines
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -247,7 +247,7 @@ func statusDot(status string) string {
 		return lipgloss.NewStyle().Foreground(t.Warning).Render("\u25cf")
 	case "Blckd":
 		return lipgloss.NewStyle().Foreground(t.Error).Render("\u25cf")
-	case "Baild":
+	case "Baild", "Faild":
 		return lipgloss.NewStyle().Foreground(t.Error).Render("\u2718")
 	case "Mrgd":
 		return lipgloss.NewStyle().Foreground(t.Success).Render("\u2713")


### PR DESCRIPTION
## Summary

- Parse the stream-json `result` event from agent logs to classify failures instead of collapsing all non-PR outcomes into `bailed`
- New `failed` status with structured `failure_reason` (permissions, max_turns, max_budget, error) and `failure_detail`
- Schema v15 adds `failure_reason` and `failure_detail` columns to `autopilot_tasks`
- Failed tasks get `in-progress` label removed from GitHub, worktree cleaned up
- TUI shows `✗ failed (reason)` with compact detail summary; press `i` to expand full detail
- Agent definition updated with permission-failure bail guidance (try 2-3 alternatives, then bail)

## Test plan

- [x] `go test ./internal/autopilot/...` — 13 new tests for log parsing + classification
- [x] `go test ./internal/db/...` — migration + query tests pass
- [x] `go test ./...` — full suite green
- [x] Manual: verified max_budget and max_turns detection via live autopilot run
- [x] Manual: verified permission denial detection by temporarily disabling tool permissions
- [x] Manual: verified TUI display, `i` to expand/collapse detail, `r` to restart failed tasks

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)