### PR TITLE
Add test-task validation loop for enrollment

### DIFF
--- a/internal/agentutil/result.go
+++ b/internal/agentutil/result.go
@@ -1,0 +1,60 @@
+package agentutil
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// AgentResult holds parsed fields from the Claude Code stream-json result event.
+type AgentResult struct {
+	SubType           string            `json:"subtype"`
+	IsError           bool              `json:"is_error"`
+	NumTurns          int               `json:"num_turns"`
+	TotalCost         float64           `json:"total_cost_usd"`
+	StopReason        json.RawMessage   `json:"stop_reason"`
+	Result            string            `json:"result"`
+	PermissionDenials []json.RawMessage `json:"permission_denials"`
+	SessionID         string            `json:"session_id"`
+}
+
+// resultEvent is the full stream-json event; we only care about type=="result".
+type resultEvent struct {
+	Type string `json:"type"`
+	AgentResult
+}
+
+// ParseAgentLog reads a Claude Code stream-json log and extracts the result event.
+// Returns nil (no error) if logPath is empty or contains no result event.
+func ParseAgentLog(logPath string) (*AgentResult, error) {
+	if logPath == "" {
+		return nil, nil
+	}
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("open agent log: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024) // 1MB max line
+
+	for scanner.Scan() {
+		var evt resultEvent
+		if err := json.Unmarshal(scanner.Bytes(), &evt); err != nil {
+			continue
+		}
+		if evt.Type == "result" {
+			r := evt.AgentResult
+			return &r, nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan log: %w", err)
+	}
+
+	return nil, nil
+}

--- a/internal/autopilot/outcome.go
+++ b/internal/autopilot/outcome.go
@@ -1,61 +1,19 @@
 package autopilot
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
-	"os"
+
+	"github.com/dustinlange/agent-minder/internal/agentutil"
 )
 
-// AgentResult holds parsed fields from the stream-json result event.
-type AgentResult struct {
-	SubType           string            `json:"subtype"`
-	IsError           bool              `json:"is_error"`
-	NumTurns          int               `json:"num_turns"`
-	TotalCost         float64           `json:"total_cost_usd"`
-	StopReason        json.RawMessage   `json:"stop_reason"`
-	Result            string            `json:"result"`
-	PermissionDenials []json.RawMessage `json:"permission_denials"`
-	SessionID         string            `json:"session_id"`
-}
+// AgentResult is an alias for the shared type, kept for backward compatibility
+// within the autopilot package.
+type AgentResult = agentutil.AgentResult
 
-// resultEvent is the full stream-json event; we only care about type=="result".
-type resultEvent struct {
-	Type string `json:"type"`
-	AgentResult
-}
-
-// parseAgentLog reads the agent log file and extracts the result event.
-// Returns nil if the log is missing, empty, or contains no result event.
+// parseAgentLog delegates to the shared parser.
 func parseAgentLog(logPath string) (*AgentResult, error) {
-	if logPath == "" {
-		return nil, nil
-	}
-
-	f, err := os.Open(logPath)
-	if err != nil {
-		return nil, fmt.Errorf("open agent log: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024) // 1MB max line
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-
-		var evt resultEvent
-		if err := json.Unmarshal(line, &evt); err != nil {
-			continue
-		}
-
-		if evt.Type == "result" {
-			result := evt.AgentResult
-			return &result, nil
-		}
-	}
-
-	return nil, nil // no result event found
+	return agentutil.ParseAgentLog(logPath)
 }
 
 // classifyOutcome determines failure reason from the result event + config.

--- a/internal/enrollment/validator.go
+++ b/internal/enrollment/validator.go
@@ -1,7 +1,6 @@
 package enrollment
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/dustinlange/agent-minder/internal/agentutil"
 )
 
 const (
@@ -28,6 +29,7 @@ type ValidateConfig struct {
 	TestCommand  string   // e.g., "go test ./..."
 	LintCommand  string   // e.g., "golangci-lint run"
 	LogDir       string   // Directory for agent log files
+	Model        string   // LLM model for the test agent (e.g., "claude-haiku-4-5")
 }
 
 // ValidateResult holds the outcome of the validation run.
@@ -101,7 +103,7 @@ func Validate(ctx context.Context, cfg ValidateConfig, runner CommandRunner) (*V
 		result.Attempts = attempt
 
 		logPath := filepath.Join(cfg.LogDir, fmt.Sprintf("validation-attempt-%d.log", attempt))
-		args := buildTestArgs(currentTools, cfg.TestCommand, cfg.LintCommand)
+		args := buildTestArgs(currentTools, cfg.TestCommand, cfg.LintCommand, cfg.Model)
 
 		exitCode, err := runner.Run(ctx, args, cfg.RepoDir, logPath)
 		if err != nil {
@@ -110,14 +112,14 @@ func Validate(ctx context.Context, cfg ValidateConfig, runner CommandRunner) (*V
 			break
 		}
 
-		agentResult, parseErr := parseValidationLog(logPath)
+		parsed, parseErr := agentutil.ParseAgentLog(logPath)
 		if parseErr != nil {
 			result.Failures = append(result.Failures,
 				fmt.Sprintf("attempt %d: parse log: %v", attempt, parseErr))
 			break
 		}
 
-		failReason := classifyValidation(agentResult, exitCode)
+		failReason := classifyValidation(parsed, exitCode)
 		if failReason == "" {
 			// Success.
 			result.Passed = true
@@ -136,7 +138,7 @@ func Validate(ctx context.Context, cfg ValidateConfig, runner CommandRunner) (*V
 		}
 
 		// Permission failure — try to extract and add denied tools.
-		denied := extractDeniedToolPatterns(agentResult)
+		denied := extractDeniedToolPatterns(parsed)
 		if len(denied) == 0 {
 			result.Failures = append(result.Failures,
 				fmt.Sprintf("attempt %d: permission failure but could not identify denied tools", attempt))
@@ -194,15 +196,18 @@ func ApplyResult(f *File, result *ValidateResult) {
 }
 
 // buildTestArgs constructs the claude CLI arguments for the test agent.
-func buildTestArgs(allowedTools []string, testCmd, lintCmd string) []string {
+func buildTestArgs(allowedTools []string, testCmd, lintCmd, model string) []string {
 	prompt := buildTestPrompt(testCmd, lintCmd)
 
 	args := []string{
 		"-p",
 		"--output-format", "stream-json",
-		"--verbose",
 		"--max-turns", fmt.Sprintf("%d", testMaxTurns),
 		"--max-budget-usd", fmt.Sprintf("%.2f", testMaxBudget),
+	}
+
+	if model != "" {
+		args = append(args, "--model", model)
 	}
 
 	for _, tool := range allowedTools {
@@ -230,54 +235,10 @@ func buildTestPrompt(testCmd, lintCmd string) string {
 	return strings.Join(parts, " ")
 }
 
-// --- Stream-JSON log parsing (mirrors autopilot/outcome.go patterns) ---
-
-// agentResult holds parsed fields from the stream-json result event.
-type agentResult struct {
-	SubType           string            `json:"subtype"`
-	IsError           bool              `json:"is_error"`
-	NumTurns          int               `json:"num_turns"`
-	TotalCost         float64           `json:"total_cost_usd"`
-	Result            string            `json:"result"`
-	PermissionDenials []json.RawMessage `json:"permission_denials"`
-}
-
-// validationResultEvent wraps the stream-json event with its type field.
-type validationResultEvent struct {
-	Type string `json:"type"`
-	agentResult
-}
-
-// parseValidationLog reads the stream-json log and extracts the result event.
-// Returns nil (no error) if the log contains no result event.
-func parseValidationLog(logPath string) (*agentResult, error) {
-	f, err := os.Open(logPath)
-	if err != nil {
-		return nil, fmt.Errorf("open log: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024) // 1MB max line
-
-	for scanner.Scan() {
-		var evt validationResultEvent
-		if err := json.Unmarshal(scanner.Bytes(), &evt); err != nil {
-			continue
-		}
-		if evt.Type == "result" {
-			r := evt.agentResult
-			return &r, nil
-		}
-	}
-
-	return nil, nil
-}
-
 // classifyValidation determines the failure reason from the result event.
 // Returns empty string for success, "permissions" for permission denials,
 // or a human-readable description for other failures.
-func classifyValidation(result *agentResult, exitCode int) string {
+func classifyValidation(result *agentutil.AgentResult, exitCode int) string {
 	if result == nil {
 		if exitCode != 0 {
 			return fmt.Sprintf("agent exited with code %d (no result event)", exitCode)
@@ -293,8 +254,8 @@ func classifyValidation(result *agentResult, exitCode int) string {
 	// Explicit error flag.
 	if result.IsError {
 		detail := result.Result
-		if len(detail) > 200 {
-			detail = detail[:200] + "..."
+		if len(detail) > 500 {
+			detail = detail[:500] + "..."
 		}
 		return fmt.Sprintf("agent error: %s", detail)
 	}
@@ -310,7 +271,7 @@ func classifyValidation(result *agentResult, exitCode int) string {
 // extractDeniedToolPatterns parses the permission_denials array and returns
 // unique tool patterns suitable for --allowedTools. For Bash denials that
 // include a command, it derives a "Bash(<cmd> *)" pattern.
-func extractDeniedToolPatterns(result *agentResult) []string {
+func extractDeniedToolPatterns(result *agentutil.AgentResult) []string {
 	if result == nil || len(result.PermissionDenials) == 0 {
 		return nil
 	}

--- a/internal/enrollment/validator_test.go
+++ b/internal/enrollment/validator_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dustinlange/agent-minder/internal/agentutil"
 )
 
 // --- Mock runner ---
@@ -124,7 +126,7 @@ func TestBuildTestPrompt_OnlyTest(t *testing.T) {
 
 func TestBuildTestArgs(t *testing.T) {
 	tools := []string{"Bash(go *)", "Read", "Edit"}
-	args := buildTestArgs(tools, "go test ./...", "golangci-lint run")
+	args := buildTestArgs(tools, "go test ./...", "golangci-lint run", "claude-haiku-4-5")
 
 	// Check required flags.
 	hasFlag := func(flag, value string) bool {
@@ -144,6 +146,9 @@ func TestBuildTestArgs(t *testing.T) {
 	}
 	if !hasFlag("--max-budget-usd", "0.25") {
 		t.Error("missing --max-budget-usd 0.25")
+	}
+	if !hasFlag("--model", "claude-haiku-4-5") {
+		t.Error("missing --model claude-haiku-4-5")
 	}
 
 	// Check that all allowed tools are present.
@@ -176,7 +181,16 @@ func TestBuildTestArgs(t *testing.T) {
 	}
 }
 
-// --- parseValidationLog tests ---
+func TestBuildTestArgs_NoModel(t *testing.T) {
+	args := buildTestArgs([]string{"Read"}, "go test ./...", "", "")
+	for _, a := range args {
+		if a == "--model" {
+			t.Error("should not include --model when empty")
+		}
+	}
+}
+
+// --- ParseAgentLog tests (via agentutil) ---
 
 func TestParseValidationLog_Success(t *testing.T) {
 	dir := t.TempDir()
@@ -185,7 +199,7 @@ func TestParseValidationLog_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := parseValidationLog(logPath)
+	result, err := agentutil.ParseAgentLog(logPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -214,7 +228,7 @@ func TestParseValidationLog_PermissionDenials(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := parseValidationLog(logPath)
+	result, err := agentutil.ParseAgentLog(logPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -236,7 +250,7 @@ func TestParseValidationLog_NoResultEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := parseValidationLog(logPath)
+	result, err := agentutil.ParseAgentLog(logPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -256,7 +270,7 @@ more garbage
 		t.Fatal(err)
 	}
 
-	result, err := parseValidationLog(logPath)
+	result, err := agentutil.ParseAgentLog(logPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,7 +283,7 @@ more garbage
 }
 
 func TestParseValidationLog_MissingFile(t *testing.T) {
-	_, err := parseValidationLog("/nonexistent/path/test.log")
+	_, err := agentutil.ParseAgentLog("/nonexistent/path/test.log")
 	if err == nil {
 		t.Error("expected error for missing file")
 	}
@@ -278,7 +292,7 @@ func TestParseValidationLog_MissingFile(t *testing.T) {
 // --- classifyValidation tests ---
 
 func TestClassifyValidation_Success(t *testing.T) {
-	result := &agentResult{NumTurns: 3, TotalCost: 0.05}
+	result := &agentutil.AgentResult{NumTurns: 3, TotalCost: 0.05}
 	reason := classifyValidation(result, 0)
 	if reason != "" {
 		t.Errorf("reason = %q, want empty", reason)
@@ -286,7 +300,7 @@ func TestClassifyValidation_Success(t *testing.T) {
 }
 
 func TestClassifyValidation_Permissions(t *testing.T) {
-	result := &agentResult{
+	result := &agentutil.AgentResult{
 		PermissionDenials: []json.RawMessage{json.RawMessage(`"Bash"`)},
 	}
 	reason := classifyValidation(result, 0)
@@ -296,7 +310,7 @@ func TestClassifyValidation_Permissions(t *testing.T) {
 }
 
 func TestClassifyValidation_Error(t *testing.T) {
-	result := &agentResult{IsError: true, Result: "something broke"}
+	result := &agentutil.AgentResult{IsError: true, Result: "something broke"}
 	reason := classifyValidation(result, 1)
 	if !strings.Contains(reason, "agent error") {
 		t.Errorf("reason = %q, should contain 'agent error'", reason)
@@ -304,7 +318,7 @@ func TestClassifyValidation_Error(t *testing.T) {
 }
 
 func TestClassifyValidation_LongErrorTruncated(t *testing.T) {
-	result := &agentResult{IsError: true, Result: strings.Repeat("x", 300)}
+	result := &agentutil.AgentResult{IsError: true, Result: strings.Repeat("x", 600)}
 	reason := classifyValidation(result, 1)
 	if !strings.HasSuffix(reason, "...") {
 		t.Error("long error should be truncated with ...")
@@ -327,7 +341,7 @@ func TestClassifyValidation_NilResultZeroExit(t *testing.T) {
 
 func TestClassifyValidation_PermissionsPriority(t *testing.T) {
 	// Permissions should take priority over error flag.
-	result := &agentResult{
+	result := &agentutil.AgentResult{
 		IsError:           true,
 		PermissionDenials: []json.RawMessage{json.RawMessage(`"Bash"`)},
 	}
@@ -398,7 +412,7 @@ func TestDenialToPattern_EmptyString(t *testing.T) {
 // --- extractDeniedToolPatterns tests ---
 
 func TestExtractDeniedToolPatterns_Mixed(t *testing.T) {
-	result := &agentResult{
+	result := &agentutil.AgentResult{
 		PermissionDenials: []json.RawMessage{
 			json.RawMessage(`{"tool_name":"Bash","command":"npm test"}`),
 			json.RawMessage(`"Write"`),
@@ -419,7 +433,7 @@ func TestExtractDeniedToolPatterns_Mixed(t *testing.T) {
 }
 
 func TestExtractDeniedToolPatterns_Dedup(t *testing.T) {
-	result := &agentResult{
+	result := &agentutil.AgentResult{
 		PermissionDenials: []json.RawMessage{
 			json.RawMessage(`"Bash"`),
 			json.RawMessage(`"Bash"`),
@@ -440,7 +454,7 @@ func TestExtractDeniedToolPatterns_Nil(t *testing.T) {
 }
 
 func TestExtractDeniedToolPatterns_Empty(t *testing.T) {
-	result := &agentResult{}
+	result := &agentutil.AgentResult{}
 	patterns := extractDeniedToolPatterns(result)
 	if patterns != nil {
 		t.Errorf("expected nil, got %v", patterns)


### PR DESCRIPTION
## Summary

- Adds `internal/enrollment/validator.go` — a test-task validation loop that spawns a lightweight Claude Code agent to verify generated enrollment permissions actually work
- Implements a refinement loop (up to 3 attempts) that parses permission denials from stream-json output, extracts denied tool patterns, and retries with expanded permissions
- Reuses #77 detection patterns (permission denial parsing from `autopilot/outcome.go`) adapted for the enrollment context
- Includes `ApplyResult()` to write validation outcomes back to the enrollment file's `validation` section

## Key design decisions

- `CommandRunner` interface allows full testability without requiring `claude` CLI
- `denialToPattern()` maps denial objects to `--allowedTools` patterns, including extracting specific Bash command patterns (e.g., `Bash(npm *)`) from denial context
- Test agent uses `--max-turns 5` and `--max-budget-usd 0.25` for cheap, fast validation
- Non-permission failures (errors, exit codes) stop retrying immediately
- Already-allowed tools being denied also stops retrying (indicates a deeper issue)

## Test plan

- [x] 47 unit tests covering all components (prompt building, log parsing, pattern extraction, refinement loop, enrollment file updates)
- [x] `go build ./...` passes
- [x] `golangci-lint run` passes with 0 issues
- [x] `gofmt` clean
- [x] All pre-commit hooks pass (lefthook: fmt, build, lint)

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)