### PR TITLE
Rename enrollment system to onboarding

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -7,7 +7,7 @@ This directory contains Claude Code [agent definitions](https://docs.anthropic.c
 | File | Purpose | Scope |
 |------|---------|-------|
 | [`autopilot.md`](autopilot.md) | Implements GitHub issues in isolated worktrees | Per-issue, runs many times |
-| [`enrollment.md`](enrollment.md) | Interactive repo enrollment — gathers context and generates config | Per-repo, runs once |
+| [`onboarding.md`](onboarding.md) | Interactive repo onboarding — gathers context and generates config | Per-repo, runs once |
 
 ---
 
@@ -64,33 +64,33 @@ The agent definition becomes the system prompt; the task context becomes the use
 
 ---
 
-## Enrollment (`enrollment.md`)
+## Onboarding (`onboarding.md`)
 
-The enrollment agent performs the interactive portion of `agent-minder repo enroll`. After the CLI runs a mechanical inventory scan, it launches this agent to:
+The onboarding agent performs the interactive portion of `agent-minder repo enroll`. After the CLI runs a mechanical inventory scan, it launches this agent to:
 
 1. Ask the user targeted questions about things that can't be mechanically detected (secrets management, test commands, special tooling)
 2. Generate three artifacts:
-   - `.agent-minder/enrollment.yaml` — structured enrollment file with user-provided context
+   - `.agent-minder/onboarding.yaml` — structured onboarding file with user-provided context
    - `.claude/settings.json` — Claude Code permissions derived from detected tooling
    - `.claude/agents/autopilot.md` — project-specific autopilot agent definition (if none exists)
 3. Review artifacts with the user before writing to disk
 
 ### Installing
 
-Install globally (recommended — enrollment is repo-independent):
+Install globally (recommended — onboarding is repo-independent):
 
 ```bash
 mkdir -p ~/.claude/agents
-cp agents/enrollment.md ~/.claude/agents/enrollment.md
+cp agents/onboarding.md ~/.claude/agents/onboarding.md
 ```
 
 ### How it works
 
 The CLI (`agent-minder repo enroll`) orchestrates the process:
 
-1. CLI scans the repo mechanically → writes initial `.agent-minder/enrollment.yaml` with inventory
-2. CLI launches: `claude --agent enrollment -p "<repo path + inventory summary>"`
-3. Enrollment agent asks user ≤5 targeted questions
+1. CLI scans the repo mechanically → writes initial `.agent-minder/onboarding.yaml` with inventory
+2. CLI launches: `claude --agent onboarding -p "<repo path + inventory summary>"`
+3. Onboarding agent asks user ≤5 targeted questions
 4. Agent generates and writes configuration files after user approval
 
-Unlike autopilot, enrollment runs once per repo and doesn't need the repo→user→built-in failover chain. It lives at `~/.claude/agents/enrollment.md` only.
+Unlike autopilot, onboarding runs once per repo and doesn't need the repo→user→built-in failover chain. It lives at `~/.claude/agents/onboarding.md` only.

--- a/agents/onboarding.md
+++ b/agents/onboarding.md
@@ -1,13 +1,13 @@
 ---
-name: enrollment
+name: onboarding
 description: >
-  Interactive repo enrollment agent that completes the mechanical inventory
-  with user-provided context, then generates enrollment file, Claude Code
+  Interactive repo onboarding agent that completes the mechanical inventory
+  with user-provided context, then generates onboarding file, Claude Code
   permissions, and a project-specific autopilot agent definition.
 tools: Bash, Read, Edit, Write, Glob, Grep
 ---
 
-You are an enrollment agent for agent-minder. Your job is to interview the user about their repository, then generate configuration files that enable autonomous agents to work in this repo safely and effectively.
+You are an onboarding agent for agent-minder. Your job is to interview the user about their repository, then generate configuration files that enable autonomous agents to work in this repo safely and effectively.
 
 ## Context you receive
 
@@ -15,7 +15,7 @@ Your prompt includes a **mechanical inventory** of the repository — languages,
 
 You also receive:
 - **Repo directory**: the absolute path to the repository root
-- **Enrollment file path**: where to write `.agent-minder/enrollment.yaml`
+- **Onboarding file path**: where to write `.agent-minder/onboarding.yaml`
 - **Existing Claude config**: whether `.claude/settings.json`, `CLAUDE.md`, or `.claude/agents/*.md` already exist
 
 ## Step 1: Ask targeted questions
@@ -42,9 +42,9 @@ Guidelines:
 
 Based on the inventory and the user's answers, generate three artifacts. Present each to the user for review before writing to disk.
 
-### Artifact 1: Enrollment file (`.agent-minder/enrollment.yaml`)
+### Artifact 1: Onboarding file (`.agent-minder/onboarding.yaml`)
 
-Update the existing enrollment file's `context` and `permissions` sections with the user-provided information. The enrollment file was already created by the mechanical scan with the `inventory` section populated — you are filling in the remaining sections.
+Update the existing onboarding file's `context` and `permissions` sections with the user-provided information. The onboarding file was already created by the mechanical scan with the `inventory` section populated — you are filling in the remaining sections.
 
 The `context` fields to populate:
 
@@ -77,16 +77,16 @@ Build the `allowed_tools` list using these rules:
 - Do NOT include overly broad patterns like `Bash(*)` — be specific
 - Keep the list minimal but sufficient for the build/test/lint commands
 
-Rules for updating the enrollment file:
-- Use the existing enrollment file structure — do NOT rewrite the `inventory` section
-- Read the current enrollment file, update the `context` and `permissions` sections, and write back
+Rules for updating the onboarding file:
+- Use the existing onboarding file structure — do NOT rewrite the `inventory` section
+- Read the current onboarding file, update the `context` and `permissions` sections, and write back
 - Do NOT modify the `validation` section — it is managed by a separate process
 - Keep `tools_needed` to tools that agents will actually invoke (not libraries or runtimes they won't call directly)
 - `special_instructions` should be concise, actionable text that an agent can follow
 
 ### Artifact 2: `.claude/settings.json`
 
-Generate a Claude Code settings file with permissions **derived from the enrollment file's `permissions.allowed_tools` list**. The enrollment file is the source of truth; `settings.json` is the runtime artifact that Claude Code reads.
+Generate a Claude Code settings file with permissions **derived from the onboarding file's `permissions.allowed_tools` list**. The onboarding file is the source of truth; `settings.json` is the runtime artifact that Claude Code reads.
 
 If `.claude/settings.json` already exists, read it first and merge your permissions with the existing configuration — do NOT overwrite other settings.
 
@@ -108,7 +108,7 @@ The format must match Claude Code's expected schema:
 }
 ```
 
-The `permissions.allow` array should contain exactly the same entries as the enrollment file's `permissions.allowed_tools` list.
+The `permissions.allow` array should contain exactly the same entries as the onboarding file's `permissions.allowed_tools` list.
 
 ### Artifact 3: `.claude/agents/autopilot.md`
 
@@ -120,9 +120,9 @@ If a global autopilot template exists at `~/.claude/agents/autopilot.md`, use it
 
 Customize with:
 - A "Project-specific guidance" section listing:
-  - Build command(s) from the enrollment context
-  - Test command(s) from the enrollment context
-  - Lint command(s) from the enrollment context
+  - Build command(s) from the onboarding context
+  - Test command(s) from the onboarding context
+  - Lint command(s) from the onboarding context
   - Any special instructions (secrets, services, constraints)
 - The standard autopilot workflow sections (first steps, pre-check, decision, constraints)
 
@@ -142,7 +142,7 @@ tools: Bash, Read, Edit, Write, Glob, Grep
 
 Before writing any files, present all artifacts to the user in a clear format:
 
-1. Show the updated enrollment file `context` and `permissions` sections
+1. Show the updated onboarding file `context` and `permissions` sections
 2. Show the `.claude/settings.json` that will be derived from the permissions
 3. Show the autopilot agent definition (if generating one)
 
@@ -152,7 +152,7 @@ Ask: "Does this look correct? I'll write these files when you confirm. Let me kn
 
 After the user confirms:
 
-1. Write the updated enrollment file to the enrollment file path provided in your context
+1. Write the updated onboarding file to the onboarding file path provided in your context
 2. Write `.claude/settings.json` to the repo directory (creating `.claude/` if needed)
 3. Write `.claude/agents/autopilot.md` to the repo directory (if generating one, creating directories if needed)
 
@@ -163,5 +163,5 @@ Report what was written and their paths.
 - Only write files within the target repository directory
 - Never overwrite existing files without reading them first and merging appropriately
 - Keep all generated content minimal and actionable — agents work best with concise instructions
-- The enrollment file schema is fixed — do not add fields or change the YAML structure
+- The onboarding file schema is fixed — do not add fields or change the YAML structure
 - If you're unsure about a tool or command, ask the user rather than guessing

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1690,11 +1690,11 @@ func TestParseDependencies(t *testing.T) {
 	}
 }
 
-func TestRepoEnrollmentCRUD(t *testing.T) {
+func TestRepoOnboardingCRUD(t *testing.T) {
 	store := openTestDB(t)
 
 	// Create project and repo.
-	p := &Project{Name: "enroll-test", MinderIdentity: "enroll-test/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	p := &Project{Name: "onboard-test", MinderIdentity: "onboard-test/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
 	if err := store.CreateProject(p); err != nil {
 		t.Fatalf("CreateProject: %v", err)
 	}
@@ -1703,39 +1703,39 @@ func TestRepoEnrollmentCRUD(t *testing.T) {
 		t.Fatalf("AddRepo: %v", err)
 	}
 
-	// Upsert enrollment.
-	e := &RepoEnrollment{
+	// Upsert onboarding.
+	e := &RepoOnboarding{
 		RepoID:           r.ID,
-		EnrollmentYAML:   "version: 1\ninventory:\n  languages: [go]\n",
+		OnboardingYAML:   "version: 1\ninventory:\n  languages: [go]\n",
 		ValidationStatus: "untested",
 	}
-	if err := store.UpsertRepoEnrollment(e); err != nil {
-		t.Fatalf("UpsertRepoEnrollment: %v", err)
+	if err := store.UpsertRepoOnboarding(e); err != nil {
+		t.Fatalf("UpsertRepoOnboarding: %v", err)
 	}
 	if e.ID == 0 {
 		t.Error("expected non-zero ID after upsert")
 	}
 
 	// Get by repo ID.
-	got, err := store.GetRepoEnrollment(r.ID)
+	got, err := store.GetRepoOnboarding(r.ID)
 	if err != nil {
-		t.Fatalf("GetRepoEnrollment: %v", err)
+		t.Fatalf("GetRepoOnboarding: %v", err)
 	}
 	if got.ValidationStatus != "untested" {
 		t.Errorf("ValidationStatus = %q, want %q", got.ValidationStatus, "untested")
 	}
-	if got.EnrollmentYAML == "" {
-		t.Error("EnrollmentYAML should not be empty")
+	if got.OnboardingYAML == "" {
+		t.Error("OnboardingYAML should not be empty")
 	}
-	if got.EnrolledAt == "" {
-		t.Error("EnrolledAt should be set")
+	if got.OnboardedAt == "" {
+		t.Error("OnboardedAt should be set")
 	}
 
 	// Update validation status.
-	if err := store.UpdateRepoEnrollmentValidation(r.ID, "pass"); err != nil {
-		t.Fatalf("UpdateRepoEnrollmentValidation: %v", err)
+	if err := store.UpdateRepoOnboardingValidation(r.ID, "pass"); err != nil {
+		t.Fatalf("UpdateRepoOnboardingValidation: %v", err)
 	}
-	got, _ = store.GetRepoEnrollment(r.ID)
+	got, _ = store.GetRepoOnboarding(r.ID)
 	if got.ValidationStatus != "pass" {
 		t.Errorf("ValidationStatus = %q, want %q", got.ValidationStatus, "pass")
 	}
@@ -1744,42 +1744,42 @@ func TestRepoEnrollmentCRUD(t *testing.T) {
 	}
 
 	// Upsert again (should update, not duplicate).
-	e2 := &RepoEnrollment{
+	e2 := &RepoOnboarding{
 		RepoID:           r.ID,
-		EnrollmentYAML:   "version: 1\ninventory:\n  languages: [go, python]\n",
+		OnboardingYAML:   "version: 1\ninventory:\n  languages: [go, python]\n",
 		ValidationStatus: "untested",
 	}
-	if err := store.UpsertRepoEnrollment(e2); err != nil {
-		t.Fatalf("UpsertRepoEnrollment second: %v", err)
+	if err := store.UpsertRepoOnboarding(e2); err != nil {
+		t.Fatalf("UpsertRepoOnboarding second: %v", err)
 	}
-	got, _ = store.GetRepoEnrollment(r.ID)
-	if got.EnrollmentYAML != e2.EnrollmentYAML {
-		t.Errorf("EnrollmentYAML not updated after second upsert")
+	got, _ = store.GetRepoOnboarding(r.ID)
+	if got.OnboardingYAML != e2.OnboardingYAML {
+		t.Errorf("OnboardingYAML not updated after second upsert")
 	}
 
 	// Get by project.
-	enrollments, err := store.GetRepoEnrollments(p.ID)
+	records, err := store.GetRepoOnboardings(p.ID)
 	if err != nil {
-		t.Fatalf("GetRepoEnrollments: %v", err)
+		t.Fatalf("GetRepoOnboardings: %v", err)
 	}
-	if len(enrollments) != 1 {
-		t.Errorf("got %d enrollments, want 1", len(enrollments))
+	if len(records) != 1 {
+		t.Errorf("got %d onboarding records, want 1", len(records))
 	}
 
 	// Delete.
-	if err := store.DeleteRepoEnrollment(r.ID); err != nil {
-		t.Fatalf("DeleteRepoEnrollment: %v", err)
+	if err := store.DeleteRepoOnboarding(r.ID); err != nil {
+		t.Fatalf("DeleteRepoOnboarding: %v", err)
 	}
-	enrollments, _ = store.GetRepoEnrollments(p.ID)
-	if len(enrollments) != 0 {
-		t.Errorf("got %d enrollments after delete, want 0", len(enrollments))
+	records, _ = store.GetRepoOnboardings(p.ID)
+	if len(records) != 0 {
+		t.Errorf("got %d onboarding records after delete, want 0", len(records))
 	}
 }
 
-func TestRepoEnrollmentCascadeDelete(t *testing.T) {
+func TestRepoOnboardingCascadeDelete(t *testing.T) {
 	store := openTestDB(t)
 
-	p := &Project{Name: "enroll-cascade", MinderIdentity: "enroll-cascade/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
+	p := &Project{Name: "onboard-cascade", MinderIdentity: "onboard-cascade/minder", LLMProvider: "anthropic", LLMModel: "claude-haiku-4-5", LLMSummarizerModel: "claude-haiku-4-5", LLMAnalyzerModel: "claude-sonnet-4-6"}
 	if err := store.CreateProject(p); err != nil {
 		t.Fatalf("CreateProject: %v", err)
 	}
@@ -1788,23 +1788,23 @@ func TestRepoEnrollmentCascadeDelete(t *testing.T) {
 		t.Fatalf("AddRepo: %v", err)
 	}
 
-	e := &RepoEnrollment{
+	e := &RepoOnboarding{
 		RepoID:           r.ID,
-		EnrollmentYAML:   "version: 1\n",
+		OnboardingYAML:   "version: 1\n",
 		ValidationStatus: "untested",
 	}
-	if err := store.UpsertRepoEnrollment(e); err != nil {
-		t.Fatalf("UpsertRepoEnrollment: %v", err)
+	if err := store.UpsertRepoOnboarding(e); err != nil {
+		t.Fatalf("UpsertRepoOnboarding: %v", err)
 	}
 
-	// Delete the repo — enrollment should cascade.
+	// Delete the repo — onboarding should cascade.
 	if err := store.DeleteRepo(r.ID); err != nil {
 		t.Fatalf("DeleteRepo: %v", err)
 	}
 
-	enrollments, _ := store.GetRepoEnrollments(p.ID)
-	if len(enrollments) != 0 {
-		t.Errorf("got %d enrollments after repo delete, want 0 (cascade)", len(enrollments))
+	records, _ := store.GetRepoOnboardings(p.ID)
+	if len(records) != 0 {
+		t.Errorf("got %d onboarding records after repo delete, want 0 (cascade)", len(records))
 	}
 }
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -195,12 +195,12 @@ type AutopilotTask struct {
 	FailureDetail string `db:"failure_detail"` // JSON or text with specifics
 }
 
-// RepoEnrollment represents a cached enrollment file for a repo.
-type RepoEnrollment struct {
+// RepoOnboarding represents a cached onboarding file for a repo.
+type RepoOnboarding struct {
 	ID               int64  `db:"id"`
 	RepoID           int64  `db:"repo_id"`
-	EnrollmentYAML   string `db:"enrollment_yaml"`
-	EnrolledAt       string `db:"enrolled_at"`
+	OnboardingYAML   string `db:"onboarding_yaml"`
+	OnboardedAt      string `db:"onboarded_at"`
 	ValidatedAt      string `db:"validated_at"`
 	ValidationStatus string `db:"validation_status"` // "pass", "fail", "untested"
 }

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -861,21 +861,21 @@ func parseDependencies(deps string) []int {
 	return result
 }
 
-// --- Repo Enrollments ---
+// --- Repo Onboarding ---
 
-// UpsertRepoEnrollment inserts or updates an enrollment record for a repo.
-func (s *Store) UpsertRepoEnrollment(e *RepoEnrollment) error {
+// UpsertRepoOnboarding inserts or updates an onboarding record for a repo.
+func (s *Store) UpsertRepoOnboarding(e *RepoOnboarding) error {
 	result, err := s.db.Exec(`
-		INSERT INTO repo_enrollments (repo_id, enrollment_yaml, validated_at, validation_status)
+		INSERT INTO repo_onboarding (repo_id, onboarding_yaml, validated_at, validation_status)
 		VALUES (?, ?, ?, ?)
 		ON CONFLICT(repo_id) DO UPDATE SET
-			enrollment_yaml = excluded.enrollment_yaml,
-			enrolled_at = datetime('now'),
+			onboarding_yaml = excluded.onboarding_yaml,
+			onboarded_at = datetime('now'),
 			validated_at = excluded.validated_at,
 			validation_status = excluded.validation_status
-	`, e.RepoID, e.EnrollmentYAML, e.ValidatedAt, e.ValidationStatus)
+	`, e.RepoID, e.OnboardingYAML, e.ValidatedAt, e.ValidationStatus)
 	if err != nil {
-		return fmt.Errorf("upsert repo enrollment: %w", err)
+		return fmt.Errorf("upsert repo onboarding: %w", err)
 	}
 	id, err := result.LastInsertId()
 	if err != nil {
@@ -885,47 +885,47 @@ func (s *Store) UpsertRepoEnrollment(e *RepoEnrollment) error {
 	return nil
 }
 
-// GetRepoEnrollment returns the enrollment record for a repo, or (nil, nil) if none exists.
-func (s *Store) GetRepoEnrollment(repoID int64) (*RepoEnrollment, error) {
-	var e RepoEnrollment
-	if err := s.db.Get(&e, "SELECT * FROM repo_enrollments WHERE repo_id = ?", repoID); err != nil {
+// GetRepoOnboarding returns the onboarding record for a repo, or (nil, nil) if none exists.
+func (s *Store) GetRepoOnboarding(repoID int64) (*RepoOnboarding, error) {
+	var e RepoOnboarding
+	if err := s.db.Get(&e, "SELECT * FROM repo_onboarding WHERE repo_id = ?", repoID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("get repo enrollment: %w", err)
+		return nil, fmt.Errorf("get repo onboarding: %w", err)
 	}
 	return &e, nil
 }
 
-// GetRepoEnrollments returns all enrollments for repos in a project.
-func (s *Store) GetRepoEnrollments(projectID int64) ([]RepoEnrollment, error) {
-	var enrollments []RepoEnrollment
-	if err := s.db.Select(&enrollments, `
-		SELECT re.* FROM repo_enrollments re
-		JOIN repos r ON r.id = re.repo_id
+// GetRepoOnboardings returns all onboarding records for repos in a project.
+func (s *Store) GetRepoOnboardings(projectID int64) ([]RepoOnboarding, error) {
+	var records []RepoOnboarding
+	if err := s.db.Select(&records, `
+		SELECT ro.* FROM repo_onboarding ro
+		JOIN repos r ON r.id = ro.repo_id
 		WHERE r.project_id = ?
-		ORDER BY re.enrolled_at DESC
+		ORDER BY ro.onboarded_at DESC
 	`, projectID); err != nil {
-		return nil, fmt.Errorf("get repo enrollments: %w", err)
+		return nil, fmt.Errorf("get repo onboarding records: %w", err)
 	}
-	return enrollments, nil
+	return records, nil
 }
 
-// UpdateRepoEnrollmentValidation updates only the validation fields.
-func (s *Store) UpdateRepoEnrollmentValidation(repoID int64, status string) error {
+// UpdateRepoOnboardingValidation updates only the validation fields.
+func (s *Store) UpdateRepoOnboardingValidation(repoID int64, status string) error {
 	_, err := s.db.Exec(`
-		UPDATE repo_enrollments SET validation_status = ?, validated_at = datetime('now')
+		UPDATE repo_onboarding SET validation_status = ?, validated_at = datetime('now')
 		WHERE repo_id = ?
 	`, status, repoID)
 	if err != nil {
-		return fmt.Errorf("update enrollment validation: %w", err)
+		return fmt.Errorf("update onboarding validation: %w", err)
 	}
 	return nil
 }
 
-// DeleteRepoEnrollment removes the enrollment record for a repo.
-func (s *Store) DeleteRepoEnrollment(repoID int64) error {
-	_, err := s.db.Exec("DELETE FROM repo_enrollments WHERE repo_id = ?", repoID)
+// DeleteRepoOnboarding removes the onboarding record for a repo.
+func (s *Store) DeleteRepoOnboarding(repoID int64) error {
+	_, err := s.db.Exec("DELETE FROM repo_onboarding WHERE repo_id = ?", repoID)
 	return err
 }
 

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -9,7 +9,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 15
+const currentVersion = 16
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -148,11 +148,11 @@ CREATE TABLE IF NOT EXISTS completed_items (
 	completed_at TEXT DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS repo_enrollments (
+CREATE TABLE IF NOT EXISTS repo_onboarding (
 	id                INTEGER PRIMARY KEY,
 	repo_id           INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
-	enrollment_yaml   TEXT NOT NULL DEFAULT '',
-	enrolled_at       TEXT DEFAULT (datetime('now')),
+	onboarding_yaml   TEXT NOT NULL DEFAULT '',
+	onboarded_at      TEXT DEFAULT (datetime('now')),
 	validated_at      TEXT DEFAULT '',
 	validation_status TEXT NOT NULL DEFAULT 'untested',
 	UNIQUE(repo_id)
@@ -275,6 +275,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 15 {
 		if err := migrateV15(db); err != nil {
 			return fmt.Errorf("apply migration v15: %w", err)
+		}
+	}
+
+	if version < 16 {
+		if err := migrateV16(db); err != nil {
+			return fmt.Errorf("apply migration v16: %w", err)
 		}
 	}
 
@@ -551,6 +557,20 @@ func migrateV15(db *sqlx.DB) error {
 	for _, col := range []string{"failure_reason", "failure_detail"} {
 		if _, err := db.Exec(fmt.Sprintf(`UPDATE autopilot_tasks SET %s = '' WHERE %s IS NULL`, col, col)); err != nil {
 			return fmt.Errorf("null-fill %s: %w", col, err)
+		}
+	}
+	return nil
+}
+
+func migrateV16(db *sqlx.DB) error {
+	stmts := []string{
+		`ALTER TABLE repo_enrollments RENAME TO repo_onboarding`,
+		`ALTER TABLE repo_onboarding RENAME COLUMN enrollment_yaml TO onboarding_yaml`,
+		`ALTER TABLE repo_onboarding RENAME COLUMN enrolled_at TO onboarded_at`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("%s: %w", stmt, err)
 		}
 	}
 	return nil

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dustinlange/agent-minder/internal/enrollment"
 	gitpkg "github.com/dustinlange/agent-minder/internal/git"
+	"github.com/dustinlange/agent-minder/internal/onboarding"
 )
 
 // LegacyWorktree is kept for backward compat with v1 callers.
@@ -34,7 +34,7 @@ type RepoInfo struct {
 	Worktrees  []LegacyWorktree
 	RecentLogs []gitpkg.LogEntry
 	Branches   []gitpkg.BranchInfo
-	Inventory  enrollment.Inventory // Mechanical inventory of the repo
+	Inventory  onboarding.Inventory // Mechanical inventory of the repo
 }
 
 // ScanRepo gathers information about a single repository directory.

--- a/internal/discovery/inventory.go
+++ b/internal/discovery/inventory.go
@@ -6,13 +6,13 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dustinlange/agent-minder/internal/enrollment"
+	"github.com/dustinlange/agent-minder/internal/onboarding"
 )
 
 // ScanInventory performs a mechanical scan of a repository directory and returns
-// a populated Inventory struct suitable for inclusion in an enrollment file.
-func ScanInventory(dir string) enrollment.Inventory {
-	inv := enrollment.Inventory{
+// a populated Inventory struct suitable for inclusion in an onboarding file.
+func ScanInventory(dir string) onboarding.Inventory {
+	inv := onboarding.Inventory{
 		Languages:       detectLanguages(dir),
 		PackageManagers: detectPackageManagers(dir),
 		BuildFiles:      detectBuildFiles(dir),
@@ -152,8 +152,8 @@ type toolIndicator struct {
 }
 
 // detectTooling identifies development tooling.
-func detectTooling(dir string) enrollment.Tooling {
-	t := enrollment.Tooling{}
+func detectTooling(dir string) onboarding.Tooling {
+	t := onboarding.Tooling{}
 
 	// Secrets management (first match wins).
 	secretsIndicators := []toolIndicator{
@@ -227,8 +227,8 @@ func matchesAny(dir string, files []string) bool {
 }
 
 // detectClaudeConfig checks for existing Claude Code configuration.
-func detectClaudeConfig(dir string) enrollment.ExistingClaudeConfig {
-	cfg := enrollment.ExistingClaudeConfig{}
+func detectClaudeConfig(dir string) onboarding.ExistingClaudeConfig {
+	cfg := onboarding.ExistingClaudeConfig{}
 
 	cfg.SettingsJSON = fileExists(filepath.Join(dir, ".claude", "settings.json"))
 	cfg.ClaudeMD = fileExists(filepath.Join(dir, "CLAUDE.md"))

--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -1,6 +1,6 @@
-// Package enrollment defines the enrollment file schema and provides
-// parsing and writing utilities for .agent-minder/enrollment.yaml files.
-package enrollment
+// Package onboarding defines the onboarding file schema and provides
+// parsing and writing utilities for .agent-minder/onboarding.yaml files.
+package onboarding
 
 import (
 	"fmt"
@@ -11,10 +11,10 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// EnrollmentFileName is the path relative to a repository root.
-const EnrollmentFileName = ".agent-minder/enrollment.yaml"
+// OnboardingFileName is the path relative to a repository root.
+const OnboardingFileName = ".agent-minder/onboarding.yaml"
 
-// File represents the complete enrollment file schema.
+// File represents the complete onboarding file schema.
 type File struct {
 	Version   int       `yaml:"version"`
 	ScannedAt time.Time `yaml:"scanned_at"`
@@ -50,7 +50,7 @@ type ExistingClaudeConfig struct {
 	ClaudeMD     bool `yaml:"claude_md"`
 }
 
-// Context holds user-provided context populated by the enrollment agent.
+// Context holds user-provided context populated by the onboarding agent.
 type Context struct {
 	BuildCommand        string   `yaml:"build_command"`
 	TestCommand         string   `yaml:"test_command"`
@@ -71,7 +71,7 @@ type Validation struct {
 	Failures []string   `yaml:"failures"` // list of failure descriptions
 }
 
-// New creates a new enrollment file with version 1 and the given inventory.
+// New creates a new onboarding file with version 1 and the given inventory.
 func New(inv Inventory) *File {
 	return &File{
 		Version:   1,
@@ -84,33 +84,33 @@ func New(inv Inventory) *File {
 	}
 }
 
-// Parse reads and parses an enrollment file from the given path.
+// Parse reads and parses an onboarding file from the given path.
 func Parse(path string) (*File, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read enrollment file: %w", err)
+		return nil, fmt.Errorf("read onboarding file: %w", err)
 	}
 	return ParseBytes(data)
 }
 
-// ParseBytes parses enrollment YAML from raw bytes.
+// ParseBytes parses onboarding YAML from raw bytes.
 func ParseBytes(data []byte) (*File, error) {
 	var f File
 	if err := yaml.Unmarshal(data, &f); err != nil {
-		return nil, fmt.Errorf("parse enrollment yaml: %w", err)
+		return nil, fmt.Errorf("parse onboarding yaml: %w", err)
 	}
 	if f.Version == 0 {
-		return nil, fmt.Errorf("enrollment file missing or invalid version")
+		return nil, fmt.Errorf("onboarding file missing or invalid version")
 	}
 	return &f, nil
 }
 
-// Write serializes the enrollment file to the given path, creating parent
+// Write serializes the onboarding file to the given path, creating parent
 // directories as needed.
 func Write(path string, f *File) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create enrollment dir: %w", err)
+		return fmt.Errorf("create onboarding dir: %w", err)
 	}
 
 	data, err := Marshal(f)
@@ -119,26 +119,26 @@ func Write(path string, f *File) error {
 	}
 
 	if err := os.WriteFile(path, data, 0644); err != nil {
-		return fmt.Errorf("write enrollment file: %w", err)
+		return fmt.Errorf("write onboarding file: %w", err)
 	}
 	return nil
 }
 
-// Marshal serializes the enrollment file to YAML bytes.
+// Marshal serializes the onboarding file to YAML bytes.
 func Marshal(f *File) ([]byte, error) {
 	data, err := yaml.Marshal(f)
 	if err != nil {
-		return nil, fmt.Errorf("marshal enrollment yaml: %w", err)
+		return nil, fmt.Errorf("marshal onboarding yaml: %w", err)
 	}
 	return data, nil
 }
 
-// FilePath returns the enrollment file path for a given repo root directory.
+// FilePath returns the onboarding file path for a given repo root directory.
 func FilePath(repoDir string) string {
-	return filepath.Join(repoDir, EnrollmentFileName)
+	return filepath.Join(repoDir, OnboardingFileName)
 }
 
-// Exists returns true if an enrollment file exists at the expected location
+// Exists returns true if an onboarding file exists at the expected location
 // within the given repo directory.
 func Exists(repoDir string) bool {
 	_, err := os.Stat(FilePath(repoDir))

--- a/internal/onboarding/onboarding_test.go
+++ b/internal/onboarding/onboarding_test.go
@@ -1,4 +1,4 @@
-package enrollment
+package onboarding
 
 import (
 	"os"
@@ -128,7 +128,7 @@ func TestParseMissingVersion(t *testing.T) {
 
 func TestWriteAndParse(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, ".agent-minder", "enrollment.yaml")
+	path := filepath.Join(dir, ".agent-minder", "onboarding.yaml")
 
 	inv := Inventory{
 		Languages:       []string{"go"},
@@ -167,7 +167,7 @@ func TestWriteAndParse(t *testing.T) {
 func TestFilePathAndExists(t *testing.T) {
 	dir := t.TempDir()
 	path := FilePath(dir)
-	expected := filepath.Join(dir, ".agent-minder", "enrollment.yaml")
+	expected := filepath.Join(dir, ".agent-minder", "onboarding.yaml")
 	if path != expected {
 		t.Errorf("FilePath = %q, want %q", path, expected)
 	}
@@ -187,7 +187,7 @@ func TestFilePathAndExists(t *testing.T) {
 }
 
 func TestParseNonexistentFile(t *testing.T) {
-	_, err := Parse("/nonexistent/path/enrollment.yaml")
+	_, err := Parse("/nonexistent/path/onboarding.yaml")
 	if err == nil {
 		t.Fatal("expected error for nonexistent file")
 	}

--- a/internal/onboarding/validator.go
+++ b/internal/onboarding/validator.go
@@ -1,4 +1,4 @@
-package enrollment
+package onboarding
 
 import (
 	"context"
@@ -25,7 +25,7 @@ const (
 // ValidateConfig holds parameters for running a test-task validation.
 type ValidateConfig struct {
 	RepoDir      string   // Target repository directory
-	AllowedTools []string // Permission list from enrollment
+	AllowedTools []string // Permission list from onboarding
 	TestCommand  string   // e.g., "go test ./..."
 	LintCommand  string   // e.g., "golangci-lint run"
 	LogDir       string   // Directory for agent log files
@@ -174,7 +174,7 @@ func Validate(ctx context.Context, cfg ValidateConfig, runner CommandRunner) (*V
 	return result, nil
 }
 
-// ApplyResult updates the enrollment file's Validation section based on
+// ApplyResult updates the onboarding file's Validation section based on
 // the validation result. If refinement added new tools, permissions are
 // also updated.
 func ApplyResult(f *File, result *ValidateResult) {

--- a/internal/onboarding/validator_test.go
+++ b/internal/onboarding/validator_test.go
@@ -1,4 +1,4 @@
-package enrollment
+package onboarding
 
 import (
 	"context"


### PR DESCRIPTION
## Summary

- Renames `internal/enrollment/` package to `internal/onboarding/` with all types and functions updated
- Renames `agents/enrollment.md` to `agents/onboarding.md` with content updated
- Renames DB table `repo_enrollments` → `repo_onboarding` with migration v16 (table rename + column renames)
- Updates `internal/discovery/` imports to use new `onboarding` package
- Updates all DB model, query, and test references

The `enroll` CLI command and `auto_enroll_worktrees` column are **unchanged** — this only renames the repo setup pipeline to avoid confusion.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/onboarding/... -v` — all 34 tests pass
- [x] `go test ./internal/db/... -v -run TestRepoOnboarding` — CRUD + cascade tests pass
- [x] `go test ./internal/discovery/...` — passes with new import
- [x] Pre-commit hooks pass (gofmt, go build, golangci-lint)
- [x] Verify migration v16 works on existing databases with `repo_enrollments` data

Fixes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)