### PR TITLE
Add + key to dynamically add autopilot slots

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -353,6 +353,19 @@ func (s *Supervisor) Resume(ctx context.Context) {
 	s.fillSlots(ctx)
 }
 
+// AddSlot appends one idle slot to the supervisor and immediately tries to fill it.
+// Returns the new total slot count.
+func (s *Supervisor) AddSlot(ctx context.Context) int {
+	s.mu.Lock()
+	s.slots = append(s.slots, nil)
+	n := len(s.slots)
+	s.emitEventLocked("info", fmt.Sprintf("Added slot — now %d total", n), nil)
+	s.mu.Unlock()
+
+	s.fillSlots(ctx)
+	return n
+}
+
 // IsPaused returns whether slot filling is currently paused.
 func (s *Supervisor) IsPaused() bool {
 	s.mu.Lock()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -226,7 +226,7 @@ type Model struct {
 
 	// Autopilot.
 	autopilotSupervisor       *autopilot.Supervisor
-	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "review-confirm", "completed"
+	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "review-confirm", "add-slot-confirm", "completed"
 	autopilotModeBeforeReview string // saved mode to restore on review-confirm cancel
 	autopilotStatus           string
 	autopilotTotal            int
@@ -1018,6 +1018,15 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	}
+	if m.autopilotMode == "add-slot-confirm" && m.activeTab == tabAutopilot {
+		switch msg.String() {
+		case "y", "enter":
+			return m.confirmAddSlot()
+		case "n", "esc":
+			m.autopilotMode = "running"
+			return m, nil
+		}
+	}
 
 	switch msg.String() {
 	case "1":
@@ -1317,6 +1326,15 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
 			return clearAutopilotStatusMsg{}
 		})
+
+	case "+":
+		if m.activeTab != tabAutopilot || m.autopilotSupervisor == nil || m.autopilotMode != "running" {
+			return m, nil
+		}
+		currentSlots := len(m.autopilotSupervisor.SlotStatus())
+		m.autopilotMode = "add-slot-confirm"
+		m.autopilotStatus = fmt.Sprintf("Add slot? Currently %d slots.", currentSlots)
+		return m, nil
 
 	case "c":
 		if m.activeTab == tabAnalysis {
@@ -2199,6 +2217,27 @@ func (m Model) confirmRestartTask() (tea.Model, tea.Cmd) {
 			Summary: fmt.Sprintf("Restarted #%d — re-queued", issueNum),
 		})
 	}
+}
+
+// confirmAddSlot adds a new slot to the supervisor and persists the setting.
+func (m Model) confirmAddSlot() (tea.Model, tea.Cmd) {
+	sup := m.autopilotSupervisor
+	if sup == nil {
+		m.autopilotMode = "running"
+		return m, nil
+	}
+
+	newCount := sup.AddSlot(context.Background())
+
+	// Persist to project settings.
+	m.project.AutopilotMaxAgents = newCount
+	_ = m.store.UpdateProject(m.project)
+
+	m.autopilotMode = "running"
+	m.autopilotStatus = fmt.Sprintf("Now %d slots — filling if tasks available", newCount)
+	return m, tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+		return clearAutopilotStatusMsg{}
+	})
 }
 
 // launchReviewSession restores the worktree and launches a pre-warmed Claude session for review.

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -341,6 +341,8 @@ func (m Model) renderAutopilotRunningContent() string {
 			slotHeader = "Slots  " + warningStyle().Render("PAUSED")
 		}
 		b.WriteString(headerStyle().Render(slotHeader))
+		b.WriteString("  ")
+		b.WriteString(mutedStyle().Render("[+: add slot]"))
 		b.WriteString("\n")
 		for _, slot := range slots {
 			if slot.Status == "idle" {
@@ -1950,6 +1952,17 @@ func (m Model) renderBottomBar() string {
 			b.WriteString(helpKeyStyle().Render("n"))
 			b.WriteString(helpStyle().Render(": cancel"))
 			b.WriteString("\n")
+		} else if m.activeTab == tabAutopilot && m.autopilotMode == "add-slot-confirm" {
+			currentSlots := 0
+			if m.autopilotSupervisor != nil {
+				currentSlots = len(m.autopilotSupervisor.SlotStatus())
+			}
+			b.WriteString(headerStyle().Render(fmt.Sprintf("  Add slot? Currently %d. ", currentSlots)))
+			b.WriteString(helpKeyStyle().Render("y"))
+			b.WriteString(helpStyle().Render(": add • "))
+			b.WriteString(helpKeyStyle().Render("n"))
+			b.WriteString(helpStyle().Render(": cancel"))
+			b.WriteString("\n")
 		} else if m.activeTab == tabAutopilot && m.autopilotMode == "review-confirm" {
 			task := m.selectedAutopilotTask()
 			issueNum := 0
@@ -2165,6 +2178,7 @@ var (
 		{"s", "stop selected"},
 		{"r", "restart/review selected"},
 		{"c", "copy worktree path"},
+		{"+", "add slot"},
 		{"P", "pause/resume slots"},
 		{"D", "show dependencies"},
 		{"G", "rebuild dep graph"},


### PR DESCRIPTION
## Summary
- Adds `+` keybinding in autopilot running mode to add a new concurrent slot
- Shows `[+: add slot]` hint next to the "Slots" header (same pattern as `[e: expand]` on Tasks)
- Confirmation prompt (y/n) before adding, then persists the new `autopilot_max_agents` to the DB
- New `Supervisor.AddSlot()` method appends a slot and immediately triggers `fillSlots()`

## Test plan
- [x] Start autopilot with 1 slot, verify `+` shows confirmation and adds a second slot
- [x] Verify the newly added slot picks up a queued task
- [x] Restart minder and confirm the increased slot count persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)