### PR TITLE
Add version constant to internal/build package

### DIFF
--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -1,0 +1,12 @@
+// Package build provides version information for agent-minder.
+package build
+
+import "fmt"
+
+// Version is the current version of agent-minder.
+const Version = "0.1.0"
+
+// VersionString returns a formatted version string.
+func VersionString() string {
+	return fmt.Sprintf("agent-minder v%s", Version)
+}

--- a/internal/build/version_test.go
+++ b/internal/build/version_test.go
@@ -1,0 +1,25 @@
+package build
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	if Version == "" {
+		t.Fatal("Version must not be empty")
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	got := VersionString()
+	want := "agent-minder v" + Version
+
+	if got != want {
+		t.Errorf("VersionString() = %q, want %q", got, want)
+	}
+
+	if !strings.HasPrefix(got, "agent-minder v") {
+		t.Errorf("VersionString() should start with 'agent-minder v', got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/build` package with a `Version` constant (`"0.1.0"`) and `VersionString()` function
- Includes tests for both the constant and the function

Fixes #185

## Test plan
- [x] `go test ./internal/build/... -v` passes
- [x] Pre-commit hooks (gofmt, go build, golangci-lint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)