### PR TITLE
Add version constant to internal/build package

### DIFF
--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -1,0 +1,9 @@
+package build
+
+// Version is the current version of agent-minder.
+const Version = "0.1.0"
+
+// VersionString returns a formatted version string.
+func VersionString() string {
+	return "agent-minder v" + Version
+}

--- a/internal/build/version_test.go
+++ b/internal/build/version_test.go
@@ -1,0 +1,17 @@
+package build
+
+import "testing"
+
+func TestVersionConstant(t *testing.T) {
+	if Version == "" {
+		t.Fatal("Version constant must not be empty")
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	got := VersionString()
+	want := "agent-minder v" + Version
+	if got != want {
+		t.Errorf("VersionString() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Create `internal/build` package with `Version` constant (`0.1.0`) and `VersionString()` function
- Add tests for both the constant and the formatted version string

## Test plan
- [x] `go test ./internal/build/... -v` passes (2 tests)
- [x] Pre-commit hooks pass (gofmt, build, golangci-lint)

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)