### PR TITLE
Add StringOrDefault helper to internal/util

### DIFF
--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -1,0 +1,9 @@
+package util
+
+// StringOrDefault returns s if it is non-empty, otherwise returns fallback.
+func StringOrDefault(s, fallback string) string {
+	if s != "" {
+		return s
+	}
+	return fallback
+}

--- a/internal/util/strings_test.go
+++ b/internal/util/strings_test.go
@@ -1,0 +1,51 @@
+package util
+
+import "testing"
+
+func TestStringOrDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "non-empty string returns s",
+			s:        "hello",
+			fallback: "default",
+			want:     "hello",
+		},
+		{
+			name:     "empty string returns fallback",
+			s:        "",
+			fallback: "default",
+			want:     "default",
+		},
+		{
+			name:     "both empty returns empty",
+			s:        "",
+			fallback: "",
+			want:     "",
+		},
+		{
+			name:     "whitespace-only string returns s",
+			s:        "  ",
+			fallback: "default",
+			want:     "  ",
+		},
+		{
+			name:     "empty fallback with non-empty s",
+			s:        "hello",
+			fallback: "",
+			want:     "hello",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StringOrDefault(tt.s, tt.fallback)
+			if got != tt.want {
+				t.Errorf("StringOrDefault(%q, %q) = %q, want %q", tt.s, tt.fallback, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds internal/util/strings.go with StringOrDefault(s, fallback string) string — returns s if non-empty, else fallback
- Adds comprehensive table-driven tests in internal/util/strings_test.go (5 cases)

## Test plan
- [x] go test ./internal/util/... -v — all 5 tests pass
- [x] go build ./... — builds cleanly
- [x] Pre-commit hooks (gofmt, build, golangci-lint) all pass

Fixes #186

Generated with Claude Code