### PR TITLE
Fix settings key not working on autopilot tab

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1186,8 +1186,8 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.trackedExpanded = !m.trackedExpanded
 		m.resizeViewports()
 		return m, nil
-	case "s":
-		// On tab 3 during autopilot, 's' stops the selected agent.
+	case "S":
+		// On tab 3 during autopilot, 'S' stops the selected agent.
 		if m.activeTab == tabAutopilot && m.autopilotMode == "running" {
 			task := m.selectedAutopilotTask()
 			if task != nil && task.Status == "running" {
@@ -1195,6 +1195,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
+	case "s":
 		m.settingsState = newSettingsState(m.project)
 		// Apply textarea theme to match current theme.
 		var s textarea.Styles

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -2175,7 +2175,7 @@ var (
 	autopilotHints = []helpHint{
 		{"a", "launch autopilot"},
 		{"A", "stop all agents"},
-		{"s", "stop selected"},
+		{"S", "stop selected"},
 		{"r", "restart/review selected"},
 		{"c", "copy worktree path"},
 		{"+", "add slot"},


### PR DESCRIPTION
## Summary
- The `s` key was intercepted by the stop-selected-agent handler on the autopilot tab, preventing settings from opening
- Moved stop-selected-agent to `S` (shift+s) so `s` consistently opens settings from any tab
- Updated help hints to reflect the new keybinding

## Test plan
- [ ] Press `s` on autopilot tab — should open settings
- [ ] Press `S` on autopilot tab with running agent selected — should prompt to stop agent
- [ ] Press `s` on other tabs — should open settings as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)