### PR TITLE
Fix: allow restarting failed autopilot tasks

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -306,8 +306,8 @@ func (s *Supervisor) RestartTask(ctx context.Context, taskID int64) error {
 	if task == nil {
 		return fmt.Errorf("task %d not found", taskID)
 	}
-	if task.Status != "bailed" && task.Status != "stopped" {
-		return fmt.Errorf("task #%d has status %q — only bailed or stopped tasks can be restarted", task.IssueNumber, task.Status)
+	if task.Status != "bailed" && task.Status != "stopped" && task.Status != "failed" {
+		return fmt.Errorf("task #%d has status %q — only bailed, stopped, or failed tasks can be restarted", task.IssueNumber, task.Status)
 	}
 
 	// Clean up worktree and branch from the previous attempt.

--- a/internal/autopilot/supervisor_test.go
+++ b/internal/autopilot/supervisor_test.go
@@ -291,3 +291,45 @@ func TestRestartTask_Requeues(t *testing.T) {
 		t.Errorf("completed_at should be cleared, got %q", tasks[0].CompletedAt)
 	}
 }
+
+func TestRestartTask_FailedRequeues(t *testing.T) {
+	store := openTestStore(t)
+	project := createTestProject(t, store)
+
+	sup := New(store, project, nil, "/tmp/fake-repo", "owner", "repo", "")
+
+	task := &db.AutopilotTask{
+		ProjectID:    project.ID,
+		IssueNumber:  8,
+		IssueTitle:   "Failed task",
+		Dependencies: "[]",
+		Status:       "queued",
+	}
+	if err := store.CreateAutopilotTask(task); err != nil {
+		t.Fatalf("CreateAutopilotTask: %v", err)
+	}
+
+	// Mark it as failed.
+	if err := store.UpdateAutopilotTaskStatus(task.ID, "failed"); err != nil {
+		t.Fatalf("UpdateAutopilotTaskStatus: %v", err)
+	}
+
+	// Restart with a cancelled context so fillSlots doesn't try to launch.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := sup.RestartTask(ctx, task.ID); err != nil {
+		t.Fatalf("RestartTask: %v", err)
+	}
+
+	tasks, err := store.GetAutopilotTasks(project.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].Status != "queued" {
+		t.Errorf("status = %q, want queued", tasks[0].Status)
+	}
+}


### PR DESCRIPTION
## Summary
- `RestartTask()` only accepted `bailed` or `stopped` statuses, but agents that hit `max_budget` are marked `failed`
- The TUI correctly showed the restart option on failed tasks, but the backend rejected them silently
- Added `"failed"` to the allowed statuses and a corresponding test

## Test plan
- [x] `TestRestartTask_FailedRequeues` — verifies failed tasks can be restarted
- [x] `TestRestartTask_WrongStatus` — still rejects invalid statuses (e.g. `queued`)
- [x] `TestRestartTask_Requeues` — existing stopped restart path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)