### PR TITLE
Fix concurrent git fetch race condition on agent launch

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -1215,6 +1215,21 @@ func (s *Supervisor) fillSlots(ctx context.Context) {
 		return
 	}
 
+	// Single fetch for all agents about to launch — avoids concurrent fetches
+	// racing on ref locks when multiple slots fill at once.
+	hasEmpty := false
+	for _, slot := range s.slots {
+		if slot == nil {
+			hasEmpty = true
+			break
+		}
+	}
+	if hasEmpty {
+		if err := gitpkg.Fetch(s.repoDir); err != nil {
+			s.emitEvent("warning", fmt.Sprintf("Fetch failed: %v (using cached refs)", err), nil)
+		}
+	}
+
 	for i, slot := range s.slots {
 		if slot != nil {
 			continue // Slot occupied.
@@ -1415,10 +1430,8 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 		baseBranch, _ = gitpkg.DefaultBranch(s.repoDir)
 	}
 
-	// Fetch latest from origin so the worktree starts from the latest base branch.
-	if err := gitpkg.Fetch(s.repoDir); err != nil {
-		s.emitEvent("warning", fmt.Sprintf("Fetch failed for #%d: %v (using cached ref)", task.IssueNumber, err), task)
-	}
+	// Note: fetch is done once in fillSlots() before launching agents,
+	// not here, to avoid concurrent fetch races on the same repo.
 
 	// Create worktree from the latest remote base branch.
 	if err := gitpkg.WorktreeAdd(s.repoDir, task.WorktreePath, task.Branch, "origin/"+baseBranch); err != nil {


### PR DESCRIPTION
## Summary
- Moves `git fetch origin` from per-agent `runAgent()` to a single call in `fillSlots()` before the slot loop
- Prevents concurrent fetches racing on ref locks when multiple slots fill at once (e.g., after a dependency completes and unblocks several tasks)
- Fixes "cannot lock ref" errors that caused immediate task failure on first launch attempt

Fixes #246

## Test plan
- [x] All existing autopilot tests pass (30/30)
- [x] Launch autopilot with multiple unblocked tasks — verify single fetch, no ref lock errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)