### PR TITLE
Show issue cost in task detail view once job is done

### DIFF
--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -649,6 +649,17 @@ func (m Model) renderTaskDetail() string {
 		b.WriteString("\n")
 	}
 
+	// Cost (shown for completed tasks).
+	switch task.Status {
+	case "done", "bailed", "review", "stopped", "failed":
+		if task.CostUSD > 0 {
+			b.WriteString(mutedStyle().Render(fmt.Sprintf("  Cost: $%.2f", task.CostUSD)))
+		} else {
+			b.WriteString(mutedStyle().Render("  Cost: N/A"))
+		}
+		b.WriteString("\n")
+	}
+
 	// Agent log.
 	if task.AgentLog != "" {
 		b.WriteString(mutedStyle().Render(fmt.Sprintf("  Log: %s", task.AgentLog)))


### PR DESCRIPTION
## Summary
- Display total cost incurred by Claude Code agent in the autopilot task detail view for completed tasks
- Shows `Cost: $X.XX` when cost data is available, or `Cost: N/A` when completed without cost info
- Hidden for in-progress and queued tasks (only shown for done, bailed, review, stopped, failed)

## Test plan
- [ ] Start autopilot and let a task complete — verify cost appears in detail view
- [ ] Check a task with `CostUSD > 0` shows formatted dollar amount (e.g., `Cost: $0.42`)
- [ ] Check a completed task with no cost data shows `Cost: N/A`
- [ ] Verify queued/running tasks do NOT show cost line
- [ ] Run `go test ./...` — all tests pass

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)