### PR TITLE
Add post-rebase test requirement to autopilot agent def

### DIFF
--- a/.claude/agents/autopilot.md
+++ b/.claude/agents/autopilot.md
@@ -58,6 +58,8 @@ After exploring, decide:
 - Before pushing, rebase onto the latest base branch using the commands from your task context
 - If there are merge conflicts during rebase, attempt to resolve them
 - If you cannot resolve conflicts, abort the rebase (`git rebase --abort`), bail with a comment listing the conflicting files
+- After a successful rebase, re-run tests (`go test ./...`) and pre-commit checks to verify nothing broke from upstream changes
+- If tests fail after rebase, fix the issues and amend your commits before pushing
 - Push the branch
 - Open a draft PR targeting the base branch specified in your task context
 

--- a/agents/autopilot.md
+++ b/agents/autopilot.md
@@ -44,6 +44,8 @@ After exploring, decide:
 - Before pushing, rebase onto the latest base branch using the commands from your task context
 - If there are merge conflicts during rebase, attempt to resolve them
 - If you cannot resolve conflicts, abort the rebase (`git rebase --abort`), bail with a comment listing the conflicting files
+- After a successful rebase, re-run tests (`go test ./...`) and pre-commit checks to verify nothing broke from upstream changes
+- If tests fail after rebase, fix the issues and amend your commits before pushing
 - Push the branch
 - Open a draft PR targeting the base branch specified in your task context
 

--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -86,6 +86,8 @@ After exploring, decide:
 - Before pushing, rebase onto the latest base branch using the commands from your task context
 - If there are merge conflicts during rebase, attempt to resolve them
 - If you cannot resolve conflicts, abort the rebase (` + "`git rebase --abort`" + `), bail with a comment listing the conflicting files
+- After a successful rebase, re-run tests (` + "`go test ./...`" + `) and pre-commit checks to verify nothing broke from upstream changes
+- If tests fail after rebase, fix the issues and amend your commits before pushing
 - Push the branch
 - Open a draft PR targeting the base branch specified in your task context
 


### PR DESCRIPTION
## Summary
- Agents must re-run `go test ./...` and pre-commit checks after rebasing onto the latest base branch, before pushing
- Prevents PRs that pass on a stale base but break after merge in a fast-moving codebase
- Updated all three synced files: `agents/autopilot.md`, `.claude/agents/autopilot.md`, `internal/autopilot/prompt.go`

## Test plan
- [x] `TestDefaultAgentDefMatchesRepoFile` passes (drift prevention)
- [x] `TestDefaultAgentDefContent` passes
- [x] All autopilot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)