### PR TITLE
Add worktree lifecycle management and cleanup

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -330,6 +330,52 @@ func (s *Supervisor) RestartTask(ctx context.Context, taskID int64) error {
 	return nil
 }
 
+// DeleteWorktree removes the worktree and optionally the branch for a completed/failed/bailed task.
+// The task record stays in the DB; only the on-disk worktree is removed.
+// If deleteBranch is true, the local branch is also deleted.
+func (s *Supervisor) DeleteWorktree(_ context.Context, taskID int64, deleteBranch bool) error {
+	tasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return fmt.Errorf("get tasks: %w", err)
+	}
+
+	var task *db.AutopilotTask
+	for i := range tasks {
+		if tasks[i].ID == taskID {
+			task = &tasks[i]
+			break
+		}
+	}
+	if task == nil {
+		return fmt.Errorf("task %d not found", taskID)
+	}
+	if task.Status == "running" || task.Status == "queued" || task.Status == "blocked" {
+		return fmt.Errorf("task #%d has status %q — only completed, failed, bailed, or stopped tasks can have worktrees deleted", task.IssueNumber, task.Status)
+	}
+	if task.WorktreePath == "" {
+		return fmt.Errorf("task #%d has no worktree to delete", task.IssueNumber)
+	}
+
+	// Remove the worktree directory.
+	if err := gitpkg.WorktreeRemove(s.repoDir, task.WorktreePath); err != nil {
+		// Best-effort: try direct removal if git command fails.
+		_ = os.RemoveAll(task.WorktreePath)
+	}
+
+	// Optionally delete the branch.
+	if deleteBranch && task.Branch != "" {
+		_ = gitpkg.DeleteBranch(s.repoDir, task.Branch)
+	}
+
+	// Clear worktree path in DB so the task shows as cleaned up.
+	if err := s.store.ClearAutopilotTaskWorktree(task.ID); err != nil {
+		return fmt.Errorf("clear worktree path: %w", err)
+	}
+
+	s.emitEvent("info", fmt.Sprintf("Deleted worktree for #%d", task.IssueNumber), task)
+	return nil
+}
+
 // Pause stops new agents from being started while letting running ones finish.
 func (s *Supervisor) Pause() {
 	s.mu.Lock()
@@ -549,12 +595,14 @@ func (s *Supervisor) ApplyDepOption(ctx context.Context, opt DepOption) error {
 }
 
 // cleanOrphanedWorktrees removes worktrees left behind by interrupted agents.
-func (s *Supervisor) cleanOrphanedWorktrees() {
+// Returns the number of worktrees cleaned up.
+func (s *Supervisor) cleanOrphanedWorktrees() int {
 	worktreeBase := filepath.Join(os.Getenv("HOME"), ".agent-minder", "worktrees", s.project.Name)
 	entries, err := os.ReadDir(worktreeBase)
 	if err != nil {
-		return // directory may not exist
+		return 0 // directory may not exist
 	}
+	cleaned := 0
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
@@ -564,7 +612,12 @@ func (s *Supervisor) cleanOrphanedWorktrees() {
 			// Best-effort: try direct removal if git worktree remove fails.
 			_ = os.RemoveAll(path)
 		}
+		cleaned++
 	}
+	if cleaned > 0 {
+		s.emitEvent("info", fmt.Sprintf("Cleaning up %d retained worktrees from previous session", cleaned), nil)
+	}
+	return cleaned
 }
 
 // Launch starts filling slots with agents. Call after Prepare + user confirmation.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -820,6 +820,12 @@ func (s *Store) ResetStaleAutopilotTasks(projectID int64) (int, error) {
 	return int(n), nil
 }
 
+// ClearAutopilotTaskWorktree clears the worktree_path for a task after cleanup.
+func (s *Store) ClearAutopilotTaskWorktree(id int64) error {
+	_, err := s.db.Exec(`UPDATE autopilot_tasks SET worktree_path = '' WHERE id = ?`, id)
+	return err
+}
+
 // ResetAutopilotTask resets a single task back to queued, clearing runtime fields.
 func (s *Store) ResetAutopilotTask(id int64) error {
 	_, err := s.db.Exec(`

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -285,6 +286,41 @@ func BranchExists(dir, branch string) bool {
 		return true
 	}
 	return false
+}
+
+// DirDiskUsage returns the total disk usage of a directory in bytes.
+// Returns 0 if the directory does not exist or cannot be measured.
+func DirDiskUsage(path string) int64 {
+	var total int64
+	_ = filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // skip inaccessible entries
+		}
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// FormatBytes formats a byte count as a human-readable string (KB, MB, GB).
+func FormatBytes(b int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.0f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.0f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
 }
 
 // DefaultBranch returns the default branch name (main, master, etc.).

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -228,6 +228,7 @@ type Model struct {
 	autopilotSupervisor       *autopilot.Supervisor
 	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "review-confirm", "add-slot-confirm", "completed"
 	autopilotModeBeforeReview string // saved mode to restore on review-confirm cancel
+	autopilotModeBeforeDelete string // saved mode to restore on delete-worktree-confirm cancel
 	autopilotStatus           string
 	autopilotTotal            int
 	autopilotUnblocked        int
@@ -1027,6 +1028,15 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	}
+	if m.autopilotMode == "delete-worktree-confirm" && m.activeTab == tabAutopilot {
+		switch msg.String() {
+		case "y", "enter":
+			return m.confirmDeleteWorktree()
+		case "n", "esc":
+			m.autopilotMode = m.autopilotModeBeforeDelete
+			return m, nil
+		}
+	}
 
 	switch msg.String() {
 	case "1":
@@ -1058,6 +1068,16 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		return m, nil
 	case "d":
+		// On autopilot tab during running/completed mode, 'd' deletes a task's worktree.
+		if m.activeTab == tabAutopilot && (m.autopilotMode == "running" || m.autopilotMode == "completed") {
+			task := m.selectedAutopilotTask()
+			if task != nil && task.WorktreePath != "" &&
+				(task.Status == "failed" || task.Status == "bailed" || task.Status == "stopped" || task.Status == "done" || task.Status == "review") {
+				m.autopilotModeBeforeDelete = m.autopilotMode
+				m.autopilotMode = "delete-worktree-confirm"
+				return m, nil
+			}
+		}
 		m.warningBanner = ""
 		return m, nil
 	case "q", "ctrl+c":
@@ -2216,6 +2236,42 @@ func (m Model) confirmRestartTask() (tea.Model, tea.Cmd) {
 			Time:    time.Now(),
 			Type:    "started",
 			Summary: fmt.Sprintf("Restarted #%d — re-queued", issueNum),
+		})
+	}
+}
+
+// confirmDeleteWorktree removes the worktree for the selected task after user confirms.
+func (m Model) confirmDeleteWorktree() (tea.Model, tea.Cmd) {
+	task := m.selectedAutopilotTask()
+	if task == nil || task.WorktreePath == "" {
+		m.autopilotMode = m.autopilotModeBeforeDelete
+		return m, nil
+	}
+
+	sup := m.autopilotSupervisor
+	if sup == nil {
+		m.autopilotMode = m.autopilotModeBeforeDelete
+		return m, nil
+	}
+
+	taskID := task.ID
+	issueNum := task.IssueNumber
+	// Delete branch for non-review tasks (review tasks may have PRs the user wants to keep).
+	deleteBranch := task.Status != "review"
+	m.autopilotMode = m.autopilotModeBeforeDelete
+
+	return m, func() tea.Msg {
+		if err := sup.DeleteWorktree(context.Background(), taskID, deleteBranch); err != nil {
+			return autopilotEventMsg(autopilot.Event{
+				Time:    time.Now(),
+				Type:    "error",
+				Summary: fmt.Sprintf("Failed to delete worktree for #%d: %v", issueNum, err),
+			})
+		}
+		return autopilotEventMsg(autopilot.Event{
+			Time:    time.Now(),
+			Type:    "info",
+			Summary: fmt.Sprintf("Deleted worktree for #%d", issueNum),
 		})
 	}
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/dustinlange/agent-minder/internal/autopilot"
 	"github.com/dustinlange/agent-minder/internal/db"
+	gitpkg "github.com/dustinlange/agent-minder/internal/git"
 )
 
 // View renders the TUI dashboard with height-budgeted sections.
@@ -631,10 +633,26 @@ func (m Model) renderTaskDetail() string {
 		b.WriteString("\n")
 	}
 
-	// Worktree path.
+	// Worktree path + disk usage.
 	if task.WorktreePath != "" {
-		b.WriteString(mutedStyle().Render(fmt.Sprintf("  Worktree: %s", task.WorktreePath)))
-		b.WriteString("\n")
+		if _, err := os.Stat(task.WorktreePath); err == nil {
+			diskBytes := gitpkg.DirDiskUsage(task.WorktreePath)
+			b.WriteString(mutedStyle().Render(fmt.Sprintf("  Worktree: %s", task.WorktreePath)))
+			b.WriteString("\n")
+			b.WriteString(mutedStyle().Render(fmt.Sprintf("  Disk usage: %s", gitpkg.FormatBytes(diskBytes))))
+			b.WriteString("\n")
+		} else {
+			b.WriteString(mutedStyle().Render(fmt.Sprintf("  Worktree: %s (removed)", task.WorktreePath)))
+			b.WriteString("\n")
+		}
+		// Show delete hint for terminal tasks with worktrees on disk.
+		canDelete := task.Status == "failed" || task.Status == "bailed" || task.Status == "stopped" || task.Status == "done" || task.Status == "review"
+		if canDelete {
+			if _, err := os.Stat(task.WorktreePath); err == nil {
+				b.WriteString(mutedStyle().Render("  [d: delete worktree]"))
+				b.WriteString("\n")
+			}
+		}
 	}
 
 	// Branch.
@@ -1975,6 +1993,18 @@ func (m Model) renderBottomBar() string {
 			b.WriteString(helpKeyStyle().Render("esc"))
 			b.WriteString(helpStyle().Render(": cancel"))
 			b.WriteString("\n")
+		} else if m.activeTab == tabAutopilot && m.autopilotMode == "delete-worktree-confirm" {
+			task := m.selectedAutopilotTask()
+			issueNum := 0
+			if task != nil {
+				issueNum = task.IssueNumber
+			}
+			b.WriteString(headerStyle().Render(fmt.Sprintf("  Delete worktree for #%d? ", issueNum)))
+			b.WriteString(helpKeyStyle().Render("y"))
+			b.WriteString(helpStyle().Render(": delete • "))
+			b.WriteString(helpKeyStyle().Render("n"))
+			b.WriteString(helpStyle().Render(": cancel"))
+			b.WriteString("\n")
 		} else if m.autopilotStatus != "" {
 			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.autopilotStatus)))
 			b.WriteString("\n")
@@ -2047,12 +2077,14 @@ func (m Model) renderHelpBar() string {
 					condensed = append(condensed,
 						hint{"r", "restart"},
 						hint{"i", "detail"},
+						hint{"d", "del worktree"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
 				case "bailed", "stopped":
 					condensed = append(condensed,
 						hint{"r", "restart"},
+						hint{"d", "del worktree"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
@@ -2061,11 +2093,13 @@ func (m Model) renderHelpBar() string {
 				case "review":
 					condensed = append(condensed,
 						hint{"r", "review"},
+						hint{"d", "del worktree"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
 				case "done":
 					condensed = append(condensed,
+						hint{"d", "del worktree"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
@@ -2085,12 +2119,14 @@ func (m Model) renderHelpBar() string {
 				switch task.Status {
 				case "failed", "bailed", "stopped", "done":
 					condensed = append(condensed,
+						hint{"d", "del worktree"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
 				case "review":
 					condensed = append(condensed,
 						hint{"r", "review"},
+						hint{"d", "del worktree"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
@@ -2177,6 +2213,7 @@ var (
 		{"A", "stop all agents"},
 		{"S", "stop selected"},
 		{"r", "restart/review selected"},
+		{"d", "delete worktree"},
 		{"c", "copy worktree path"},
 		{"+", "add slot"},
 		{"P", "pause/resume slots"},


### PR DESCRIPTION
## Summary
- Add `d` key binding in TUI autopilot tab to delete worktrees for completed/failed/bailed/stopped tasks with y/n confirmation dialog
- Add `DeleteWorktree()` supervisor method that removes worktree directory, optionally deletes branch (skipped for review tasks with PRs), and clears worktree_path in DB while preserving task record
- Show disk usage in task detail view when worktree exists on disk, with `(removed)` annotation when already cleaned up
- Add `DirDiskUsage()` and `FormatBytes()` helpers to git package for measuring worktree size
- Enhance `cleanOrphanedWorktrees()` in `Prepare()` to emit event showing count of retained worktrees cleaned from previous session
- Add delete worktree hints to condensed help bar and full help overlay

## Test plan
- [ ] Verify `d` key on autopilot tab triggers delete confirmation for failed/bailed/stopped/done/review tasks with worktrees
- [ ] Verify `y` confirms deletion (worktree removed, DB updated, event emitted)
- [ ] Verify `n`/`esc` cancels and returns to previous mode
- [ ] Verify disk usage shows in task detail for tasks with existing worktrees
- [ ] Verify `(removed)` annotation shows for tasks whose worktrees were cleaned
- [ ] Verify branch is preserved for review tasks but deleted for others
- [ ] Verify Prepare() emits cleanup summary event when retained worktrees exist
- [ ] Run `go test ./...` — all affected packages pass

Fixes #234

:robot: Generated with [Claude Code](https://claude.com/claude-code)