### PR TITLE
Wire onboarding agent into repo enroll command

### DIFF
--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -118,9 +119,42 @@ func runRepoEnroll(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Steps 3-4 (enrollment agent + validation) depend on future work.
-	fmt.Println("\nEnrollment agent not yet available.")
-	fmt.Println("The mechanical inventory above will be used as context when the enrollment agent is implemented.")
+	// Step 3: Create initial onboarding file with inventory (agent will fill in context + permissions).
+	f := onboarding.New(info.Inventory)
+	filePath := onboarding.FilePath(info.Path)
+	if err := onboarding.Write(filePath, f); err != nil {
+		return fmt.Errorf("writing initial onboarding file: %w", err)
+	}
+	fmt.Printf("\nCreated initial onboarding file: %s\n", filePath)
+
+	// Step 4: Launch onboarding agent.
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		fmt.Println("\nClaude CLI not found on PATH. Install it to run the onboarding agent.")
+		fmt.Println("The mechanical inventory has been saved. Re-run 'agent-minder repo enroll' after installing Claude CLI.")
+		return nil
+	}
+
+	prompt := buildEnrollmentPrompt(info, filePath, permFailures)
+	agentCmd := exec.Command(claudePath, "--agent", "onboarding", prompt)
+	agentCmd.Dir = info.Path
+	agentCmd.Stdin = os.Stdin
+	agentCmd.Stdout = os.Stdout
+	agentCmd.Stderr = os.Stderr
+
+	fmt.Println("\nLaunching onboarding agent...")
+	fmt.Println("The agent will ask you a few questions about your repository, then generate configuration files.")
+	fmt.Println()
+
+	if err := agentCmd.Run(); err != nil {
+		fmt.Printf("\nOnboarding agent exited with error: %v\n", err)
+		fmt.Println("The mechanical inventory has been saved. You can re-run 'agent-minder repo enroll' to try again.")
+		return nil
+	}
+
+	// Step 5: Post-agent validation.
+	fmt.Println()
+	printPostAgentSummary(info.Path)
 
 	return nil
 }
@@ -323,4 +357,78 @@ func checkMark(v bool) string {
 		return "yes"
 	}
 	return "no"
+}
+
+// buildEnrollmentPrompt constructs the initial prompt for the onboarding agent
+// with the mechanical inventory context.
+func buildEnrollmentPrompt(info *discovery.RepoInfo, onboardingPath string, permFailures []string) string {
+	var b strings.Builder
+
+	b.WriteString("## Mechanical Inventory\n\n")
+	fmt.Fprintf(&b, "Repo directory: %s\n", info.Path)
+	fmt.Fprintf(&b, "Onboarding file path: %s\n\n", onboardingPath)
+
+	inv := info.Inventory
+
+	writeList := func(label string, items []string) {
+		if len(items) > 0 {
+			fmt.Fprintf(&b, "- %s: %s\n", label, strings.Join(items, ", "))
+		}
+	}
+
+	writeList("Languages", inv.Languages)
+	writeList("Package managers", inv.PackageManagers)
+	writeList("Build files", inv.BuildFiles)
+	writeList("CI", inv.CI)
+
+	if inv.Tooling.Secrets != "" {
+		fmt.Fprintf(&b, "- Secrets manager: %s\n", inv.Tooling.Secrets)
+	}
+	if inv.Tooling.Process != "" {
+		fmt.Fprintf(&b, "- Process manager: %s\n", inv.Tooling.Process)
+	}
+	if inv.Tooling.Containers != "" {
+		fmt.Fprintf(&b, "- Containers: %s\n", inv.Tooling.Containers)
+	}
+	if len(inv.Tooling.Env) > 0 {
+		fmt.Fprintf(&b, "- Env management: %s\n", strings.Join(inv.Tooling.Env, ", "))
+	}
+
+	b.WriteString("\n### Existing Claude Code config\n\n")
+	fmt.Fprintf(&b, "- CLAUDE.md: %s\n", checkMark(inv.ExistingClaude.ClaudeMD))
+	fmt.Fprintf(&b, "- settings.json: %s\n", checkMark(inv.ExistingClaude.SettingsJSON))
+	fmt.Fprintf(&b, "- Agent definition: %s\n", checkMark(inv.ExistingClaude.AgentDef))
+
+	if len(permFailures) > 0 {
+		b.WriteString("\n### Prior agent permission failures\n\n")
+		for _, f := range permFailures {
+			fmt.Fprintf(&b, "- %s\n", f)
+		}
+		b.WriteString("\nConsider adding permissions to cover these tool patterns.\n")
+	}
+
+	return b.String()
+}
+
+// printPostAgentSummary checks which artifacts the onboarding agent created
+// and prints a summary.
+func printPostAgentSummary(repoDir string) {
+	fmt.Println("Enrollment summary:")
+
+	artifacts := []struct {
+		label string
+		path  string
+	}{
+		{"Onboarding file", onboarding.FilePath(repoDir)},
+		{"Claude settings", filepath.Join(repoDir, ".claude", "settings.json")},
+		{"Autopilot agent", filepath.Join(repoDir, ".claude", "agents", "autopilot.md")},
+	}
+
+	for _, a := range artifacts {
+		if _, err := os.Stat(a.path); err == nil {
+			fmt.Printf("  ✓ %s: %s\n", a.label, a.path)
+		} else {
+			fmt.Printf("  - %s: not created\n", a.label)
+		}
+	}
 }

--- a/cmd/repo_test.go
+++ b/cmd/repo_test.go
@@ -5,7 +5,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/dustinlange/agent-minder/internal/discovery"
+	"github.com/dustinlange/agent-minder/internal/onboarding"
 )
 
 func TestCheckMark(t *testing.T) {
@@ -27,11 +31,22 @@ func TestDefaultAgentLogDir(t *testing.T) {
 	}
 }
 
-func TestRepoEnrollRunsOnRealRepo(t *testing.T) {
+func TestRepoEnrollCreatesOnboardingFile(t *testing.T) {
 	dir := setupGitRepo(t)
 
 	// Add a go.mod to make inventory interesting.
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-create the onboarding file so enroll hits the "already exists" path
+	// and doesn't try to launch the interactive agent.
+	onboardingDir := filepath.Join(dir, ".agent-minder")
+	if err := os.MkdirAll(onboardingDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	onboardingFile := filepath.Join(onboardingDir, "onboarding.yaml")
+	if err := os.WriteFile(onboardingFile, []byte("version: 1\nscanned_at: 2024-01-01T00:00:00Z\ninventory:\n  languages: [go]\nvalidation:\n  status: untested\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -42,6 +57,31 @@ func TestRepoEnrollRunsOnRealRepo(t *testing.T) {
 
 	if err := cmd.RunE(cmd, []string{dir}); err != nil {
 		t.Fatalf("runRepoEnroll: %v", err)
+	}
+}
+
+func TestRepoEnrollNoClaudeCLI(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	// Create a temporary bin dir with only git (not claude) to simulate missing claude CLI.
+	fakeBin := t.TempDir()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal("git not found")
+	}
+	if err := os.Symlink(gitPath, filepath.Join(fakeBin, "git")); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	if err := runRepoEnroll(repoEnrollCmd, []string{dir}); err != nil {
+		t.Fatalf("runRepoEnroll: %v", err)
+	}
+
+	// Should have created the initial onboarding file even without claude.
+	onboardingPath := filepath.Join(dir, ".agent-minder", "onboarding.yaml")
+	if _, err := os.Stat(onboardingPath); os.IsNotExist(err) {
+		t.Error("expected onboarding file to be created")
 	}
 }
 
@@ -65,6 +105,41 @@ func TestRepoRefreshNoEnrollmentFile(t *testing.T) {
 	// Should not error, just report no enrollment file.
 	if err := cmd.RunE(cmd, []string{dir}); err != nil {
 		t.Fatalf("runRepoRefresh: %v", err)
+	}
+}
+
+func TestBuildEnrollmentPrompt(t *testing.T) {
+	info := &discovery.RepoInfo{
+		Path: "/tmp/test-repo",
+		Inventory: onboarding.Inventory{
+			Languages:       []string{"go", "typescript"},
+			PackageManagers: []string{"go-modules", "npm"},
+			BuildFiles:      []string{"Makefile", "package.json"},
+			CI:              []string{"github-actions"},
+			Tooling: onboarding.Tooling{
+				Secrets: "doppler",
+			},
+			ExistingClaude: onboarding.ExistingClaudeConfig{
+				ClaudeMD: true,
+			},
+		},
+	}
+
+	prompt := buildEnrollmentPrompt(info, "/tmp/test-repo/.agent-minder/onboarding.yaml", []string{"Bash(make lint)"})
+
+	// Check key content is present.
+	for _, want := range []string{
+		"go, typescript",
+		"go-modules, npm",
+		"doppler",
+		"CLAUDE.md: yes",
+		"settings.json: no",
+		"/tmp/test-repo",
+		"Bash(make lint)",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replaces the stub in `repo enroll` with a full enrollment flow: creates the initial onboarding file with mechanical inventory, then launches `claude --agent onboarding` interactively with structured context
- After the agent exits, validates which artifacts were created (onboarding.yaml, settings.json, autopilot.md) and prints a summary
- Falls back gracefully when the `claude` CLI is not on PATH, preserving the inventory for a later re-run

Closes #257

## Test plan
- [x] `TestRepoEnrollCreatesOnboardingFile` — verifies the "already enrolled" path
- [x] `TestRepoEnrollNoClaudeCLI` — verifies graceful fallback when claude is missing (symlinks only git into a fake PATH)
- [x] `TestBuildEnrollmentPrompt` — verifies the prompt includes inventory fields, repo path, and permission failures
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: run `agent-minder repo enroll ~/repos/some-repo` and interact with the onboarding agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)