### PR TITLE
Add version constant to internal/build package

### DIFF
--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -1,0 +1,11 @@
+package build
+
+import "fmt"
+
+// Version is the current version of agent-minder.
+const Version = "0.1.0"
+
+// VersionString returns a formatted version string.
+func VersionString() string {
+	return fmt.Sprintf("agent-minder v%s", Version)
+}

--- a/internal/build/version_test.go
+++ b/internal/build/version_test.go
@@ -1,0 +1,25 @@
+package build
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionConstant(t *testing.T) {
+	if Version == "" {
+		t.Fatal("Version constant must not be empty")
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	got := VersionString()
+	want := "agent-minder v" + Version
+
+	if got != want {
+		t.Errorf("VersionString() = %q, want %q", got, want)
+	}
+
+	if !strings.HasPrefix(got, "agent-minder v") {
+		t.Errorf("VersionString() = %q, should start with 'agent-minder v'", got)
+	}
+}


### PR DESCRIPTION
Adds internal/build/version.go with Version constant and VersionString function plus tests. Fixes #185