### PR TITLE
Update LICENSE copyright holder (#216)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 APTX Health
+Copyright (c) 2026 Dustin Mays and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Updated LICENSE copyright from "APTX Health" to "Dustin Mays and contributors"
- Confirmed MIT license is appropriate (all 13 direct deps are MIT-compatible)
- No CLA needed

Closes #216

## Related
- Created #261 for the separate Go module path rename (`dustinlange` → TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)