### PR TITLE
Add goreleaser config and CI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,56 @@
+version: 2
+
+project_name: agent-minder
+
+builds:
+  - id: agent-minder
+    main: .
+    binary: agent-minder
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+release:
+  github:
+    owner: aptx-health
+    name: agent-minder
+  draft: false
+  prerelease: auto
+  name_template: "v{{.Version}}"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version info injected from main.go (set by goreleaser ldflags).
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+// SetVersionInfo is called from main() to pass ldflags-injected values.
+func SetVersionInfo(v, c, d string) {
+	version = v
+	commit = c
+	date = d
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of agent-minder",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("agent-minder %s (commit: %s, built: %s)\n", version, commit, date)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,14 @@ package main
 
 import "github.com/dustinlange/agent-minder/cmd"
 
+// Version info set by goreleaser via -ldflags.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+	cmd.SetVersionInfo(version, commit, date)
 	cmd.Execute()
 }


### PR DESCRIPTION
## Summary
- Add .goreleaser.yml config targeting Linux (amd64/arm64), macOS (amd64/arm64), and Windows (amd64) with CGO_ENABLED=0 for pure Go SQLite
- Add version command with ldflags-injected version, commit, and build date
- Add GitHub Actions release workflow triggered on v* tag push
- Generate checksums and attach to GitHub Release

## Test plan
- [ ] Verify go run . version outputs expected output
- [ ] Verify goreleaser config with goreleaser check
- [ ] Tag a test release to validate the full workflow

Fixes #206

Generated with Claude Code
