### PR TITLE
Release workflow review fixes (#206)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Vet
+        run: go vet ./...
+
       - name: Run tests
         run: go test ./...
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
     binary: agent-minder
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w
       - -X main.version={{.Version}}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,25 +6,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Version info injected from main.go (set by goreleaser ldflags).
+// Version info set from main.go via goreleaser ldflags.
 var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
 )
-
-// SetVersionInfo is called from main() to pass ldflags-injected values.
-func SetVersionInfo(v, c, d string) {
-	version = v
-	commit = c
-	date = d
-}
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of agent-minder",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("agent-minder %s (commit: %s, built: %s)\n", version, commit, date)
+		fmt.Printf("agent-minder %s (commit: %s, built: %s)\n", Version, Commit, Date)
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ var (
 )
 
 func main() {
-	cmd.SetVersionInfo(version, commit, date)
+	cmd.Version = version
+	cmd.Commit = commit
+	cmd.Date = date
 	cmd.Execute()
 }


### PR DESCRIPTION
## Summary
- Add `-trimpath` build flag to goreleaser for reproducible builds
- Export version vars directly instead of using `SetVersionInfo` setter
- Add `go vet` step to release workflow for parity with CI

Follow-up to #265.

## Test plan
- [ ] Verify `go run . version` still works
- [ ] Verify `goreleaser check` passes
- [ ] Tag a test release to validate full workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)