### PR TITLE
Add --version flag to root CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `--version` flag on root CLI command, backed by `internal/build.Version` constant
+
 ## [0.1.0] - 2026-03-19
 
 Initial pre-release. This captures the current feature set ahead of public open-source release.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dustinlange/agent-minder/internal/build"
 	"github.com/dustinlange/agent-minder/internal/config"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "agent-minder",
-	Short: "Coordination layer on top of agent-msg",
+	Use:     "agent-minder",
+	Short:   "Coordination layer on top of agent-msg",
+	Version: build.Version,
 	Long: `A CLI tool that monitors multiple repositories, watches the message bus,
 tracks git activity, and keeps both AI agents and the human operator
 informed about cross-repo state.

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -1,0 +1,11 @@
+package build
+
+import "fmt"
+
+// Version is the current version of agent-minder.
+const Version = "0.1.0"
+
+// VersionString returns a formatted version string.
+func VersionString() string {
+	return fmt.Sprintf("agent-minder v%s", Version)
+}

--- a/internal/build/version_test.go
+++ b/internal/build/version_test.go
@@ -1,0 +1,22 @@
+package build
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	if Version == "" {
+		t.Error("Version should not be empty")
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	got := VersionString()
+	if !strings.HasPrefix(got, "agent-minder v") {
+		t.Errorf("VersionString() = %q, want prefix %q", got, "agent-minder v")
+	}
+	if !strings.Contains(got, Version) {
+		t.Errorf("VersionString() = %q, should contain Version %q", got, Version)
+	}
+}


### PR DESCRIPTION
## Summary
- Creates internal/build package with Version constant and VersionString() function
- Wires build.Version into the root Cobra command so agent-minder --version prints the version
- Includes unit tests for the build package

## Test plan
- [x] go test ./internal/build/... -v passes
- [x] go build ./... succeeds
- [x] Pre-commit hooks (gofmt, build, golangci-lint) pass
- [ ] Manual: run go run . --version to verify output

Fixes #187

Generated with [Claude Code](https://claude.com/claude-code)