### PR TITLE
Fix claude CLI prompt input when --tools flag is used

### DIFF
--- a/internal/claudecli/claudecli.go
+++ b/internal/claudecli/claudecli.go
@@ -87,15 +87,14 @@ func (c *CLICompleter) Complete(ctx context.Context, req *Request) (*Response, e
 		args = append(args, "--max-budget-usd", strconv.FormatFloat(req.MaxBudget, 'f', -1, 64))
 	}
 
-	// The prompt is the last positional argument.
-	args = append(args, req.Prompt)
-
 	bin := c.ClaudeBin
 	if bin == "" {
 		bin = "claude"
 	}
 
+	// Pass prompt via stdin — positional args break when --tools "" is used.
 	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Stdin = strings.NewReader(req.Prompt)
 	out, err := cmd.Output()
 	if err != nil {
 		// Try to extract stderr for better error messages.


### PR DESCRIPTION
## Summary
- Pass prompt via stdin instead of positional argument in `claudecli.Complete()`
- Fixes sweep errors: `--tools ""` caused the CLI arg parser to consume the empty string as the prompt, leaving the actual prompt unrecognized
- Closes #187

## Test plan
- [x] Unit tests pass (`go test ./internal/claudecli/...`)
- [x] Verify sweep calls succeed in TUI (no more "Input must be provided" errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)