### PR TITLE
Incremental dep graph updates with reverse dependency injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,11 +64,12 @@ Supervisor manages N concurrent Claude Code agents working on GitHub issues in i
 
 **Key behaviors:**
 - `Prepare()` preserves existing tasks across restarts — if tasks exist, shows reprepare-choice (k=keep, r=rebuild); selected dep graph stored in `autopilot_dep_graphs` table
-- On reprepare: done stays done, review/failed/bailed/stopped/running → manual, queued/blocked → cleared; new tracked items discovered and optionally analyzed incrementally
+- On reprepare keep: stale running → queued, everything else preserved; new tracked items discovered and analyzed incrementally with reverse dep injection
+- On reprepare rebuild: done stays done, review/failed/bailed/stopped/running → manual, queued/blocked → cleared; full dep graph regenerated
 - Issues with the skip label (default `no-agent`, configurable via `project.AutopilotSkipLabel`) are excluded
 - Dependency graph built via one LLM call using analyzer model; includes all tracked items as context for cross-repo deps
 - External dependency blocking: `QueuedUnblockedTasks()` cross-references `tracked_items` — if a dep is tracked and open, it blocks
-- Dynamic task discovery: every 60s when idle slots exist, checks for new tracked items not yet in autopilot_tasks
+- New task discovery: handled during ReprepareKeep — new tracked items get incremental dep analysis with reverse dependency injection (existing queued/blocked tasks can gain deps on new issues)
 - Review check: every 30s, checks if PRs for `review` tasks have been merged → promotes to `done`
 - Label management: agent adds `in-progress` on start; supervisor swaps to `needs-review` when PR detected; removes `needs-review` when merged
 - On restart, `Prepare()` clears all tasks and rebuilds — no resume of stale state

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -125,7 +125,6 @@ type Supervisor struct {
 	parentCtx  context.Context // parent context for the session (used by slot goroutines for fillSlots)
 	cancel     context.CancelFunc
 	done       chan struct{}
-	discovery  chan struct{} // signal to trigger immediate discovery
 }
 
 // New creates a new Supervisor.
@@ -144,7 +143,6 @@ func New(store *db.Store, project *db.Project, completer claudecli.Completer, re
 		ghToken:   ghToken,
 		slots:     make([]*slotState, maxAgents),
 		events:    make(chan Event, 64),
-		discovery: make(chan struct{}, 1),
 	}
 }
 
@@ -164,14 +162,6 @@ func (s *Supervisor) IsActive() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.active
-}
-
-// TriggerDiscovery signals the supervisor to check for new tracked items immediately.
-func (s *Supervisor) TriggerDiscovery() {
-	select {
-	case s.discovery <- struct{}{}:
-	default: // already pending
-	}
 }
 
 // StopAgent cancels a single agent slot, leaving other agents running.
@@ -658,7 +648,7 @@ func (s *Supervisor) ReprepareKeep(ctx context.Context) (*PrepareResult, error) 
 	s.cleanOrphanedWorktrees()
 
 	// Discover and add new tracked items as tasks.
-	added := s.discoverNewTasks(ctx)
+	added := s.addNewTrackedItems(ctx)
 
 	// Get final task list.
 	allTasks, err := s.store.GetAutopilotTasks(s.project.ID)
@@ -670,8 +660,9 @@ func (s *Supervisor) ReprepareKeep(ctx context.Context) (*PrepareResult, error) 
 		return &PrepareResult{AgentDef: agentDef}, nil
 	}
 
-	// If there are new issues, build incremental dep options for them.
+	// If there are new issues, run incremental dep analysis (including reverse deps).
 	if added > 0 {
+		s.emitEvent("info", fmt.Sprintf("Analyzing dependencies for %d new issue(s)", added), nil)
 		options, err := s.BuildIncrementalDepOptions(ctx, allTasks, "")
 		if err != nil {
 			s.emitEvent("warning", fmt.Sprintf("Incremental dep analysis failed: %v — new tasks queued without deps", err), nil)
@@ -903,9 +894,26 @@ func (s *Supervisor) BuildIncrementalDepOptions(ctx context.Context, allTasks []
 		}
 	}
 
-	if len(existingTasks) > 0 {
-		issueList.WriteString("\n## Existing tasks (context — may be dependencies for new issues):\n")
-		for _, t := range existingTasks {
+	// Separate existing tasks by mutability for the prompt.
+	var mutableTasks, immutableTasks []*db.AutopilotTask
+	for _, t := range existingTasks {
+		switch t.Status {
+		case "queued", "blocked":
+			mutableTasks = append(mutableTasks, t)
+		default:
+			immutableTasks = append(immutableTasks, t)
+		}
+	}
+
+	if len(mutableTasks) > 0 {
+		issueList.WriteString("\n## Existing queued/blocked tasks (deps may be updated if a new issue should block them):\n")
+		for _, t := range mutableTasks {
+			fmt.Fprintf(&issueList, "Issue #%d [%s]: %s (current deps: %s)\n", t.IssueNumber, t.Status, t.IssueTitle, t.Dependencies)
+		}
+	}
+	if len(immutableTasks) > 0 {
+		issueList.WriteString("\n## Existing tasks (context only — deps cannot be changed):\n")
+		for _, t := range immutableTasks {
 			fmt.Fprintf(&issueList, "Issue #%d [%s]: %s (deps: %s)\n", t.IssueNumber, t.Status, t.IssueTitle, t.Dependencies)
 		}
 	}
@@ -916,17 +924,21 @@ func (s *Supervisor) BuildIncrementalDepOptions(ctx context.Context, allTasks []
 	}
 
 	prompt := fmt.Sprintf(`Analyze these NEW GitHub issues and determine their dependencies.
-Only analyze the NEW issues — existing tasks are provided as context for cross-references.
-A new issue can depend on an existing task or another new issue.
+Also check if any existing queued/blocked tasks should now depend on a new issue (reverse dependencies).
+
+Rules:
+- New issues can depend on existing tasks or other new issues.
+- Existing queued/blocked tasks can gain new dependencies on new issues. If so, include that task's FULL updated dependency array (not just the new dep).
+- Do NOT include entries for existing running/review/done/manual tasks — their deps are locked.
 
 %s%s
 Respond with ONLY a JSON array of exactly 3 dependency graph options. Each has "name", "rationale", and "graph".
-The "graph" should ONLY contain entries for the NEW issues (not existing tasks).
+The "graph" MUST contain entries for all NEW issues. It MAY also contain entries for existing queued/blocked tasks whose deps changed.
 Values are arrays of integer issue numbers (deps) or "skip"/"manual".
 
-Example:
+Example (issue #50 and #51 are new; existing #42 now depends on new #50):
 [
-  {"name": "Conservative", "rationale": "...", "graph": {"50": [42], "51": []}},
+  {"name": "Conservative", "rationale": "...", "graph": {"50": [42], "51": [], "42": [99, 50]}},
   {"name": "Parallel", "rationale": "...", "graph": {"50": [], "51": []}},
   {"name": "Sequential", "rationale": "...", "graph": {"50": [], "51": [50]}}
 ]`, issueList.String(), guidanceSection)
@@ -997,32 +1009,51 @@ Example:
 	return options, nil
 }
 
-// ApplyIncrementalDepOption applies deps for new issues and merges into the stored graph.
+// ApplyIncrementalDepOption applies deps for new and updated issues, merges into
+// the stored graph, and re-evaluates blocked status. Existing tasks in non-mutable
+// states (running/review/done/bailed/stopped/failed) are never modified.
 func (s *Supervisor) ApplyIncrementalDepOption(ctx context.Context, opt DepOption) error {
-	// Apply deps for the new issues (same logic as ApplyDepOption but only for new keys).
 	tasks, err := s.store.GetAutopilotTasks(s.project.ID)
 	if err != nil {
 		return fmt.Errorf("get tasks: %w", err)
 	}
 
+	var newCount, updatedCount int
+
 	for _, t := range tasks {
 		key := strconv.Itoa(t.IssueNumber)
 		rawDeps, ok := opt.Graph[key]
 		if !ok {
-			continue // not a new issue
+			continue
 		}
 
+		// Never modify deps for tasks in non-mutable states.
+		switch t.Status {
+		case "running", "review", "done", "bailed", "stopped", "failed":
+			continue
+		}
+
+		isNew := t.Dependencies == "[]" && t.Status == "queued"
+
+		// Handle string directives: "skip" or "manual".
 		var strVal string
 		if json.Unmarshal(rawDeps, &strVal) == nil {
 			switch strVal {
 			case "skip":
 				_ = s.store.UpdateAutopilotTaskStatus(t.ID, "skipped")
+				if isNew {
+					s.emitEvent("graph-update", fmt.Sprintf("#%d marked as skip", t.IssueNumber), nil)
+				}
 			case "manual":
 				_ = s.store.UpdateAutopilotTaskStatus(t.ID, "manual")
+				if isNew {
+					s.emitEvent("graph-update", fmt.Sprintf("#%d marked as manual", t.IssueNumber), nil)
+				}
 			}
 			continue
 		}
 
+		// Parse dependency array.
 		var deps []int
 		if err := json.Unmarshal(rawDeps, &deps); err != nil {
 			var strDeps []string
@@ -1035,11 +1066,39 @@ func (s *Supervisor) ApplyIncrementalDepOption(ctx context.Context, opt DepOptio
 			}
 		}
 
-		if len(deps) > 0 {
-			depsJSON, _ := json.Marshal(deps)
-			_ = s.store.UpdateAutopilotTaskDeps(t.ID, string(depsJSON))
-			_ = s.store.UpdateAutopilotTaskStatus(t.ID, "blocked")
+		depsJSON, _ := json.Marshal(deps)
+		newDepsStr := string(depsJSON)
+
+		if isNew {
+			newCount++
+			if len(deps) > 0 {
+				_ = s.store.UpdateAutopilotTaskDeps(t.ID, newDepsStr)
+				_ = s.store.UpdateAutopilotTaskStatus(t.ID, "blocked")
+				s.emitEvent("graph-update", fmt.Sprintf("#%d added with deps %s", t.IssueNumber, newDepsStr), nil)
+			} else {
+				s.emitEvent("graph-update", fmt.Sprintf("#%d added with no deps (queued)", t.IssueNumber), nil)
+			}
+		} else if newDepsStr != t.Dependencies {
+			// Existing queued/blocked task with updated deps (reverse dependency injection).
+			updatedCount++
+			_ = s.store.UpdateAutopilotTaskDeps(t.ID, newDepsStr)
+			if len(deps) > 0 {
+				_ = s.store.UpdateAutopilotTaskStatus(t.ID, "blocked")
+			}
+			s.emitEvent("graph-update", fmt.Sprintf("#%d deps updated: %s -> %s", t.IssueNumber, t.Dependencies, newDepsStr), nil)
 		}
+	}
+
+	// Summary event.
+	if newCount > 0 || updatedCount > 0 {
+		parts := make([]string, 0, 2)
+		if newCount > 0 {
+			parts = append(parts, fmt.Sprintf("%d new", newCount))
+		}
+		if updatedCount > 0 {
+			parts = append(parts, fmt.Sprintf("%d updated", updatedCount))
+		}
+		s.emitEvent("info", fmt.Sprintf("Dep graph applied: %s tasks", strings.Join(parts, ", ")), nil)
 	}
 
 	// Merge new entries into stored graph.
@@ -1058,7 +1117,7 @@ func (s *Supervisor) ApplyIncrementalDepOption(ctx context.Context, opt DepOptio
 		_ = s.store.SaveDepGraph(s.project.ID, string(graphJSON), opt.Name)
 	}
 
-	// Re-evaluate blocked status.
+	// Re-evaluate blocked status — some tasks may now be unblocked.
 	s.unblockSatisfiedTasks()
 
 	s.mu.Lock()
@@ -1218,9 +1277,6 @@ func (s *Supervisor) Launch(ctx context.Context) {
 		// discover new tracked items, fill new slots.
 		reviewCheckTicker := time.NewTicker(30 * time.Second)
 		defer reviewCheckTicker.Stop()
-		discoveryTicker := time.NewTicker(60 * time.Second)
-		defer discoveryTicker.Stop()
-
 		for {
 			select {
 			case <-ctx.Done():
@@ -1234,18 +1290,6 @@ func (s *Supervisor) Launch(ctx context.Context) {
 				s.checkManualTasks(ctx)
 				unblocked := s.unblockSatisfiedTasks()
 				if unblocked > 0 {
-					s.fillSlots(ctx)
-				}
-			case <-discoveryTicker.C:
-				if s.hasIdleSlot() {
-					added := s.discoverNewTasks(ctx)
-					if added > 0 {
-						s.fillSlots(ctx)
-					}
-				}
-			case <-s.discovery:
-				added := s.discoverNewTasks(ctx)
-				if added > 0 {
 					s.fillSlots(ctx)
 				}
 			default:
@@ -1895,9 +1939,11 @@ func (s *Supervisor) hasIdleSlot() bool {
 	return false
 }
 
-// discoverNewTasks checks tracked items for new open issues not already in the
-// autopilot task list and adds them. Returns the number of new tasks added.
-func (s *Supervisor) discoverNewTasks(ctx context.Context) int {
+// addNewTrackedItems checks tracked items for new open issues not already in the
+// autopilot task list and adds them with queued status. Called during ReprepareKeep
+// so that incremental dep analysis can determine their ordering.
+// Returns the number of new tasks added.
+func (s *Supervisor) addNewTrackedItems(ctx context.Context) int {
 	existing, err := s.store.GetAutopilotTasks(s.project.ID)
 	if err != nil {
 		return 0
@@ -1968,7 +2014,7 @@ func (s *Supervisor) discoverNewTasks(ctx context.Context) int {
 			IssueNumber:  item.Number,
 			IssueTitle:   liveStatus.Title,
 			IssueBody:    body,
-			Dependencies: "[]", // No deps — new tasks start unblocked.
+			Dependencies: "[]",
 			Status:       "queued",
 		})
 	}
@@ -1984,21 +2030,11 @@ func (s *Supervisor) discoverNewTasks(ctx context.Context) int {
 
 	for _, t := range newTasks {
 		if t.Status == "manual" {
-			s.emitEvent("discovered", fmt.Sprintf("New manual task #%d: %s (watching for completion)", t.IssueNumber, t.IssueTitle), nil)
+			s.emitEvent("info", fmt.Sprintf("New manual task #%d: %s (watching for completion)", t.IssueNumber, t.IssueTitle), nil)
 		} else {
-			s.emitEvent("discovered", fmt.Sprintf("New task #%d: %s", t.IssueNumber, t.IssueTitle), nil)
+			s.emitEvent("info", fmt.Sprintf("New task #%d: %s (pending dep analysis)", t.IssueNumber, t.IssueTitle), nil)
 		}
 	}
-
-	// Warn that the dependency graph (built once during Prepare) may be stale.
-	// Dynamically discovered tasks are queued without deps, but they could
-	// affect ordering of already-queued tasks. The user can stop and re-launch
-	// autopilot to rebuild the full dep graph with an LLM call.
-	var nums []string
-	for _, t := range newTasks {
-		nums = append(nums, fmt.Sprintf("#%d", t.IssueNumber))
-	}
-	s.emitEvent("warning", fmt.Sprintf("New tasks discovered (%s) — dependency graph may be stale. New tasks will run without dependency ordering.", strings.Join(nums, ", ")), nil)
 
 	return added
 }

--- a/internal/autopilot/supervisor_coverage_test.go
+++ b/internal/autopilot/supervisor_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -519,31 +520,6 @@ func TestAddSlot(t *testing.T) {
 	if len(sup.slots) != initial+1 {
 		t.Errorf("slots len = %d, want %d", len(sup.slots), initial+1)
 	}
-}
-
-// ---------------------------------------------------------------------------
-// TriggerDiscovery
-// ---------------------------------------------------------------------------
-
-func TestTriggerDiscovery(t *testing.T) {
-	store := openTestStore(t)
-	project := createTestProject(t, store)
-	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "")
-
-	// Should be non-blocking.
-	sup.TriggerDiscovery()
-
-	// Channel should have one signal.
-	select {
-	case <-sup.discovery:
-		// good
-	default:
-		t.Error("expected signal on discovery channel")
-	}
-
-	// Second trigger while one is pending should be dropped.
-	sup.TriggerDiscovery()
-	sup.TriggerDiscovery() // should not block
 }
 
 // ---------------------------------------------------------------------------
@@ -2703,22 +2679,22 @@ func TestApplyRebuildDepOption_MalformedDeps(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// discoverNewTasks — error paths
+// addNewTrackedItems — error paths
 // ---------------------------------------------------------------------------
 
-func TestDiscoverNewTasks_NoTrackedItems(t *testing.T) {
+func TestAddNewTrackedItems_NoTrackedItems(t *testing.T) {
 	store := openTestStore(t)
 	project := createTestProject(t, store)
 	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "fake-token")
 
 	// No tracked items → should return 0.
-	added := sup.discoverNewTasks(context.Background())
+	added := sup.addNewTrackedItems(context.Background())
 	if added != 0 {
-		t.Errorf("discoverNewTasks = %d, want 0", added)
+		t.Errorf("addNewTrackedItems = %d, want 0", added)
 	}
 }
 
-func TestDiscoverNewTasks_AllAlreadyKnown(t *testing.T) {
+func TestAddNewTrackedItems_AllAlreadyKnown(t *testing.T) {
 	store := openTestStore(t)
 	project := createTestProject(t, store)
 	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "fake-token")
@@ -2745,13 +2721,13 @@ func TestDiscoverNewTasks_AllAlreadyKnown(t *testing.T) {
 	}
 	_ = store.CreateAutopilotTask(task)
 
-	added := sup.discoverNewTasks(context.Background())
+	added := sup.addNewTrackedItems(context.Background())
 	if added != 0 {
-		t.Errorf("discoverNewTasks = %d, want 0 (already known)", added)
+		t.Errorf("addNewTrackedItems = %d, want 0 (already known)", added)
 	}
 }
 
-func TestDiscoverNewTasks_ClosedItemSkipped(t *testing.T) {
+func TestAddNewTrackedItems_ClosedItemSkipped(t *testing.T) {
 	store := openTestStore(t)
 	project := createTestProject(t, store)
 	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "fake-token")
@@ -2769,13 +2745,13 @@ func TestDiscoverNewTasks_ClosedItemSkipped(t *testing.T) {
 	}
 	_ = store.AddTrackedItem(item)
 
-	added := sup.discoverNewTasks(context.Background())
+	added := sup.addNewTrackedItems(context.Background())
 	if added != 0 {
-		t.Errorf("discoverNewTasks = %d, want 0 (closed item)", added)
+		t.Errorf("addNewTrackedItems = %d, want 0 (closed item)", added)
 	}
 }
 
-func TestDiscoverNewTasks_PRSkipped(t *testing.T) {
+func TestAddNewTrackedItems_PRSkipped(t *testing.T) {
 	store := openTestStore(t)
 	project := createTestProject(t, store)
 	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "fake-token")
@@ -2793,9 +2769,9 @@ func TestDiscoverNewTasks_PRSkipped(t *testing.T) {
 	}
 	_ = store.AddTrackedItem(item)
 
-	added := sup.discoverNewTasks(context.Background())
+	added := sup.addNewTrackedItems(context.Background())
 	if added != 0 {
-		t.Errorf("discoverNewTasks = %d, want 0 (PR skipped)", added)
+		t.Errorf("addNewTrackedItems = %d, want 0 (PR skipped)", added)
 	}
 }
 
@@ -2870,44 +2846,156 @@ func TestConvertTrackedItems_OnlyPRs(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Launch with triggered discovery (via channel signal)
+// ApplyIncrementalDepOption — reverse deps and non-mutable guard
 // ---------------------------------------------------------------------------
 
-func TestLaunch_DiscoverySignal(t *testing.T) {
+func TestApplyIncrementalDepOption_SkipsNonMutableStatuses(t *testing.T) {
 	store := openTestStore(t)
 	project := createTestProject(t, store)
 	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "")
 
-	// Blocked task keeps loop alive.
-	task := &db.AutopilotTask{
-		ProjectID:    project.ID,
-		IssueNumber:  10,
-		IssueTitle:   "Blocked",
-		Dependencies: "[99]",
-		Status:       "blocked",
+	// Create tasks in various non-mutable states.
+	for _, status := range []string{"running", "review", "done", "bailed", "stopped", "failed"} {
+		task := &db.AutopilotTask{
+			ProjectID:    project.ID,
+			IssueNumber:  10 + len(status), // unique numbers
+			IssueTitle:   "Task " + status,
+			Dependencies: "[]",
+			Status:       status,
+		}
+		_ = store.CreateAutopilotTask(task)
 	}
-	_ = store.CreateAutopilotTask(task)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	sup.Launch(ctx)
-	time.Sleep(100 * time.Millisecond)
+	// Build a graph that tries to update all of them.
+	graph := make(map[string]json.RawMessage)
+	tasks, _ := store.GetAutopilotTasks(project.ID)
+	for _, t := range tasks {
+		graph[strconv.Itoa(t.IssueNumber)] = json.RawMessage("[99]")
+	}
 
-	// Trigger discovery — should not panic.
-	sup.TriggerDiscovery()
-	time.Sleep(100 * time.Millisecond)
+	err := sup.ApplyIncrementalDepOption(context.Background(), DepOption{
+		Name:  "test",
+		Graph: graph,
+	})
+	if err != nil {
+		t.Fatalf("ApplyIncrementalDepOption: %v", err)
+	}
 
-	cancel()
+	// Verify none of them were modified.
+	tasks, _ = store.GetAutopilotTasks(project.ID)
+	for _, task := range tasks {
+		if task.Dependencies != "[]" {
+			t.Errorf("task #%d (%s) deps changed to %s, want []", task.IssueNumber, task.Status, task.Dependencies)
+		}
+	}
+}
 
-	done := make(chan struct{})
-	go func() {
-		sup.Stop()
-		close(done)
-	}()
+func TestApplyIncrementalDepOption_UpdatesExistingQueuedTask(t *testing.T) {
+	store := openTestStore(t)
+	project := createTestProject(t, store)
+	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "")
 
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Stop() hung")
+	// Existing queued task with deps [99].
+	existing := &db.AutopilotTask{
+		ProjectID:    project.ID,
+		IssueNumber:  42,
+		IssueTitle:   "Existing task",
+		Dependencies: "[99]",
+		Status:       "queued",
+	}
+	_ = store.CreateAutopilotTask(existing)
+
+	// New task #50.
+	newTask := &db.AutopilotTask{
+		ProjectID:    project.ID,
+		IssueNumber:  50,
+		IssueTitle:   "New task",
+		Dependencies: "[]",
+		Status:       "queued",
+	}
+	_ = store.CreateAutopilotTask(newTask)
+
+	// Graph: new #50 has no deps; existing #42 now also depends on #50 (reverse dep).
+	graph := map[string]json.RawMessage{
+		"50": json.RawMessage("[]"),
+		"42": json.RawMessage("[99,50]"),
+	}
+
+	err := sup.ApplyIncrementalDepOption(context.Background(), DepOption{
+		Name:  "test",
+		Graph: graph,
+	})
+	if err != nil {
+		t.Fatalf("ApplyIncrementalDepOption: %v", err)
+	}
+
+	tasks, _ := store.GetAutopilotTasks(project.ID)
+	for _, task := range tasks {
+		if task.IssueNumber == 42 {
+			if task.Dependencies != "[99,50]" {
+				t.Errorf("task #42 deps = %s, want [99,50]", task.Dependencies)
+			}
+			if task.Status != "blocked" {
+				t.Errorf("task #42 status = %s, want blocked", task.Status)
+			}
+		}
+		if task.IssueNumber == 50 {
+			// New task with no deps should remain queued.
+			if task.Status != "queued" {
+				t.Errorf("task #50 status = %s, want queued", task.Status)
+			}
+		}
+	}
+}
+
+func TestApplyIncrementalDepOption_EmitsEvents(t *testing.T) {
+	store := openTestStore(t)
+	project := createTestProject(t, store)
+	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "")
+
+	// New task (queued with empty deps).
+	newTask := &db.AutopilotTask{
+		ProjectID:    project.ID,
+		IssueNumber:  50,
+		IssueTitle:   "New task",
+		Dependencies: "[]",
+		Status:       "queued",
+	}
+	_ = store.CreateAutopilotTask(newTask)
+
+	graph := map[string]json.RawMessage{
+		"50": json.RawMessage("[42]"),
+	}
+
+	err := sup.ApplyIncrementalDepOption(context.Background(), DepOption{
+		Name:  "test",
+		Graph: graph,
+	})
+	if err != nil {
+		t.Fatalf("ApplyIncrementalDepOption: %v", err)
+	}
+
+	// Drain events and check for graph-update and info events.
+	var graphUpdates, infoEvents int
+	for {
+		select {
+		case ev := <-sup.Events():
+			switch ev.Type {
+			case "graph-update":
+				graphUpdates++
+			case "info":
+				infoEvents++
+			}
+		default:
+			goto done
+		}
+	}
+done:
+	if graphUpdates == 0 {
+		t.Error("expected at least one graph-update event")
+	}
+	if infoEvents == 0 {
+		t.Error("expected at least one info summary event")
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -617,9 +617,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case bulkTrackResultMsg:
 		m.refreshTrackedItems()
-		if msg.added > 0 && m.autopilotSupervisor != nil {
-			m.autopilotSupervisor.TriggerDiscovery()
-		}
 		if msg.failed > 0 {
 			m.trackError = true
 			m.trackStatus = fmt.Sprintf("Tracked %d, %d failed: %s", msg.added, msg.failed, strings.Join(msg.errors, "; "))


### PR DESCRIPTION
## Summary
- Remove dynamic task discovery (60s polling loop) — new tasks are only added during deliberate ReprepareKeep flow (#243)
- Add reverse dependency injection: incremental LLM analysis can now update deps of existing queued/blocked tasks when new issues should block them
- Guard non-mutable task states (running/review/done/bailed/stopped/failed) from dep modifications
- Emit descriptive `graph-update` events for each task change and summary `info` events

Closes #243

## Test plan
- [x] `TestApplyIncrementalDepOption_SkipsNonMutableStatuses` — verifies running/review/done/etc. tasks are never modified
- [x] `TestApplyIncrementalDepOption_UpdatesExistingQueuedTask` — verifies reverse dep injection updates existing queued task deps
- [x] `TestApplyIncrementalDepOption_EmitsEvents` — verifies graph-update and info events are emitted
- [x] `TestAddNewTrackedItems_*` — 4 tests covering no items, already known, closed, and PR-skipped paths
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)