### PR TITLE
Add --version flag to root CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `--version` flag on root CLI command, using `internal/build.Version` constant (#187)
+
 ## [0.1.0] - 2026-03-19
 
 Initial pre-release. This captures the current feature set ahead of public open-source release.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dustinlange/agent-minder/internal/build"
 	"github.com/dustinlange/agent-minder/internal/config"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "agent-minder",
-	Short: "Coordination layer on top of agent-msg",
+	Use:     "agent-minder",
+	Short:   "Coordination layer on top of agent-msg",
+	Version: build.Version,
 	Long: `A CLI tool that monitors multiple repositories, watches the message bus,
 tracks git activity, and keeps both AI agents and the human operator
 informed about cross-repo state.


### PR DESCRIPTION
Adds --version flag to root Cobra command using build.Version. Fixes #187