### PR TITLE
Schema v23: review automation columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Schema v23**: Review automation columns — `autopilot_auto_merge`, `autopilot_review_max_turns`, `autopilot_review_max_budget_usd` on projects; `review_risk`, `review_comment_id` on autopilot_tasks; new `reviewing`/`reviewed` task statuses
+
 ## [0.1.0] - 2026-03-19
 
 Initial pre-release. This captures the current feature set ahead of public open-source release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,13 +81,13 @@ Supervisor manages N concurrent Claude Code agents working on GitHub issues in i
 
 **Agent command:** `claude --agent autopilot -p --max-turns <N> --max-budget-usd <B> --allowedTools <tool> ... "<prompt>"` with `GITHUB_TOKEN` env var. Allowed tools are loaded from `.agent-minder/onboarding.yaml` (if present) or a built-in default set.
 
-### DB schema (internal/db) — currently v21
+### DB schema (internal/db) — currently v23
 
-**projects**: name, goal_type, goal_description, refresh_interval_sec, message_ttl_sec, auto_enroll_worktrees, minder_identity, llm_provider (deprecated), llm_model (deprecated), llm_summarizer_model, llm_analyzer_model, autopilot_max_agents, autopilot_max_turns, autopilot_max_budget_usd, autopilot_skip_label
+**projects**: name, goal_type, goal_description, refresh_interval_sec, message_ttl_sec, auto_enroll_worktrees, minder_identity, llm_provider (deprecated), llm_model (deprecated), llm_summarizer_model, llm_analyzer_model, autopilot_max_agents, autopilot_max_turns, autopilot_max_budget_usd, autopilot_skip_label, autopilot_auto_merge, autopilot_review_max_turns (nullable), autopilot_review_max_budget_usd (nullable)
 
 **polls**: project_id, new_commits, new_messages, concerns_raised, llm_response (legacy), tier1_response, tier2_response, bus_message_sent, polled_at
 
-**autopilot_tasks**: project_id, issue_number, issue_title, issue_body, dependencies (JSON), status (queued/running/done/bailed/blocked/manual/skipped), worktree_path, branch, pr_number, agent_log, started_at, completed_at, max_turns_override (nullable), max_budget_override (nullable) — UNIQUE on project_id+issue_number
+**autopilot_tasks**: project_id, issue_number, issue_title, issue_body, dependencies (JSON), status (queued/running/review/reviewing/reviewed/done/bailed/blocked/manual/skipped), worktree_path, branch, pr_number, agent_log, started_at, completed_at, max_turns_override (nullable), max_budget_override (nullable), review_risk (nullable), review_comment_id (nullable) — UNIQUE on project_id+issue_number
 
 **autopilot_dep_graphs**: project_id (UNIQUE), graph_json, option_name, created_at — persists the selected dependency graph across autopilot restarts
 
@@ -95,7 +95,7 @@ Supervisor manages N concurrent Claude Code agents working on GitHub issues in i
 
 **Also**: repos, worktrees, topics, concerns (see `schema.go` for full DDL)
 
-Migrations: v1→v2 (two-tier LLM columns), v3 (tracked_items), v4 (content hash + summaries), v5 (idle_pause_sec), v6 (is_draft + review_state), v7 (completed_items), v8 (analyzer_focus), v9 (autopilot_tasks table + autopilot project columns), v18 (deprecate llm_provider/llm_model columns), v20 (autopilot_dep_graphs table for persisting dep graphs), v21 (per-task max_turns_override + max_budget_override columns).
+Migrations: v1→v2 (two-tier LLM columns), v3 (tracked_items), v4 (content hash + summaries), v5 (idle_pause_sec), v6 (is_draft + review_state), v7 (completed_items), v8 (analyzer_focus), v9 (autopilot_tasks table + autopilot project columns), v18 (deprecate llm_provider/llm_model columns), v20 (autopilot_dep_graphs table for persisting dep graphs), v21 (per-task max_turns_override + max_budget_override columns), v23 (review automation: autopilot_auto_merge, review_max_turns/budget on projects; review_risk, review_comment_id on tasks; reviewing/reviewed statuses).
 
 `Poll.LLMResponse()` accessor returns tier2 > tier1 > raw (backward compat).
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2471,3 +2471,133 @@ func TestMigrateV20_CreatesDepGraphTable(t *testing.T) {
 		t.Errorf("unexpected dep graph after migration: %+v", dg)
 	}
 }
+
+func TestMigrateV23_ReviewAutomationColumns(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	// Create a v22 database.
+	conn, err := sqlx.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	// Apply schemaV1 but set version to 22.
+	if _, err := conn.Exec(schemaV1); err != nil {
+		t.Fatalf("apply schema: %v", err)
+	}
+	// Drop v23 columns so migration can re-add them.
+	for _, col := range []string{"autopilot_auto_merge", "autopilot_review_max_turns", "autopilot_review_max_budget_usd"} {
+		if _, err := conn.Exec("ALTER TABLE projects DROP COLUMN " + col); err != nil {
+			t.Fatalf("drop column %s: %v", col, err)
+		}
+	}
+	for _, col := range []string{"review_risk", "review_comment_id"} {
+		if _, err := conn.Exec("ALTER TABLE autopilot_tasks DROP COLUMN " + col); err != nil {
+			t.Fatalf("drop column %s: %v", col, err)
+		}
+	}
+	if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (22)"); err != nil {
+		t.Fatalf("set version: %v", err)
+	}
+	_ = conn.Close()
+
+	// Re-open with Open() which will run migrations.
+	conn2, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open with migration: %v", err)
+	}
+	defer func() { _ = conn2.Close() }()
+
+	store := NewStore(conn2)
+
+	// Verify project columns exist with defaults.
+	p := &Project{Name: "v23-test", GoalType: "feature", GoalDescription: "test"}
+	if err := store.CreateProject(p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	got, err := store.GetProject("v23-test")
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	if got.AutopilotAutoMerge != false {
+		t.Errorf("AutopilotAutoMerge = %v, want false", got.AutopilotAutoMerge)
+	}
+	if got.AutopilotReviewMaxTurns != nil {
+		t.Errorf("AutopilotReviewMaxTurns = %v, want nil", got.AutopilotReviewMaxTurns)
+	}
+	if got.AutopilotReviewMaxBudgetUSD != nil {
+		t.Errorf("AutopilotReviewMaxBudgetUSD = %v, want nil", got.AutopilotReviewMaxBudgetUSD)
+	}
+
+	// Verify autopilot_tasks review columns.
+	task := &AutopilotTask{
+		ProjectID:   p.ID,
+		Owner:       "test",
+		Repo:        "test",
+		IssueNumber: 1,
+		IssueTitle:  "test issue",
+		Status:      "review",
+	}
+	if err := store.CreateAutopilotTask(task); err != nil {
+		t.Fatalf("CreateAutopilotTask: %v", err)
+	}
+
+	// Update review fields.
+	if err := store.UpdateAutopilotTaskReview(task.ID, "low-risk", 12345); err != nil {
+		t.Fatalf("UpdateAutopilotTaskReview: %v", err)
+	}
+
+	// Verify the update.
+	tasks, err := store.GetAutopilotTasks(p.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].ReviewRisk == nil || *tasks[0].ReviewRisk != "low-risk" {
+		t.Errorf("ReviewRisk = %v, want 'low-risk'", tasks[0].ReviewRisk)
+	}
+	if tasks[0].ReviewCommentID == nil || *tasks[0].ReviewCommentID != 12345 {
+		t.Errorf("ReviewCommentID = %v, want 12345", tasks[0].ReviewCommentID)
+	}
+
+	// Test reviewing/reviewed status transitions.
+	if err := store.UpdateAutopilotTaskStatus(task.ID, "reviewing"); err != nil {
+		t.Fatalf("UpdateAutopilotTaskStatus(reviewing): %v", err)
+	}
+	tasks, _ = store.GetAutopilotTasks(p.ID)
+	if tasks[0].Status != "reviewing" {
+		t.Errorf("Status = %q, want 'reviewing'", tasks[0].Status)
+	}
+	if err := store.UpdateAutopilotTaskStatus(task.ID, "reviewed"); err != nil {
+		t.Fatalf("UpdateAutopilotTaskStatus(reviewed): %v", err)
+	}
+	tasks, _ = store.GetAutopilotTasks(p.ID)
+	if tasks[0].Status != "reviewed" {
+		t.Errorf("Status = %q, want 'reviewed'", tasks[0].Status)
+	}
+	// reviewed should set completed_at.
+	if tasks[0].CompletedAt == "" {
+		t.Errorf("CompletedAt should be set for 'reviewed' status")
+	}
+
+	// Test ReviewTasks query.
+	task2 := &AutopilotTask{
+		ProjectID:   p.ID,
+		Owner:       "test",
+		Repo:        "test",
+		IssueNumber: 2,
+		IssueTitle:  "another issue",
+		Status:      "review",
+	}
+	if err := store.CreateAutopilotTask(task2); err != nil {
+		t.Fatalf("CreateAutopilotTask: %v", err)
+	}
+	reviewTasks, err := store.ReviewTasks(p.ID)
+	if err != nil {
+		t.Fatalf("ReviewTasks: %v", err)
+	}
+	if len(reviewTasks) != 1 {
+		t.Errorf("ReviewTasks returned %d tasks, want 1", len(reviewTasks))
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -8,34 +8,37 @@ import (
 
 // Project represents a monitored project.
 type Project struct {
-	ID                    int64   `db:"id"`
-	Name                  string  `db:"name"`
-	GoalType              string  `db:"goal_type"`
-	GoalDescription       string  `db:"goal_description"`
-	RefreshIntervalSec    int     `db:"refresh_interval_sec"`
-	MessageTTLSec         int     `db:"message_ttl_sec"`
-	AutoEnrollWorktrees   bool    `db:"auto_enroll_worktrees"`
-	MinderIdentity        string  `db:"minder_identity"`
-	LLMProvider           string  `db:"llm_provider"`
-	LLMModel              string  `db:"llm_model"`
-	LLMSummarizerModel    string  `db:"llm_summarizer_model"`
-	LLMAnalyzerModel      string  `db:"llm_analyzer_model"`
-	LLMSummarizerProvider string  `db:"llm_summarizer_provider"`
-	LLMAnalyzerProvider   string  `db:"llm_analyzer_provider"`
-	StatusIntervalSec     int     `db:"status_interval_sec"`
-	AnalysisIntervalSec   int     `db:"analysis_interval_sec"`
-	IdlePauseSec          int     `db:"idle_pause_sec"`
-	AnalyzerFocus         string  `db:"analyzer_focus"`
-	AutopilotFilterType   string  `db:"autopilot_filter_type"`  // deprecated, unused
-	AutopilotFilterValue  string  `db:"autopilot_filter_value"` // deprecated, unused
-	AutopilotMaxAgents    int     `db:"autopilot_max_agents"`
-	AutopilotMaxTurns     int     `db:"autopilot_max_turns"`
-	AutopilotMaxBudgetUSD float64 `db:"autopilot_max_budget_usd"`
-	AutopilotSkipLabel    string  `db:"autopilot_skip_label"`
-	AutopilotBaseBranch   string  `db:"autopilot_base_branch"`
-	IsDeploy              bool    `db:"is_deploy"`
-	AnalyzerSessionID     string  `db:"analyzer_session_id"`
-	CreatedAt             string  `db:"created_at"`
+	ID                          int64    `db:"id"`
+	Name                        string   `db:"name"`
+	GoalType                    string   `db:"goal_type"`
+	GoalDescription             string   `db:"goal_description"`
+	RefreshIntervalSec          int      `db:"refresh_interval_sec"`
+	MessageTTLSec               int      `db:"message_ttl_sec"`
+	AutoEnrollWorktrees         bool     `db:"auto_enroll_worktrees"`
+	MinderIdentity              string   `db:"minder_identity"`
+	LLMProvider                 string   `db:"llm_provider"`
+	LLMModel                    string   `db:"llm_model"`
+	LLMSummarizerModel          string   `db:"llm_summarizer_model"`
+	LLMAnalyzerModel            string   `db:"llm_analyzer_model"`
+	LLMSummarizerProvider       string   `db:"llm_summarizer_provider"`
+	LLMAnalyzerProvider         string   `db:"llm_analyzer_provider"`
+	StatusIntervalSec           int      `db:"status_interval_sec"`
+	AnalysisIntervalSec         int      `db:"analysis_interval_sec"`
+	IdlePauseSec                int      `db:"idle_pause_sec"`
+	AnalyzerFocus               string   `db:"analyzer_focus"`
+	AutopilotFilterType         string   `db:"autopilot_filter_type"`  // deprecated, unused
+	AutopilotFilterValue        string   `db:"autopilot_filter_value"` // deprecated, unused
+	AutopilotMaxAgents          int      `db:"autopilot_max_agents"`
+	AutopilotMaxTurns           int      `db:"autopilot_max_turns"`
+	AutopilotMaxBudgetUSD       float64  `db:"autopilot_max_budget_usd"`
+	AutopilotSkipLabel          string   `db:"autopilot_skip_label"`
+	AutopilotBaseBranch         string   `db:"autopilot_base_branch"`
+	IsDeploy                    bool     `db:"is_deploy"`
+	AnalyzerSessionID           string   `db:"analyzer_session_id"`
+	AutopilotAutoMerge          bool     `db:"autopilot_auto_merge"`
+	AutopilotReviewMaxTurns     *int     `db:"autopilot_review_max_turns"`
+	AutopilotReviewMaxBudgetUSD *float64 `db:"autopilot_review_max_budget_usd"`
+	CreatedAt                   string   `db:"created_at"`
 }
 
 // RefreshInterval returns the refresh interval as a time.Duration.
@@ -200,6 +203,9 @@ type AutopilotTask struct {
 
 	MaxTurnsOverride  *int     `db:"max_turns_override"`  // per-task turns override (nil = use project default)
 	MaxBudgetOverride *float64 `db:"max_budget_override"` // per-task budget override (nil = use project default)
+
+	ReviewRisk      *string `db:"review_risk"`       // risk assessment: "low-risk", "needs-testing", "suspect"
+	ReviewCommentID *int64  `db:"review_comment_id"` // GitHub PR comment ID for updating review comment
 }
 
 // EffectiveMaxTurns returns the per-task max turns override if set,

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -35,14 +35,16 @@ func (s *Store) CreateProject(p *Project) error {
 			idle_pause_sec, analyzer_focus,
 			autopilot_filter_type, autopilot_filter_value, autopilot_max_agents,
 			autopilot_max_turns, autopilot_max_budget_usd, autopilot_skip_label,
-			autopilot_base_branch, is_deploy)
+			autopilot_base_branch, is_deploy,
+			autopilot_auto_merge, autopilot_review_max_turns, autopilot_review_max_budget_usd)
 		VALUES (:name, :goal_type, :goal_description, :refresh_interval_sec,
 			:message_ttl_sec, :auto_enroll_worktrees, :minder_identity, :llm_provider, :llm_model,
 			:llm_summarizer_model, :llm_analyzer_model, :status_interval_sec, :analysis_interval_sec,
 			:idle_pause_sec, :analyzer_focus,
 			:autopilot_filter_type, :autopilot_filter_value, :autopilot_max_agents,
 			:autopilot_max_turns, :autopilot_max_budget_usd, :autopilot_skip_label,
-			:autopilot_base_branch, :is_deploy)
+			:autopilot_base_branch, :is_deploy,
+			:autopilot_auto_merge, :autopilot_review_max_turns, :autopilot_review_max_budget_usd)
 	`, p)
 	if err != nil {
 		return fmt.Errorf("insert project: %w", err)
@@ -108,7 +110,10 @@ func (s *Store) UpdateProject(p *Project) error {
 			autopilot_max_turns = :autopilot_max_turns,
 			autopilot_max_budget_usd = :autopilot_max_budget_usd,
 			autopilot_skip_label = :autopilot_skip_label,
-			autopilot_base_branch = :autopilot_base_branch
+			autopilot_base_branch = :autopilot_base_branch,
+			autopilot_auto_merge = :autopilot_auto_merge,
+			autopilot_review_max_turns = :autopilot_review_max_turns,
+			autopilot_review_max_budget_usd = :autopilot_review_max_budget_usd
 		WHERE id = :id
 	`, p)
 	return err
@@ -802,7 +807,7 @@ func (s *Store) GetAutopilotTasks(projectID int64) ([]AutopilotTask, error) {
 
 // UpdateAutopilotTaskStatus updates only the status and completed_at of an autopilot task.
 func (s *Store) UpdateAutopilotTaskStatus(id int64, status string) error {
-	if status == "done" || status == "bailed" || status == "stopped" || status == "failed" {
+	if status == "done" || status == "bailed" || status == "stopped" || status == "failed" || status == "reviewed" {
 		_, err := s.db.Exec(`
 			UPDATE autopilot_tasks SET status = ?, completed_at = datetime('now') WHERE id = ?
 		`, status, id)
@@ -1083,6 +1088,25 @@ func (s *Store) UpdateAutopilotTaskOverrides(id int64, maxTurns *int, maxBudget 
 func (s *Store) UpdateAutopilotTaskCost(id int64, costUSD float64) error {
 	_, err := s.db.Exec(`UPDATE autopilot_tasks SET cost_usd = ? WHERE id = ?`, costUSD, id)
 	return err
+}
+
+// UpdateAutopilotTaskReview sets the review risk and comment ID for a task.
+func (s *Store) UpdateAutopilotTaskReview(id int64, reviewRisk string, commentID int64) error {
+	_, err := s.db.Exec(`
+		UPDATE autopilot_tasks SET review_risk = ?, review_comment_id = ? WHERE id = ?
+	`, reviewRisk, commentID, id)
+	return err
+}
+
+// ReviewTasks returns all tasks in "review" status (PR opened, awaiting review).
+func (s *Store) ReviewTasks(projectID int64) ([]AutopilotTask, error) {
+	var tasks []AutopilotTask
+	if err := s.db.Select(&tasks, `
+		SELECT * FROM autopilot_tasks WHERE project_id = ? AND status = 'review' ORDER BY issue_number
+	`, projectID); err != nil {
+		return nil, fmt.Errorf("review tasks: %w", err)
+	}
+	return tasks, nil
 }
 
 // --- Cost Aggregation ---

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -10,7 +10,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const currentVersion = 22
+const currentVersion = 23
 
 const schemaV1 = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -44,8 +44,11 @@ CREATE TABLE IF NOT EXISTS projects (
 	autopilot_skip_label   TEXT DEFAULT 'no-agent',
 	autopilot_base_branch  TEXT DEFAULT '',
 	is_deploy             INTEGER DEFAULT 0,
-	analyzer_session_id   TEXT DEFAULT '',
-	created_at            TEXT DEFAULT (datetime('now'))
+	analyzer_session_id          TEXT DEFAULT '',
+	autopilot_auto_merge         INTEGER DEFAULT 0,
+	autopilot_review_max_turns   INTEGER,
+	autopilot_review_max_budget_usd REAL,
+	created_at                   TEXT DEFAULT (datetime('now'))
 );
 
 CREATE TABLE IF NOT EXISTS repos (
@@ -137,6 +140,8 @@ CREATE TABLE IF NOT EXISTS autopilot_tasks (
 	cost_usd              REAL DEFAULT 0,
 	max_turns_override    INTEGER,
 	max_budget_override   REAL,
+	review_risk           TEXT,
+	review_comment_id     INTEGER,
 	UNIQUE(project_id, issue_number)
 );
 
@@ -332,6 +337,12 @@ func migrate(db *sqlx.DB) error {
 	if version < 22 {
 		if err := migrateV22(db); err != nil {
 			return fmt.Errorf("apply migration v22: %w", err)
+		}
+	}
+
+	if version < 23 {
+		if err := migrateV23(db); err != nil {
+			return fmt.Errorf("apply migration v23: %w", err)
 		}
 	}
 
@@ -695,6 +706,31 @@ func migrateV22(db *sqlx.DB) error {
 	}
 	if _, err := db.Exec(`UPDATE projects SET analyzer_session_id = '' WHERE analyzer_session_id IS NULL`); err != nil {
 		return fmt.Errorf("null-fill analyzer_session_id: %w", err)
+	}
+	return nil
+}
+
+func migrateV23(db *sqlx.DB) error {
+	stmts := []string{
+		// Projects: review automation settings.
+		`ALTER TABLE projects ADD COLUMN autopilot_auto_merge INTEGER DEFAULT 0`,
+		`ALTER TABLE projects ADD COLUMN autopilot_review_max_turns INTEGER`,
+		`ALTER TABLE projects ADD COLUMN autopilot_review_max_budget_usd REAL`,
+		// Autopilot tasks: review pipeline columns.
+		`ALTER TABLE autopilot_tasks ADD COLUMN review_risk TEXT`,
+		`ALTER TABLE autopilot_tasks ADD COLUMN review_comment_id INTEGER`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			if strings.Contains(err.Error(), "duplicate column") {
+				continue
+			}
+			return fmt.Errorf("%s: %w", stmt, err)
+		}
+	}
+	// Null-fill the boolean column so Go bool scanning works.
+	if _, err := db.Exec(`UPDATE projects SET autopilot_auto_merge = 0 WHERE autopilot_auto_merge IS NULL`); err != nil {
+		return fmt.Errorf("null-fill autopilot_auto_merge: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add project columns for review automation settings (autopilot_auto_merge, autopilot_review_max_turns, autopilot_review_max_budget_usd)
- Add task columns for review pipeline state (review_risk, review_comment_id)
- Add reviewing and reviewed as valid autopilot task statuses
- Migration v23 with duplicate-column tolerance for fresh DBs

## Test plan

- [x] TestMigrateV23 covers migration from v22, column defaults, CRUD, status transitions, and ReviewTasks query
- [x] All existing DB tests pass
- [x] Pre-commit hooks pass

Fixes #289
