### PR TITLE
Inject dep graph and task context into reviewer prompt

### DIFF
--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -467,9 +467,65 @@ func renderResumeTaskContext(task *db.AutopilotTask, baseBranch, owner, repo str
 	return b.String()
 }
 
+// reviewRelatedWork holds dependency graph and sibling task context for the reviewer.
+type reviewRelatedWork struct {
+	// depGraph is the raw JSON dependency graph (issue→[deps]) from autopilot_dep_graphs.
+	depGraph string
+	// siblingTasks is the list of all autopilot tasks in the same project.
+	siblingTasks []db.AutopilotTask
+}
+
+// renderRelatedWork formats the dependency graph and sibling task statuses
+// into a "Related Work" section for the review prompt. Returns empty string
+// if no useful context is available.
+func renderRelatedWork(task *db.AutopilotTask, rw *reviewRelatedWork) string {
+	if rw == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Related Work\n\n")
+
+	// Show where this issue sits in the dependency graph.
+	if rw.depGraph != "" {
+		b.WriteString("### Dependency Graph\n\n")
+		b.WriteString("This JSON maps each issue number to the issues it depends on (must complete first):\n\n")
+		b.WriteString("```json\n")
+		b.WriteString(rw.depGraph)
+		b.WriteString("\n```\n\n")
+	}
+
+	// Show sibling task statuses so the reviewer can evaluate the PR in context.
+	if len(rw.siblingTasks) > 0 {
+		b.WriteString("### Autopilot Task Status\n\n")
+		b.WriteString("Other issues being worked on in this autopilot session:\n\n")
+		b.WriteString("| Issue | Title | Status | PR |\n")
+		b.WriteString("|-------|-------|--------|----|\n")
+		for _, t := range rw.siblingTasks {
+			if t.IssueNumber == task.IssueNumber {
+				continue // skip the task under review
+			}
+			pr := "—"
+			if t.PRNumber > 0 {
+				pr = fmt.Sprintf("#%d", t.PRNumber)
+			}
+			fmt.Fprintf(&b, "| #%d | %s | %s | %s |\n", t.IssueNumber, t.IssueTitle, t.Status, pr)
+		}
+		b.WriteString("\n")
+	}
+
+	result := b.String()
+	// If we only wrote the header with no content, return empty.
+	if result == "## Related Work\n\n" {
+		return ""
+	}
+	return result
+}
+
 // renderReviewTaskContext builds a prompt with review-specific context for the reviewer agent.
-// It provides the PR number, issue details, project goal, and commands for the review workflow.
-func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal string) string {
+// It provides the PR number, issue details, project goal, dependency graph, sibling task
+// statuses, and commands for the review workflow.
+func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal string, rw *reviewRelatedWork) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "## Review Context\n\n")
@@ -490,6 +546,10 @@ func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, pr
 		fmt.Fprintf(&b, "## Project Goal\n\n%s\n\n", projectGoal)
 	}
 
+	if related := renderRelatedWork(task, rw); related != "" {
+		b.WriteString(related)
+	}
+
 	fmt.Fprintf(&b, "## Commands for this review\n\n")
 	fmt.Fprintf(&b, "View PR diff: gh pr diff %d -R %s/%s\n", task.PRNumber, owner, repo)
 	fmt.Fprintf(&b, "View PR files: gh pr view %d --json files -R %s/%s\n", task.PRNumber, owner, repo)
@@ -502,8 +562,8 @@ func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, pr
 }
 
 // buildReviewClaudeArgs constructs the CLI arguments for launching a reviewer agent.
-func buildReviewClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal string, maxTurns int, maxBudget float64, allowedTools []string) []string {
-	prompt := renderReviewTaskContext(task, baseBranch, owner, repo, projectGoal)
+func buildReviewClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal string, maxTurns int, maxBudget float64, allowedTools []string, rw *reviewRelatedWork) []string {
+	prompt := renderReviewTaskContext(task, baseBranch, owner, repo, projectGoal, rw)
 	return []string{
 		"--agent", "reviewer",
 		"-p",

--- a/internal/autopilot/prompt_test.go
+++ b/internal/autopilot/prompt_test.go
@@ -758,7 +758,7 @@ func TestRenderReviewTaskContext(t *testing.T) {
 		PRNumber:     99,
 	}
 
-	ctx := renderReviewTaskContext(task, "main", "myorg", "myrepo", "Build a secure healthcare platform")
+	ctx := renderReviewTaskContext(task, "main", "myorg", "myrepo", "Build a secure healthcare platform", nil)
 
 	checks := []string{
 		"#99", // PR number
@@ -791,7 +791,7 @@ func TestRenderReviewTaskContextEmptyGoal(t *testing.T) {
 		PRNumber:     15,
 	}
 
-	ctx := renderReviewTaskContext(task, "main", "org", "repo", "")
+	ctx := renderReviewTaskContext(task, "main", "org", "repo", "", nil)
 
 	if strings.Contains(ctx, "Project Goal") {
 		t.Error("should not include project goal section when empty")
@@ -809,7 +809,7 @@ func TestBuildReviewClaudeArgs(t *testing.T) {
 	}
 
 	tools := []string{"Read", "Edit", "Write", "Bash(git *)"}
-	args := buildReviewClaudeArgs(task, "main", "org", "repo", "Project goal", 30, 2.00, tools)
+	args := buildReviewClaudeArgs(task, "main", "org", "repo", "Project goal", 30, 2.00, tools, nil)
 
 	// Should use --agent reviewer.
 	if args[0] != "--agent" || args[1] != "reviewer" {
@@ -838,6 +838,115 @@ func TestBuildReviewClaudeArgs(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "Project goal") {
 		t.Error("prompt should contain project goal")
+	}
+}
+
+func TestRenderRelatedWork(t *testing.T) {
+	task := &db.AutopilotTask{IssueNumber: 42}
+
+	t.Run("nil returns empty", func(t *testing.T) {
+		if got := renderRelatedWork(task, nil); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("empty struct returns empty", func(t *testing.T) {
+		rw := &reviewRelatedWork{}
+		if got := renderRelatedWork(task, rw); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("dep graph only", func(t *testing.T) {
+		rw := &reviewRelatedWork{
+			depGraph: `{"42":[],"38":[42]}`,
+		}
+		got := renderRelatedWork(task, rw)
+		if !strings.Contains(got, "Dependency Graph") {
+			t.Error("should contain Dependency Graph heading")
+		}
+		if !strings.Contains(got, `"38":[42]`) {
+			t.Error("should contain dep graph JSON")
+		}
+		if strings.Contains(got, "Autopilot Task Status") {
+			t.Error("should not contain task status when no sibling tasks")
+		}
+	})
+
+	t.Run("sibling tasks only", func(t *testing.T) {
+		rw := &reviewRelatedWork{
+			siblingTasks: []db.AutopilotTask{
+				{IssueNumber: 42, IssueTitle: "Current task", Status: "reviewing"},
+				{IssueNumber: 38, IssueTitle: "Dependency task", Status: "done", PRNumber: 50},
+				{IssueNumber: 55, IssueTitle: "Blocked task", Status: "blocked"},
+			},
+		}
+		got := renderRelatedWork(task, rw)
+		if strings.Contains(got, "Dependency Graph") {
+			t.Error("should not contain Dependency Graph when no dep graph")
+		}
+		if !strings.Contains(got, "Autopilot Task Status") {
+			t.Error("should contain task status heading")
+		}
+		// Current task (#42) should be excluded.
+		if strings.Contains(got, "Current task") {
+			t.Error("should not include the task under review")
+		}
+		if !strings.Contains(got, "#38") || !strings.Contains(got, "done") {
+			t.Error("should include sibling task #38 with status")
+		}
+		if !strings.Contains(got, "#50") {
+			t.Error("should include PR number for sibling task")
+		}
+		if !strings.Contains(got, "#55") || !strings.Contains(got, "blocked") {
+			t.Error("should include blocked sibling task")
+		}
+	})
+
+	t.Run("both dep graph and tasks", func(t *testing.T) {
+		rw := &reviewRelatedWork{
+			depGraph: `{"42":[],"38":[42]}`,
+			siblingTasks: []db.AutopilotTask{
+				{IssueNumber: 38, IssueTitle: "Other", Status: "queued"},
+			},
+		}
+		got := renderRelatedWork(task, rw)
+		if !strings.Contains(got, "Dependency Graph") {
+			t.Error("should contain dep graph")
+		}
+		if !strings.Contains(got, "Autopilot Task Status") {
+			t.Error("should contain task status")
+		}
+	})
+}
+
+func TestRenderReviewTaskContextWithRelatedWork(t *testing.T) {
+	task := &db.AutopilotTask{
+		IssueNumber:  42,
+		IssueTitle:   "Add auth",
+		IssueBody:    "Implement auth",
+		WorktreePath: "/tmp/wt",
+		Branch:       "agent/issue-42",
+		PRNumber:     99,
+	}
+
+	rw := &reviewRelatedWork{
+		depGraph: `{"42":[]}`,
+		siblingTasks: []db.AutopilotTask{
+			{IssueNumber: 10, IssueTitle: "Setup DB", Status: "done", PRNumber: 20},
+		},
+	}
+
+	ctx := renderReviewTaskContext(task, "main", "org", "repo", "Goal", rw)
+
+	if !strings.Contains(ctx, "Related Work") {
+		t.Error("should contain Related Work section")
+	}
+	if !strings.Contains(ctx, "Dependency Graph") {
+		t.Error("should contain dep graph")
+	}
+	if !strings.Contains(ctx, "#10") {
+		t.Error("should contain sibling task")
 	}
 }
 
@@ -885,7 +994,7 @@ func TestPrintPrompts(t *testing.T) {
 
 	fmt.Printf("\n%s\n  REVIEW TASK CONTEXT (used with --agent reviewer)\n%s\n\n", sep, sep)
 	task.PRNumber = 123
-	fmt.Println(renderReviewTaskContext(task, "main", "myorg", "myrepo", "Build a secure healthcare platform"))
+	fmt.Println(renderReviewTaskContext(task, "main", "myorg", "myrepo", "Build a secure healthcare platform", nil))
 
 	fmt.Printf("\n%s\n  BUILT-IN DEFAULT REVIEWER DEFINITION\n%s\n\n", sep, sep)
 	fmt.Print(defaultReviewerDef)

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -2566,7 +2566,21 @@ func (s *Supervisor) runReviewAgent(ctx context.Context, slotIdx int, task *db.A
 	allowedTools := resolveAllowedTools(s.repoDir)
 	projectGoal := s.project.GoalDescription
 
-	args := buildReviewClaudeArgs(task, baseBranch, s.owner, s.repo, projectGoal, maxTurns, maxBudget, allowedTools)
+	// Load dependency graph and sibling task statuses for review context.
+	var rw *reviewRelatedWork
+	dg, err := s.store.GetDepGraph(s.project.ID)
+	tasks, taskErr := s.store.GetAutopilotTasks(s.project.ID)
+	if err == nil || taskErr == nil {
+		rw = &reviewRelatedWork{}
+		if err == nil && dg != nil {
+			rw.depGraph = dg.GraphJSON
+		}
+		if taskErr == nil {
+			rw.siblingTasks = tasks
+		}
+	}
+
+	args := buildReviewClaudeArgs(task, baseBranch, s.owner, s.repo, projectGoal, maxTurns, maxBudget, allowedTools, rw)
 
 	debugLog("review agent command",
 		"stage", "autopilot", "step", "review-launch",


### PR DESCRIPTION
## Summary
- The review agent previously had no visibility into the dependency graph or sibling task statuses, leaving it unable to evaluate PRs in the context of related work
- Loads the dep graph JSON from `autopilot_dep_graphs` and all sibling tasks from `autopilot_tasks` when launching a review agent
- Renders a "Related Work" section in the review prompt with the dependency graph and a table of sibling task statuses (excluding the task under review)

## Test plan
- [x] New `TestRenderRelatedWork` covers nil, empty, dep-graph-only, tasks-only, and combined cases
- [x] New `TestRenderReviewTaskContextWithRelatedWork` verifies the section appears in the full prompt
- [x] Existing tests updated and passing
- [x] Full `go test ./...` passes
- [ ] Manual: run autopilot with review enabled, verify the reviewer agent log shows dep graph and sibling tasks in the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)