### PR TITLE
Fix autopilot git ref lock race causing immediate failures

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -117,6 +117,7 @@ type Supervisor struct {
 	ghToken   string
 
 	mu              sync.Mutex
+	gitSetupMu      sync.Mutex   // serializes git branch/worktree ops to avoid ref lock contention
 	slots           []*slotState // len == maxAgents; nil = idle
 	active          bool
 	paused          bool // when true, fillSlots returns early
@@ -2173,6 +2174,10 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 	}
 
 	if !isResume {
+		// Serialize git branch/worktree operations across concurrent agents to
+		// avoid ref lock contention that causes ~15% of fresh launches to fail.
+		s.gitSetupMu.Lock()
+
 		// Clean up stale branch from previous run if it exists.
 		_ = gitpkg.DeleteBranch(s.repoDir, task.Branch)
 
@@ -2180,8 +2185,11 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 		// not here, to avoid concurrent fetch races on the same repo.
 
 		// Create worktree from the latest remote base branch.
-		if err := gitpkg.WorktreeAdd(s.repoDir, task.WorktreePath, task.Branch, "origin/"+baseBranch); err != nil {
-			s.emitEvent("error", fmt.Sprintf("Failed to create worktree for #%d: %v", task.IssueNumber, err), task)
+		gitErr := gitpkg.WorktreeAdd(s.repoDir, task.WorktreePath, task.Branch, "origin/"+baseBranch)
+		s.gitSetupMu.Unlock()
+
+		if gitErr != nil {
+			s.emitEvent("error", fmt.Sprintf("Failed to create worktree for #%d: %v", task.IssueNumber, gitErr), task)
 			_ = s.store.UpdateAutopilotTaskStatus(task.ID, failStatus)
 			return
 		}
@@ -2976,6 +2984,10 @@ func (s *Supervisor) inspectOutcome(ctx context.Context, task *db.AutopilotTask,
 }
 
 func (s *Supervisor) cleanup(task *db.AutopilotTask, deleteBranch bool) {
+	// Serialize with git setup operations to avoid ref lock contention.
+	s.gitSetupMu.Lock()
+	defer s.gitSetupMu.Unlock()
+
 	// Remove worktree.
 	_ = gitpkg.WorktreeRemove(s.repoDir, task.WorktreePath)
 


### PR DESCRIPTION
## Summary
- ~15% of autopilot agent launches were failing immediately (0 seconds) due to git ref lock contention
- `fillSlots()` launches multiple agent goroutines simultaneously, each running `git branch -D` + `git worktree add` concurrently against the same repo
- Added a `gitSetupMu` mutex to serialize git branch/worktree setup and teardown operations while keeping actual agent execution fully concurrent

## Test plan
- [x] All existing autopilot tests pass
- [ ] Launch autopilot with 3+ concurrent agents and verify no immediate failures
- [ ] Verify retry of previously-failed tasks still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)