### PR TITLE
Improve autopilot agent prompt with quality guidelines and richer context

### DIFF
--- a/agents/autopilot.md
+++ b/agents/autopilot.md
@@ -44,7 +44,7 @@ After exploring, decide:
 - Before pushing, rebase onto the latest base branch using the commands from your task context
 - If there are merge conflicts during rebase, attempt to resolve them
 - If you cannot resolve conflicts, abort the rebase (`git rebase --abort`), bail with a comment listing the conflicting files
-- After a successful rebase, re-run tests (`go test ./...`) and pre-commit checks to verify nothing broke from upstream changes
+- After a successful rebase, re-run the test command from your task context and pre-commit checks to verify nothing broke from upstream changes
 - If tests fail after rebase, fix the issues and amend your commits before pushing
 - Push the branch
 - Open a draft PR targeting the base branch specified in your task context
@@ -56,6 +56,24 @@ After exploring, decide:
   - Your specific questions or what's blocking you
   - A follow-up prompt that could be pasted into a future Claude Code session
 - Add the "blocked" label and remove the "in-progress" label using the commands from your task context
+
+## Implementation quality
+
+Before opening a PR, review your own diff as if you were a code reviewer. Watch for these common issues:
+
+### Avoid duplicated logic
+If you find yourself writing the same sequence of operations in two places, extract a shared helper. Duplicated code means duplicated bugs when the logic changes later.
+
+### Write meaningful tests
+- **Happy path first**: Every new behavior needs at least one test that exercises the success path end-to-end. If testing the real dependency is hard (e.g., external API), use an interface or mock — do not skip the happy path just because it is inconvenient.
+- **Gate conditions second**: Test that guards and preconditions reject bad input.
+- **Edge cases**: nil values, empty strings, boundary conditions.
+
+### Order side effects correctly
+Do not announce success before verifying it. If you post a comment saying "Done!" and then the operation fails, the issue now has misleading state. Pattern: attempt the action → check the result → then report.
+
+### Write descriptive commit messages and PR context
+Include enough context that someone reading `git log` understands *what changed and why* without opening the PR. Reference the issue title, not just the number.
 
 ## Important constraints
 

--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -101,7 +101,7 @@ After exploring, decide:
 - Before pushing, rebase onto the latest base branch using the commands from your task context
 - If there are merge conflicts during rebase, attempt to resolve them
 - If you cannot resolve conflicts, abort the rebase (` + "`git rebase --abort`" + `), bail with a comment listing the conflicting files
-- After a successful rebase, re-run tests (` + "`go test ./...`" + `) and pre-commit checks to verify nothing broke from upstream changes
+- After a successful rebase, re-run the test command from your task context and pre-commit checks to verify nothing broke from upstream changes
 - If tests fail after rebase, fix the issues and amend your commits before pushing
 - Push the branch
 - Open a draft PR targeting the base branch specified in your task context
@@ -113,6 +113,24 @@ After exploring, decide:
   - Your specific questions or what's blocking you
   - A follow-up prompt that could be pasted into a future Claude Code session
 - Add the "blocked" label and remove the "in-progress" label using the commands from your task context
+
+## Implementation quality
+
+Before opening a PR, review your own diff as if you were a code reviewer. Watch for these common issues:
+
+### Avoid duplicated logic
+If you find yourself writing the same sequence of operations in two places, extract a shared helper. Duplicated code means duplicated bugs when the logic changes later.
+
+### Write meaningful tests
+- **Happy path first**: Every new behavior needs at least one test that exercises the success path end-to-end. If testing the real dependency is hard (e.g., external API), use an interface or mock — do not skip the happy path just because it is inconvenient.
+- **Gate conditions second**: Test that guards and preconditions reject bad input.
+- **Edge cases**: nil values, empty strings, boundary conditions.
+
+### Order side effects correctly
+Do not announce success before verifying it. If you post a comment saying "Done!" and then the operation fails, the issue now has misleading state. Pattern: attempt the action → check the result → then report.
+
+### Write descriptive commit messages and PR context
+Include enough context that someone reading ` + "`git log`" + ` understands *what changed and why* without opening the PR. Reference the issue title, not just the number.
 
 ## Important constraints
 
@@ -414,7 +432,7 @@ func toCliAllowedTools(tools []string) string {
 
 // renderTaskContext builds a minimal prompt with only dynamic per-task context.
 // Used when a .claude/agents/autopilot.md agent definition provides the behavioral instructions.
-func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo string) string {
+func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, rw *relatedWork) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "## Task Context\n\n")
@@ -429,6 +447,15 @@ func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo string) s
 	fmt.Fprintf(&b, "**Worktree:** %s\n", task.WorktreePath)
 	fmt.Fprintf(&b, "**Branch:** %s (already checked out)\n", task.Branch)
 	fmt.Fprintf(&b, "**Base branch:** %s\n\n", baseBranch)
+
+	if testCommand != "" {
+		fmt.Fprintf(&b, "## Test command\n\n")
+		fmt.Fprintf(&b, "Run tests: `%s`\n\n", testCommand)
+	}
+
+	if related := renderRelatedWork(task, rw); related != "" {
+		b.WriteString(related)
+	}
 
 	fmt.Fprintf(&b, "## Commands for this task\n\n")
 	fmt.Fprintf(&b, "Label in-progress: gh issue edit %d --add-label \"in-progress\" -R %s/%s\n", task.IssueNumber, owner, repo)
@@ -446,7 +473,7 @@ func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo string) s
 
 // renderResumeTaskContext builds a continuation prompt for resuming work in an existing worktree.
 // It includes context about the prior failure and instructs the agent to pick up where it left off.
-func renderResumeTaskContext(task *db.AutopilotTask, baseBranch, owner, repo string) string {
+func renderResumeTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, rw *relatedWork) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "## Resuming Previous Work\n\n")
@@ -462,13 +489,13 @@ func renderResumeTaskContext(task *db.AutopilotTask, baseBranch, owner, repo str
 	b.WriteString("continue from where it left off, and open a PR when ready.\n\n")
 
 	// Include the standard task context.
-	b.WriteString(renderTaskContext(task, baseBranch, owner, repo))
+	b.WriteString(renderTaskContext(task, baseBranch, owner, repo, testCommand, rw))
 
 	return b.String()
 }
 
-// reviewRelatedWork holds dependency graph and sibling task context for the reviewer.
-type reviewRelatedWork struct {
+// relatedWork holds dependency graph and sibling task context for autopilot and reviewer agents.
+type relatedWork struct {
 	// depGraph is the raw JSON dependency graph (issue→[deps]) from autopilot_dep_graphs.
 	depGraph string
 	// siblingTasks is the list of all autopilot tasks in the same project.
@@ -478,7 +505,7 @@ type reviewRelatedWork struct {
 // renderRelatedWork formats the dependency graph and sibling task statuses
 // into a "Related Work" section for the review prompt. Returns empty string
 // if no useful context is available.
-func renderRelatedWork(task *db.AutopilotTask, rw *reviewRelatedWork) string {
+func renderRelatedWork(task *db.AutopilotTask, rw *relatedWork) string {
 	if rw == nil {
 		return ""
 	}
@@ -565,7 +592,7 @@ func detectTestCommand(repoDir string) string {
 // renderReviewTaskContext builds a prompt with review-specific context for the reviewer agent.
 // It provides the PR number, issue details, project goal, test command, dependency graph,
 // sibling task statuses, and commands for the review workflow.
-func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal, testCommand string, rw *reviewRelatedWork) string {
+func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal, testCommand string, rw *relatedWork) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "## Review Context\n\n")
@@ -608,7 +635,7 @@ func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, pr
 }
 
 // buildReviewClaudeArgs constructs the CLI arguments for launching a reviewer agent.
-func buildReviewClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *reviewRelatedWork) []string {
+func buildReviewClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork) []string {
 	prompt := renderReviewTaskContext(task, baseBranch, owner, repo, projectGoal, testCommand, rw)
 	return []string{
 		"--agent", "reviewer",

--- a/internal/autopilot/prompt_test.go
+++ b/internal/autopilot/prompt_test.go
@@ -101,7 +101,7 @@ func TestRenderTaskContext(t *testing.T) {
 		Branch:       "agent/issue-42",
 	}
 
-	ctx := renderTaskContext(task, "main", "myorg", "myrepo")
+	ctx := renderTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil)
 
 	checks := []string{
 		"#42",
@@ -120,12 +120,20 @@ func TestRenderTaskContext(t *testing.T) {
 		"--add-label \"blocked\"",
 		"--remove-label \"in-progress\"",
 		"-R myorg/myrepo",
+		"go test ./...",
+		"## Test command",
 	}
 
 	for _, check := range checks {
 		if !strings.Contains(ctx, check) {
 			t.Errorf("task context missing expected content: %q", check)
 		}
+	}
+
+	// Empty test command should omit the section entirely.
+	ctxNoTest := renderTaskContext(task, "main", "myorg", "myrepo", "", nil)
+	if strings.Contains(ctxNoTest, "## Test command") {
+		t.Error("task context should omit test command section when empty")
 	}
 }
 
@@ -138,7 +146,7 @@ func TestRenderTaskContextEmptyBody(t *testing.T) {
 		Branch:       "agent/issue-1",
 	}
 
-	ctx := renderTaskContext(task, "main", "owner", "repo")
+	ctx := renderTaskContext(task, "main", "owner", "repo", "", nil)
 
 	if strings.Contains(ctx, "\n\n\n\n") {
 		t.Error("task context has excessive blank lines when body is empty")
@@ -157,7 +165,7 @@ func TestRenderTaskContextNoBehavioralInstructions(t *testing.T) {
 		Branch:       "agent/issue-42",
 	}
 
-	ctx := renderTaskContext(task, "main", "org", "repo")
+	ctx := renderTaskContext(task, "main", "org", "repo", "", nil)
 
 	// Task context must NOT contain behavioral instructions — those belong in the agent definition.
 	behavioral := []string{
@@ -295,7 +303,7 @@ func TestBuildClaudeArgs(t *testing.T) {
 
 	t.Run("always uses --agent autopilot", func(t *testing.T) {
 		tools := []string{"Read", "Edit", "Write", "Bash(git *)"}
-		args := buildClaudeArgs(task, "main", "org", "repo", 50, 3.00, tools)
+		args := buildClaudeArgs(task, "main", "org", "repo", "go test ./...", 50, 3.00, tools, nil)
 
 		// Should always use --agent autopilot as first args.
 		if args[0] != "--agent" || args[1] != "autopilot" {
@@ -346,7 +354,7 @@ func TestBuildClaudeArgs(t *testing.T) {
 	})
 
 	t.Run("includes max turns and budget", func(t *testing.T) {
-		args := buildClaudeArgs(task, "main", "org", "repo", 75, 5.50, defaultAllowedTools)
+		args := buildClaudeArgs(task, "main", "org", "repo", "", 75, 5.50, defaultAllowedTools, nil)
 		joined := strings.Join(args, " ")
 
 		if !strings.Contains(joined, "--max-turns 75") {
@@ -721,7 +729,7 @@ func TestRenderResumeTaskContext(t *testing.T) {
 		FailureDetail: "used 50 of 50 turns",
 	}
 
-	prompt := renderResumeTaskContext(task, "main", "myorg", "myrepo")
+	prompt := renderResumeTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil)
 
 	// Should contain resume header.
 	if !strings.Contains(prompt, "Resuming Previous Work") {
@@ -760,7 +768,7 @@ func TestRenderResumeTaskContextNoFailure(t *testing.T) {
 		Branch:       "agent/issue-10",
 	}
 
-	prompt := renderResumeTaskContext(task, "main", "org", "repo")
+	prompt := renderResumeTaskContext(task, "main", "org", "repo", "", nil)
 
 	if !strings.Contains(prompt, "Resuming Previous Work") {
 		t.Error("should contain resume header")
@@ -787,7 +795,7 @@ func TestBuildResumeClaudeArgs(t *testing.T) {
 		FailureDetail: "spent $3.00 of $3.00 budget",
 	}
 
-	args := buildResumeClaudeArgs(task, "main", "org", "repo", 50, 3.00, defaultAllowedTools)
+	args := buildResumeClaudeArgs(task, "main", "org", "repo", "go test ./...", 50, 3.00, defaultAllowedTools, nil)
 	joined := strings.Join(args, " ")
 
 	// Should use --agent autopilot.
@@ -1004,14 +1012,14 @@ func TestRenderRelatedWork(t *testing.T) {
 	})
 
 	t.Run("empty struct returns empty", func(t *testing.T) {
-		rw := &reviewRelatedWork{}
+		rw := &relatedWork{}
 		if got := renderRelatedWork(task, rw); got != "" {
 			t.Errorf("expected empty, got %q", got)
 		}
 	})
 
 	t.Run("dep graph only", func(t *testing.T) {
-		rw := &reviewRelatedWork{
+		rw := &relatedWork{
 			depGraph: `{"42":[],"38":[42]}`,
 		}
 		got := renderRelatedWork(task, rw)
@@ -1027,7 +1035,7 @@ func TestRenderRelatedWork(t *testing.T) {
 	})
 
 	t.Run("sibling tasks only", func(t *testing.T) {
-		rw := &reviewRelatedWork{
+		rw := &relatedWork{
 			siblingTasks: []db.AutopilotTask{
 				{IssueNumber: 42, IssueTitle: "Current task", Status: "reviewing"},
 				{IssueNumber: 38, IssueTitle: "Dependency task", Status: "done", PRNumber: 50},
@@ -1057,7 +1065,7 @@ func TestRenderRelatedWork(t *testing.T) {
 	})
 
 	t.Run("both dep graph and tasks", func(t *testing.T) {
-		rw := &reviewRelatedWork{
+		rw := &relatedWork{
 			depGraph: `{"42":[],"38":[42]}`,
 			siblingTasks: []db.AutopilotTask{
 				{IssueNumber: 38, IssueTitle: "Other", Status: "queued"},
@@ -1083,7 +1091,7 @@ func TestRenderReviewTaskContextWithRelatedWork(t *testing.T) {
 		PRNumber:     99,
 	}
 
-	rw := &reviewRelatedWork{
+	rw := &relatedWork{
 		depGraph: `{"42":[]}`,
 		siblingTasks: []db.AutopilotTask{
 			{IssueNumber: 10, IssueTitle: "Setup DB", Status: "done", PRNumber: 20},
@@ -1140,7 +1148,7 @@ func TestPrintPrompts(t *testing.T) {
 	fmt.Println(renderPrompt(task, "main", "myorg", "myrepo"))
 
 	fmt.Printf("\n%s\n  TASK CONTEXT (used with --agent autopilot)\n%s\n\n", sep, sep)
-	fmt.Println(renderTaskContext(task, "main", "myorg", "myrepo"))
+	fmt.Println(renderTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil))
 
 	fmt.Printf("\n%s\n  BUILT-IN DEFAULT AGENT DEFINITION\n%s\n\n", sep, sep)
 	fmt.Print(defaultAgentDef)

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -2233,11 +2233,28 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 		}
 	}
 
+	testCommand := resolveTestCommand(s.repoDir)
+
+	// Load dependency graph and sibling task statuses so the agent
+	// understands where its issue fits in the broader work.
+	var rw *relatedWork
+	dg, dgErr := s.store.GetDepGraph(s.project.ID)
+	siblings, sibErr := s.store.GetAutopilotTasks(s.project.ID)
+	if dgErr == nil || sibErr == nil {
+		rw = &relatedWork{}
+		if dgErr == nil && dg != nil {
+			rw.depGraph = dg.GraphJSON
+		}
+		if sibErr == nil {
+			rw.siblingTasks = siblings
+		}
+	}
+
 	var args []string
 	if isResume {
-		args = buildResumeClaudeArgs(task, baseBranch, s.owner, s.repo, maxTurns, maxBudget, allowedTools)
+		args = buildResumeClaudeArgs(task, baseBranch, s.owner, s.repo, testCommand, maxTurns, maxBudget, allowedTools, rw)
 	} else {
-		args = buildClaudeArgs(task, baseBranch, s.owner, s.repo, maxTurns, maxBudget, allowedTools)
+		args = buildClaudeArgs(task, baseBranch, s.owner, s.repo, testCommand, maxTurns, maxBudget, allowedTools, rw)
 	}
 
 	debugStep := "launch"
@@ -2568,11 +2585,11 @@ func (s *Supervisor) runReviewAgent(ctx context.Context, slotIdx int, task *db.A
 	testCommand := resolveTestCommand(s.repoDir)
 
 	// Load dependency graph and sibling task statuses for review context.
-	var rw *reviewRelatedWork
+	var rw *relatedWork
 	dg, err := s.store.GetDepGraph(s.project.ID)
 	tasks, taskErr := s.store.GetAutopilotTasks(s.project.ID)
 	if err == nil || taskErr == nil {
-		rw = &reviewRelatedWork{}
+		rw = &relatedWork{}
 		if err == nil && dg != nil {
 			rw.depGraph = dg.GraphJSON
 		}
@@ -2964,8 +2981,8 @@ var userHomeDir = os.UserHomeDir
 // Instead of --dangerously-skip-permissions, each tool from allowedTools is
 // passed as a separate --allowedTools flag, giving the agent least-privilege
 // access scoped to the tools it actually needs.
-func buildClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo string, maxTurns int, maxBudget float64, allowedTools []string) []string {
-	prompt := renderTaskContext(task, baseBranch, owner, repo)
+func buildClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork) []string {
+	prompt := renderTaskContext(task, baseBranch, owner, repo, testCommand, rw)
 	return []string{
 		"--agent", "autopilot",
 		"-p",
@@ -2980,8 +2997,8 @@ func buildClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo string, max
 
 // buildResumeClaudeArgs constructs the argument list for resuming a claude agent
 // in an existing worktree. Uses a continuation prompt instead of a fresh start prompt.
-func buildResumeClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo string, maxTurns int, maxBudget float64, allowedTools []string) []string {
-	prompt := renderResumeTaskContext(task, baseBranch, owner, repo)
+func buildResumeClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork) []string {
+	prompt := renderResumeTaskContext(task, baseBranch, owner, repo, testCommand, rw)
 	return []string{
 		"--agent", "autopilot",
 		"-p",


### PR DESCRIPTION
## Summary

- **Implementation quality section**: Adds self-review guidelines to the autopilot agent definition targeting recurring review issues — duplicated logic, missing happy-path tests, incorrect side-effect ordering, and sparse commit messages
- **Dynamic test command**: Replaces hardcoded `go test ./...` in the agent def with `resolveTestCommand()` injected via task context (same pattern the reviewer already uses), making autopilot work correctly for non-Go repos
- **Dependency graph + sibling tasks**: Injects the dep graph and sibling task statuses into autopilot task context so agents understand where their issue fits in the broader work. Renames `reviewRelatedWork` → `relatedWork` since both agent types now share it

## Test plan

- [x] All existing tests pass with updated signatures
- [x] New test coverage for test command injection (present when set, omitted when empty)
- [x] `TestDefaultAgentDefMatchesRepoFile` confirms embedded constant matches `agents/autopilot.md`
- [ ] Verify autopilot agents receive dep graph and test command in next autopilot run

🤖 Generated with [Claude Code](https://claude.com/claude-code)