### PR TITLE
Fix RestartTask failing when old worktree persists

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -357,7 +357,20 @@ func (s *Supervisor) RestartTask(ctx context.Context, taskID int64) error {
 
 	// Clean up worktree and branch from the previous attempt.
 	if task.WorktreePath != "" {
-		_ = gitpkg.WorktreeRemove(s.repoDir, task.WorktreePath)
+		if err := gitpkg.WorktreeRemove(s.repoDir, task.WorktreePath); err != nil {
+			// git worktree remove can fail if the worktree is in a bad state
+			// (e.g., agent bailed early). Fall back to removing the directory
+			// and pruning stale worktree bookkeeping.
+			if rmErr := os.RemoveAll(task.WorktreePath); rmErr != nil {
+				return fmt.Errorf("failed to clean up worktree at %s (git remove: %v, rm: %v)", task.WorktreePath, err, rmErr)
+			}
+			_ = gitpkg.WorktreePrune(s.repoDir)
+		}
+		// Final sanity check: if the directory still exists, don't re-queue — the
+		// agent will just fail immediately at worktree creation.
+		if _, statErr := os.Stat(task.WorktreePath); statErr == nil {
+			return fmt.Errorf("worktree directory %s still exists after cleanup — remove it manually and retry", task.WorktreePath)
+		}
 	}
 	if task.Branch != "" {
 		_ = gitpkg.DeleteBranch(s.repoDir, task.Branch)


### PR DESCRIPTION
## Summary
- When restarting a bailed task, `git worktree remove` can fail if the worktree is in a bad state (agent bailed early). Previously the error was silently ignored, causing the re-queued task to immediately bail again at worktree creation.
- Now falls back to `os.RemoveAll` + `git worktree prune`, with a final `os.Stat` sanity check. Returns descriptive errors if cleanup fails instead of letting the task silently bail again.

## Test plan
- [x] Existing `TestRestartTask_*` tests pass
- [ ] Manual: bail a task, verify restart works without manually removing the worktree directory
- [ ] Manual: simulate stuck worktree (e.g., permission-denied directory), verify error message surfaces in TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)