### PR TITLE
Add manual task spin-off, reviewed task restore, and README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-minder
 
-A Go CLI tool that coordinates AI agents working across multiple repositories. It monitors git activity, watches the [agent-msg](https://github.com/aptx-health/agent-msg) message bus, tracks GitHub issues/PRs, and uses a two-tier LLM pipeline to analyze changes and keep agents informed.
+A Go CLI tool that coordinates AI agents working across multiple repositories. It monitors git activity, watches the [agent-msg](https://github.com/aptx-health/agent-msg) message bus, tracks GitHub issues/PRs, and uses Claude Code CLI for LLM analysis to keep agents informed and dispatch automated work.
 
 Built as a coordination layer on top of agent-msg's simple bash scripts + SQLite foundation.
 
@@ -10,60 +10,54 @@ Built as a coordination layer on top of agent-msg's simple bash scripts + SQLite
 agent-minder start <project>
 ```
 
-Launches a TUI dashboard that:
-
-1. **Polls** git repos and the agent-msg bus on a configurable interval
-2. **Tier 1 (Haiku)** — Cheap/fast summarizer. Digests raw git commits + bus messages into a terse summary
-3. **Tier 2 (Sonnet)** — Rich analyzer. Produces structured JSON with actionable insights, flags concerns, and optionally publishes messages back to the bus when coordination is needed
-4. **Sweeps** tracked GitHub issues/PRs for status changes, runs per-item Haiku summaries on changed items
-5. **Displays** everything in a real-time terminal dashboard with event log, active concerns, tracked items, and poll results
+Launches a TUI dashboard with three tabs:
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│ agent-minder: myproject  RUNNING  [dark]                │
-│   feature — Building the new auth system                │
-│                                                         │
-│ Repos                                                   │
-│   app (/Users/me/repos/myproject-app)                   │
-│   infra (/Users/me/repos/myproject-infra)               │
-│                                                         │
-│ Topics                                                  │
-│   myproject/app                                         │
-│   myproject/infra                                       │
-│   myproject/coord                                       │
-│                                                         │
-│ Tracked Items (3)                                       │
-│   #42 [Open]  Add auth middleware          repo/app     │
-│   #18 [Mrgd]  Fix DB connection pool       repo/infra  │
-│   #7  [Revw]  Update API docs              repo/app    │
-│                                                         │
-│ Active Concerns (2)                                     │
-│   [WARN] Schema changed in app but infra queries ...    │
-│   [INFO] feature/auth branch stale for 3 days           │
-│                                                         │
-│ Last Poll  [e: expand]                                  │
-│   3 commits, 1 message (took 4.2s)                      │
-│   App and infra both active. Schema migration in app... │
-│                                                         │
-│ Event Log                                               │
-│   [14:32:05] poll: 3 new commits, 1 new message         │
-│   [14:27:01] poll: No new activity                      │
-│                                                         │
-│ ?: help • p: pause • r: poll • e: expand • i: items •   │
-│ f: filter • m: broadcast • u: user msg • o: onboard •   │
-│ t: theme • q: quit                                      │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│ agent-minder: myproject  RUNNING  [dark]                      │
+│ [1 Operations]  [2 Analysis]  [3 Autopilot]                  │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│ Tracked Items (3)                                             │
+│   #42 [Open]  Add auth middleware          repo/app           │
+│   #18 [Mrgd]  Fix DB connection pool       repo/infra         │
+│   #7  [Revw]  Update API docs              repo/app           │
+│                                                               │
+│ Worktrees                                                     │
+│   app (/Users/me/repos/myproject-app)                         │
+│   infra (/Users/me/repos/myproject-infra)                     │
+│                                                               │
+│ Event Log                                                     │
+│   [14:32:05] poll: 3 new commits, 1 new message               │
+│   [14:27:01] poll: No new activity                            │
+│                                                               │
+│ ?: help  p: pause  r: sync  s: settings  t: theme  q: quit   │
+└──────────────────────────────────────────────────────────────┘
 ```
+
+### Tab 1: Operations
+
+Tracked items, worktree status, and event log. Press `r` to trigger a sync (gather git/bus data without LLM analysis). Track and untrack GitHub issues/PRs with `i`/`I`.
+
+### Tab 2: Analysis
+
+LLM analysis of project activity. Press `r` to run a full analysis cycle. The analyzer receives git commits, bus messages, tracked item changes, and project context, then produces a markdown summary with concerns and optional bus messages. Press `e` to expand/collapse the analysis view.
+
+- `u` — User message: query the analyzer directly
+- `m` — Broadcast: LLM crafts and publishes a coordination message
+- `o` — Onboard: generate an onboarding message for new agents
+
+### Tab 3: Autopilot
+
+Automated agent management. Press `a` to launch autopilot, which converts tracked GitHub issues into a task queue, builds a dependency graph, and dispatches concurrent Claude Code agents to work on unblocked issues in isolated git worktrees.
 
 ## Supported platforms
 
-| OS | Architecture | Status | Notes |
-|----|-------------|--------|-------|
-| macOS | amd64 (Intel) | Supported | Primary development platform |
-| macOS | arm64 (Apple Silicon) | Supported | Primary development platform |
-| Linux | amd64 | Supported | Tested on Ubuntu, Fedora |
-| Linux | arm64 | Supported | |
-| Windows | amd64 | Supported | Native or WSL2 |
+| OS | Architecture | Status |
+|----|-------------|--------|
+| macOS | amd64 / arm64 | Supported (primary) |
+| Linux | amd64 / arm64 | Supported |
+| Windows | amd64 | Supported (native or WSL2) |
 
 ## Prerequisites
 
@@ -71,68 +65,35 @@ Launches a TUI dashboard that:
 
 | Dependency | Min version | Purpose | Install |
 |-----------|-------------|---------|---------|
-| **Go** | 1.25+ | Build from source (bubbletea v2 requires 1.25+) | [go.dev/dl](https://go.dev/dl/) |
-| **git** | 2.x | Repository monitoring, worktree management | Package manager or [git-scm.com](https://git-scm.com/) |
-| **`ANTHROPIC_API_KEY`** | — | LLM pipeline (tier 1 + tier 2 analysis) | [console.anthropic.com](https://console.anthropic.com/) |
+| **Go** | 1.25+ | Build from source (bubbletea v2) | [go.dev/dl](https://go.dev/dl/) |
+| **git** | 2.x | Repository monitoring, worktree management | [git-scm.com](https://git-scm.com/) |
+| **[claude](https://docs.anthropic.com/en/docs/claude-code)** (Claude Code CLI) | Latest | All LLM calls (`claude -p`), autopilot agents | [docs.anthropic.com](https://docs.anthropic.com/en/docs/claude-code) |
+
+No API keys are needed — the Claude Code CLI handles authentication.
 
 ### Required for specific features
 
 | Dependency | Feature | What happens if missing |
 |-----------|---------|------------------------|
-| **`GITHUB_TOKEN`** or **`GH_TOKEN`** | Tracked items (issue/PR sweep), autopilot | `track`/`untrack` commands and the sweep pipeline are unavailable. Autopilot refuses to start with an error message. Token can also be stored in the OS keychain via `agent-minder setup`. |
-| **[gh](https://cli.github.com/)** (GitHub CLI) | Autopilot agent operations | Autopilot agents use `gh` to interact with GitHub (create PRs, post comments, manage labels). Without it, agents will fail. Not needed for non-autopilot usage. |
-| **[claude](https://docs.anthropic.com/en/docs/claude-code)** (Claude Code CLI) | Autopilot, LLM-assisted init | Autopilot dispatches work via `claude -p`. The `init` command can optionally use Claude Code for repo onboarding. Without it, autopilot cannot run and init skips the onboarding step. |
+| **`GITHUB_TOKEN`** or **`GH_TOKEN`** | Tracked items (issue/PR sweep), autopilot | `track`/`untrack` and the sweep pipeline are unavailable. Autopilot refuses to start. Token can be stored in the OS keychain via `agent-minder setup`. |
+| **[gh](https://cli.github.com/)** (GitHub CLI) | Autopilot agent operations | Agents use `gh` to create PRs, post comments, manage labels. Not needed for non-autopilot usage. |
 
 ### Optional
 
 | Dependency | Feature | What happens if missing |
 |-----------|---------|------------------------|
-| **[agent-msg](https://github.com/aptx-health/agent-msg)** | Inter-agent message bus | Bus features (broadcast, onboard, user messages) are unavailable. A warning is logged at startup. Polling, git monitoring, and GitHub sweeps continue normally. |
-| **jq** | Debug log viewing | `tail -f` log viewing works without it, but structured output (`jq` piping) is unavailable. |
-| **lnav** | Color-coded debug log viewer | Optional — `tail -f` works as a simpler alternative. |
+| **[agent-msg](https://github.com/aptx-health/agent-msg)** | Inter-agent message bus | Bus features (broadcast, onboard, user messages) are unavailable. Polling, git monitoring, and GitHub sweeps continue normally. |
+| **jq** / **lnav** | Debug log viewing | Structured log output and color-coded log viewing. `tail -f` works as a simpler alternative. |
 
-### OS keychain (go-keyring)
+### OS keychain
 
-agent-minder uses [go-keyring](https://github.com/zalando/go-keyring) to store API keys and tokens securely in the OS-native keychain. The keychain is **optional** — if unavailable, credentials fall back to the config file or environment variables.
+agent-minder uses [go-keyring](https://github.com/zalando/go-keyring) to store tokens securely in the OS-native keychain. The keychain is **optional** — if unavailable, credentials fall back to the config file or environment variables.
 
-| Platform | Backend | System requirement |
-|----------|---------|-------------------|
-| **macOS** | Keychain (Security framework) | None — built-in |
-| **Linux** | Secret Service API (via D-Bus) | Requires a running D-Bus session and a secret service provider (e.g., `gnome-keyring`, `kwallet`). The daemon must be running, not just installed — start it with `gnome-keyring-daemon --start --components=secrets` or ensure your desktop session launches it automatically. Install: `sudo apt install gnome-keyring dbus-x11` (Ubuntu/Debian) or `sudo dnf install gnome-keyring` (Fedora). Headless servers and minimal containers typically lack these — the keychain will be unavailable but agent-minder works fine without it. |
-| **Windows** | Windows Credential Manager (WinCred) | None — built-in |
-| **WSL2** | Secret Service API (via D-Bus) | Same as Linux. Some WSL2 distros ship without D-Bus — install as above. |
-
-**Graceful degradation:** On startup, `agent-minder setup` probes the keychain with a test write/delete. If the probe fails, credentials are stored in the config file (`~/.agent-minder/config.yaml`) instead. A warning is printed when a keychain write fails:
-
-```
-Warning: keychain write failed: <error> — falling back to config file
-```
-
-### Platform-specific notes
-
-**Ubuntu / Debian:**
-```bash
-# Keychain support (optional)
-sudo apt install gnome-keyring dbus-x11
-
-# If running headless (SSH, containers), start a D-Bus session:
-eval $(dbus-launch --sh-syntax)
-```
-
-**Fedora:**
-```bash
-# Keychain support (optional)
-sudo dnf install gnome-keyring
-```
-
-**macOS:**
-No additional system dependencies. Keychain, git, and all required frameworks are built-in.
-
-**Windows (native):**
-Windows Credential Manager is built-in. Install git from [git-scm.com](https://git-scm.com/). The TUI requires a terminal emulator with ANSI support (Windows Terminal, ConEmu, or similar).
-
-**WSL2:**
-Behaves like Linux. Install dependencies via your distro's package manager. Note that `pbcopy` (used for clipboard operations in the TUI) is macOS-only — clipboard features are unavailable on Linux/WSL2.
+| Platform | Backend | Notes |
+|----------|---------|-------|
+| macOS | Keychain (Security framework) | Built-in |
+| Linux | Secret Service API (D-Bus) | Requires `gnome-keyring` or `kwallet` |
+| Windows | Windows Credential Manager | Built-in |
 
 ## Installation
 
@@ -144,39 +105,15 @@ go install github.com/dustinlange/agent-minder@latest
 
 ### `agent-minder init <repo-dir> [repo-dir ...]`
 
-Interactive wizard that bootstraps a new project:
-- Scans repos for git info and worktrees
-- Derives a project name from directory names
-- Selects a goal type (feature, bugfix, infrastructure, maintenance, standby)
-- Suggests message bus topics (`<project>/app`, `<project>/coord`, etc.)
-- Configures poll interval, LLM models, and writes everything to SQLite
+Interactive wizard that bootstraps a new project: scans repos, derives a project name, selects a goal type, suggests bus topics, configures poll interval and LLM models, and writes everything to SQLite.
 
 ### `agent-minder start <project>` / `resume <project>`
 
-Launches the TUI dashboard + polling loop. Key bindings:
-
-| Key | Action |
-|-----|--------|
-| `?` | Show help overlay |
-| `p` | Pause/resume polling |
-| `r` | Trigger immediate poll |
-| `e` | Expand/collapse poll result |
-| `i` | Toggle tracked items panel |
-| `I` | Bulk track — add issues/PRs across repos |
-| `w` | Bulk untrack — remove tracked items |
-| `d` | Cleanup — remove terminal (merged/closed) items |
-| `f` | Filter events by keyword |
-| `u` | User message — post a raw message to a topic |
-| `m` | Broadcast mode — type a message for the LLM to craft and publish to the bus |
-| `o` | Onboard mode — generate an onboarding message for new agents |
-| `a` | Launch autopilot — assign agents to tracked GitHub issues |
-| `A` | Stop autopilot (with confirmation) |
-| `t` | Cycle theme (dark/light) |
-| `q` | Quit |
+Launches the TUI dashboard + polling loop.
 
 ### `agent-minder status <project>`
 
-Quick CLI summary from SQLite — no LLM call. Shows repos, concerns, and last poll result.
+Quick CLI summary from SQLite — no LLM call.
 
 ### `agent-minder list`
 
@@ -186,167 +123,284 @@ List all configured projects.
 
 Add a repo to an existing project.
 
-### `agent-minder track <project> <owner/repo> <number> [number ...]`
+### `agent-minder repo enroll` / `repo status` / `repo refresh`
 
-Track GitHub issues or PRs. The sweep pipeline will monitor their status each poll cycle.
+Guided repo enrollment wizard with onboarding file generation, enrollment status checks, and re-scanning.
 
-### `agent-minder untrack <project> <owner/repo> <number> [number ...]`
+### `agent-minder track <project> <owner/repo> <number> [...]`
+
+Track GitHub issues or PRs for monitoring.
+
+### `agent-minder untrack <project> <owner/repo> <number> [...]`
 
 Stop tracking GitHub issues or PRs.
 
-### `agent-minder setup <project>`
+### `agent-minder setup`
 
-Re-run project configuration (goal, poll interval, LLM models, etc.).
+Configure credentials and integrations (GitHub token via keychain or config file).
 
 ### `agent-minder delete <project>`
 
 Delete a project and all its associated data.
 
+### `agent-minder deploy [issue#] [...]`
+
+Launch agents on specific GitHub issues as a background daemon. Infers repo from the current working directory.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--max-agents N` | min(issues, 5) | Max concurrent agents |
+| `--max-turns N` | 50 | Max turns per agent |
+| `--max-budget USD` | 3.00 | Budget per agent |
+| `--dry-run` | — | Show plan without launching |
+| `--project NAME` | — | Inherit settings from existing project |
+| `--serve :PORT` | — | Enable HTTP API server |
+| `--remote HOST:PORT` | — | Query remote daemon |
+| `--api-key KEY` | — | API key for HTTP auth |
+
+**Subcommands:** `deploy list`, `deploy status <id>`, `deploy open <id>`, `deploy stop <id>`, `deploy respawn <id>`, `deploy watch <id>`
+
+### `agent-minder version`
+
+Show version information.
+
+## TUI keybindings
+
+### Global
+
+| Key | Action |
+|-----|--------|
+| `1` / `2` / `3` | Switch tabs |
+| `Tab` / `Shift+Tab` | Cycle tabs |
+| `s` | Open settings |
+| `t` | Cycle theme (dark/light) |
+| `p` | Pause/resume polling |
+| `?` | Toggle help overlay |
+| `d` | Dismiss warning banner |
+| `q` / `Ctrl+C` | Quit |
+
+### Operations tab
+
+| Key | Action |
+|-----|--------|
+| `r` | Sync now (gather git/bus data, no LLM) |
+| `i` | Track issues/PRs |
+| `I` | Untrack issues/PRs |
+| `x` | Expand/collapse tracked items |
+| `w` | Toggle worktree panel |
+| `f` | Filter events |
+
+### Analysis tab
+
+| Key | Action |
+|-----|--------|
+| `r` | Run full analysis |
+| `e` | Expand/collapse analysis |
+| `u` | User message (query analyzer) |
+| `m` | Broadcast (LLM-crafted message to bus) |
+| `o` | Onboard (generate onboarding message) |
+
+### Autopilot tab
+
+| Key | Action |
+|-----|--------|
+| `a` | Launch autopilot |
+| `A` | Stop all agents (with confirmation) |
+| `S` | Stop selected agent |
+| `r` | Context-dependent: restart (failed/bailed/stopped), review (review/reviewed), spin off (manual) |
+| `b` | Bump task resource limits (1.5x) |
+| `c` | Copy worktree path to clipboard |
+| `+` | Add agent slot |
+| `P` | Pause/resume slot filling |
+| `D` | Show dependency info for selected task |
+| `G` | Rebuild dependency graph |
+| `l` | View agent log |
+| `e` | Expand/collapse task list |
+| `i` | Toggle failure detail (on failed tasks) |
+
+### Settings (`s`)
+
+Configurable via the in-TUI settings dialog:
+
+| Setting | Description |
+|---------|-------------|
+| Sync interval | How often status checks run (minutes) |
+| Analyzer focus | Custom instructions for the analyzer's perspective |
+| Autopilot max agents | Max concurrent agents |
+| Autopilot max turns | Max turns per agent |
+| Autopilot max budget | Max budget per agent (USD) |
+| Autopilot skip label(s) | Comma-separated labels to exclude from autopilot |
+| Autopilot base branch | Base branch for worktrees/PRs (empty = auto-detect) |
+| Review max turns | Max turns per review agent (empty = reviews disabled) |
+| Review max budget | Max budget per review agent (USD) |
+| Auto-merge | Auto-merge low-risk PRs after review |
+
 ## Architecture
 
-### Two-tier LLM pipeline
+### LLM pipeline
 
-Each poll cycle with new activity runs two LLM calls:
+All LLM calls go through `internal/claudecli`, which wraps `claude -p --output-format json`. No API keys needed — Claude Code CLI handles authentication.
 
-- **Tier 1 (Haiku)** — Summarizes raw data (git commits, bus messages) into a concise factual summary. MaxTokens: 512.
-- **Tier 2 (Sonnet)** — Analyzes the summary + active concerns + tracked items + project context. Returns structured JSON with an analysis, optional concerns, and an optional bus message. MaxTokens: 1024.
+Each poll cycle with new activity runs a single analysis call. The analyzer receives git commits, bus messages, tracked item changes, and project context, then returns structured JSON:
 
-The tier 2 response is parsed for:
-- **Analysis** — Displayed in the TUI
-- **Concerns** — Managed via `reconcileConcerns()`: each cycle returns the full desired list, diffs against existing (adds new, resolves dropped, updates severity). Severities: `info`, `warning`, `danger`.
-- **Bus message** — Published to agent-msg if the analyzer determines coordination is needed
+```json
+{
+  "analysis": "status update text",
+  "concerns": [{"severity": "warning", "message": "..."}],
+  "bus_message": {"topic": "project/coord", "message": "..."}
+}
+```
+
+The analyzer uses persistent sessions — it resumes context from the previous poll rather than starting fresh each time. Model defaults to `sonnet` (configurable per project).
+
+Concerns are managed by the analyzer: each cycle returns the full desired list, `reconcileConcerns()` diffs against existing (adds new, resolves dropped, updates severity). Severities: `info`, `warning`, `danger`.
 
 ### GitHub item sweep
 
 Tracked items (issues/PRs) are swept each poll cycle:
-- Fetches current status from GitHub API (`go-github` client)
+- Fetches current status from GitHub API
 - Detects state changes (open → closed, draft → ready, review state changes)
-- Runs a per-item **Haiku** call to generate a progress summary when status changes
-- Archives completed items (merged/closed with a summary) to `completed_items` table
-- Status tags in TUI: Open, Closd, Mrgd, Draft, Revw, Blkd
+- Archives completed items to `completed_items` table
+- Status tags: Open, Closd, Mrgd, Draft, Revw, Blkd
 
 ### Bus integration
 
-The minder reads from and writes to the agent-msg SQLite database directly:
-- **`Client`** — Read-only connection (`?mode=ro`) for polling messages
-- **`Publisher`** — Read-write connection for publishing; supports `PublishReplace()` for single-message topics (e.g., onboarding)
-- Both use `sqliteutil.OpenWithRecovery()` to auto-detect and recover from stale WAL/SHM files
-- agent-msg's bash scripts (`agent-pub`, `agent-check`, `agent-ack`) remain fully compatible
-
-### Broadcast mode
-
-Press `m` in the TUI to enter broadcast mode. Type a prompt describing what you want to communicate, and the tier 2 model crafts a context-aware message using current project state, then publishes it to the coordination topic.
-
-### Onboard mode
-
-Press `o` to generate an onboarding message for new agents joining the project. Optionally provide guidance text. The tier 2 model generates a comprehensive onboarding message and publishes it to `<project>/onboarding` with replace semantics (only the latest onboarding message is kept).
+Reads from and writes to the agent-msg SQLite database:
+- **Client** — Read-only connection for polling messages
+- **Publisher** — Read-write connection; supports `PublishReplace()` for single-message topics
+- Both use `sqliteutil.OpenWithRecovery()` for stale WAL/SHM recovery
+- agent-msg bash scripts remain fully compatible
 
 ### Autopilot
 
-Press `a` to launch autopilot — minder converts tracked GitHub issues into a task queue, builds a dependency graph (one LLM call), and dispatches up to N concurrent Claude Code agents to work on unblocked issues in isolated git worktrees. Agents self-triage: they either complete the work and open a draft PR, or bail with a detailed comment explaining what they found.
+Press `a` to launch autopilot. The supervisor:
+1. Scans tracked GitHub issues, excluding those with skip labels (default: `no-agent`)
+2. Builds a dependency graph via one LLM call
+3. Dispatches up to N concurrent Claude Code agents to work on unblocked issues
+4. Each agent runs in an isolated git worktree
+5. Agents either open a draft PR or bail with a comment explaining what they found
+6. Supervisor monitors slots, refills as agents complete, discovers new issues
 
-**Minder is a work dispatcher, not a quality gate.** It generates the dependency graph and assigns work — the target repo's own tooling (pre-commit hooks, linters, test suites, CI/CD) is responsible for enforcing code quality. Repos should have a `CLAUDE.md` with project conventions and build/test commands so agents can work effectively.
+**Task lifecycle:**
 
-#### Skipping issues with GitHub labels
+```
+queued → running → review → done (PR merged)
+                 → bailed (agent gave up)
+                 → failed (error, can resume/restart)
+         blocked (waiting on dependencies)
+         manual  (human-driven, spin off worktree with r)
+         skipped (has exclusion label)
+```
 
-Issues can be excluded from autopilot by adding skip labels in GitHub. By default, issues labeled `no-agent` are skipped. You can configure one or more skip labels (comma-separated) via:
+**Review automation:**
+- When a task reaches `review`, supervisor checks every 30s if the PR was merged
+- Press `r` to launch a review session: restores worktree, pre-loads PR context
+- Review agents assess risk: `low-risk`, `needs-testing`, `suspect`
+- Optional auto-merge for low-risk PRs (configurable)
+- States: `review` → `reviewing` (agent active) → `reviewed` (assessment complete)
 
-- **Init wizard**: prompted during `agent-minder init`
-- **TUI settings**: press `s` → edit "Autopilot skip label(s)"
+**Manual tasks:**
+- Issues with skip/in-progress/needs-review/blocked labels become manual tasks
+- Press `r` to spin off a worktree with preloaded context (dep graph, issue details)
+- Branch convention: `manual/issue-<N>` (vs `agent/issue-<N>` for autopilot)
 
-For example, setting skip labels to `no-agent, manual, human-only` will exclude any tracked issue that carries any of those labels. The dependency graph also marks skipped issues so downstream tasks aren't blocked waiting on work that won't be automated.
+**Webhook notifications:**
+- Configure via project settings (webhook URL, format, event filter)
+- Supports Slack and generic JSON formats
+- Events: task.started, task.completed, task.bailed, task.failed, task.stopped, task.discovered, autopilot.finished
 
 #### Agent definition (optional)
 
-Autopilot supports an optional [Claude Code agent definition](https://docs.anthropic.com/en/docs/claude-code/sub-agents) that gives agents consistent behavioral guidance. **The agent definition is additive, never required** — it's a thin layer to make agent behaviors more predictable and customizable. Without it, autopilot works exactly as before using its built-in prompt.
-
-To use it, install `agents/autopilot.md` in a target repo or globally:
+Autopilot supports [Claude Code agent definitions](https://docs.anthropic.com/en/docs/claude-code/sub-agents) for consistent behavioral guidance. Install in a target repo or globally:
 
 ```bash
-# Per-repo (committed with the project)
+# Per-repo
 cp agents/autopilot.md <your-repo>/.claude/agents/autopilot.md
 
-# Or globally (applies to all repos)
+# Globally
 cp agents/autopilot.md ~/.claude/agents/autopilot.md
 ```
 
-When the supervisor detects the definition (project-level or user-level), it switches from a single monolithic prompt to `claude --agent autopilot -p "<task context>"` — the agent definition provides the behavioral instructions (workflow, constraints, bail conditions) and the prompt carries only the dynamic task context (issue number, paths, commands).
+Agent definitions are **additive, never required** — autopilot works without them using built-in prompts. See [agents/README.md](agents/README.md) for details.
 
-You can customize the definition per-repo to adjust complexity thresholds, add project-specific conventions, or modify the workflow. See [agents/README.md](agents/README.md) for details.
+#### Skipping issues with labels
 
-See [docs/automated-agents-design.md](docs/automated-agents-design.md) for the full design.
+Issues labeled with skip labels (default: `no-agent`) are excluded from autopilot. Configure one or more skip labels (comma-separated) via the TUI settings (`s`).
 
 ### Data storage
 
-All state lives in SQLite at `~/.agent-minder/minder.db` (WAL mode, foreign keys). Schema version: **v9**.
+All state in SQLite at `~/.agent-minder/minder.db` (WAL mode, foreign keys). Schema version: **v25**.
 
-- **projects** — Name, goal, LLM config, poll settings, idle pause
-- **repos** — Git repositories tracked per project (with optional summary)
-- **worktrees** — Git worktrees per repo
-- **topics** — Message bus topics to monitor
-- **concerns** — Active/resolved issues the minder tracks
-- **polls** — Full history of poll results with tier 1/tier 2 responses
-- **tracked_items** — GitHub issues/PRs being monitored (with content hash, progress summary, draft/review state)
-- **completed_items** — Archived from tracked_items when they reach terminal state
-- **autopilot_tasks** — Issue work queue for autopilot (status, dependencies, worktree path, PR number)
+Key tables:
+
+| Table | Purpose |
+|-------|---------|
+| projects | Name, goal, LLM config, poll settings, autopilot config, webhook config |
+| repos / worktrees | Git repositories and worktrees per project |
+| topics | Message bus topics to monitor |
+| concerns | Active/resolved alerts (severity: info/warning/danger) |
+| polls | Poll history with analysis responses |
+| tracked_items | GitHub issues/PRs with content hash, summaries, draft/review state |
+| completed_items | Archived terminal items |
+| autopilot_tasks | Issue work queue (status, deps, worktree, PR, cost, review risk) |
+| autopilot_dep_graphs | Persisted dependency graphs |
 
 ## Project structure
 
 ```
 agent-minder/
 ├── agents/
-│   └── autopilot.md    # Claude Code agent definition template for autopilot
-├── cmd/
-│   ├── root.go          # Cobra root command
-│   ├── init.go          # Interactive setup wizard
-│   ├── start.go         # TUI + poller launch
-│   ├── status.go        # CLI status summary
-│   ├── list.go          # List projects
-│   ├── enroll.go        # Add repo to project
-│   ├── track.go         # Track GitHub issues/PRs
-│   ├── untrack.go       # Untrack GitHub issues/PRs
-│   ├── setup.go         # Reconfigure project
-│   ├── delete.go        # Delete project
-│   ├── pause.go         # Pause hint
-│   └── resume.go        # Alias for start
+│   ├── autopilot.md       # Agent definition for implementation
+│   ├── reviewer.md        # Agent definition for PR review
+│   └── onboarding.md      # Agent definition for onboarding
+├── cmd/                    # Cobra commands
+│   ├── init.go, start.go, status.go, list.go
+│   ├── enroll.go, track.go, untrack.go
+│   ├── setup.go, delete.go, repo.go
+│   ├── deploy.go, deploy_*.go
+│   └── version.go
 ├── internal/
-│   ├── autopilot/       # Autopilot supervisor, agent prompt, slot management
-│   ├── db/              # SQLite schema, migrations (v1→v9), CRUD
-│   ├── llm/             # Provider interface (Anthropic + OpenAI-compatible)
-│   ├── poller/          # Two-tier poll loop, analysis parsing, item sweep
-│   ├── tui/             # Bubbletea v2 dashboard (app, styles, layout, filter)
-│   ├── git/             # Git CLI wrappers (log, branches, worktrees)
-│   ├── github/          # GitHub API client (go-github), issue/PR status fetching
-│   ├── discovery/       # Repo scanning, project name derivation
-│   ├── sqliteutil/      # SQLite health + WAL recovery
-│   ├── msgbus/          # Agent-msg SQLite client (read) + publisher (write)
-│   └── secrets/         # Secret detection and filtering
+│   ├── api/                # Remote daemon HTTP API (client + server)
+│   ├── autopilot/          # Supervisor, prompt generation, agent lifecycle
+│   ├── claudecli/          # Claude Code CLI wrapper (claude -p)
+│   ├── config/             # Viper config + keychain credential management
+│   ├── db/                 # SQLite schema (v25), migrations, CRUD
+│   ├── deploy/             # Deployment daemon paths and helpers
+│   ├── discovery/          # Repo scanning, project name derivation
+│   ├── git/                # Git CLI wrappers (log, branches, worktrees)
+│   ├── github/             # GitHub API client (go-github)
+│   ├── msgbus/             # Agent-msg client (read) + publisher (write)
+│   ├── notify/             # Webhook notifications (Slack + generic)
+│   ├── onboarding/         # Repo onboarding YAML (inventory, permissions)
+│   ├── poller/             # Poll loop, analysis parsing, item sweep
+│   ├── secrets/            # Keychain integration
+│   ├── sqliteutil/         # SQLite health + WAL recovery
+│   └── tui/                # Bubbletea v2 dashboard (3 tabs, settings, themes)
+├── docs/
+│   └── automated-agents-design.md
+├── scripts/
+│   └── test-env.sh         # Isolated test environment for worktrees
 ├── lnav/
-│   └── agent-minder.json  # lnav format file for debug log viewing
-├── go.mod
-├── go.sum
+│   └── agent-minder.json   # lnav format for debug logs
 └── main.go
 ```
 
 ## Dependencies
 
 - [bubbletea v2](https://charm.land/bubbletea) + [lipgloss v2](https://charm.land/lipgloss) + [bubbles v2](https://charm.land/bubbles) — TUI framework
-- [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go) + [openai-go](https://github.com/openai/openai-go) — LLM providers
 - [go-github](https://github.com/google/go-github) — GitHub API client
 - [sqlx](https://github.com/jmoiron/sqlx) + [modernc.org/sqlite](https://modernc.org/sqlite) — Database (pure Go, no CGo)
-- [cobra](https://github.com/spf13/cobra) — CLI framework
+- [cobra](https://github.com/spf13/cobra) + [viper](https://github.com/spf13/viper) — CLI + config
+- [go-keyring](https://github.com/zalando/go-keyring) — OS keychain integration
 
 ## Testing
 
 ```bash
 go test ./...                           # All unit tests
 go test ./internal/db/... -v            # DB + migration tests
-go test ./internal/poller/... -v        # Analysis parsing, concern dedup, sweep, tracked items
+go test ./internal/poller/... -v        # Analysis parsing, concern dedup, sweep
+go test ./internal/autopilot/... -v     # Autopilot supervisor, prompts, lifecycle
 go test ./internal/msgbus/... -v        # Client + publisher tests
-go test ./internal/github/... -v        # GitHub URL parsing + status tests
-
-# Integration test (requires ANTHROPIC_API_KEY + existing agent-test project):
-go test -tags integration -run TestIntegrationTwoTierPipeline -v ./internal/poller/ -timeout 90s
 ```
 
 ## Debug logging
@@ -362,13 +416,18 @@ lnav -i lnav/agent-minder.json   # one-time install
 lnav ~/.agent-minder/debug.log
 ```
 
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MINDER_DB` | `~/.agent-minder/minder.db` | Database path |
+| `MINDER_LOG` | `~/.agent-minder/debug.log` | Debug log path |
+| `MINDER_DEBUG` | (unset) | Enable structured JSON debug logging |
+| `AGENT_MSG_DB` | `~/repos/agent-msg/messages.db` | Agent-msg database path |
+| `GITHUB_TOKEN` / `GH_TOKEN` | (from keychain/config) | GitHub API token |
+
 ## agent-msg integration
 
-agent-msg is **optional**. Without it, agent-minder still monitors git repos, tracks GitHub items, runs the LLM pipeline, and displays everything in the TUI — you just won't have inter-agent messaging.
+agent-msg is **optional**. Without it, agent-minder still monitors git repos, tracks GitHub items, runs LLM analysis, manages autopilot — you just won't have inter-agent messaging.
 
-When agent-msg is available, agent-minder sits on top of its SQLite database:
-
-- **Reads**: Recent messages, unread messages, topic summaries, active agents
-- **Writes**: Publishes messages as `<project>/minder` identity when coordination is needed
-- **Compatible**: agent-msg's bash scripts (`agent-pub`, `agent-check`, `agent-ack`, `agent-topics`) continue working against the same database
-- **Graceful degradation**: If the agent-msg DB is missing at startup, a warning is logged and bus features are disabled. Polling, git monitoring, and GitHub sweeps continue normally.
+When available, agent-minder reads and writes to agent-msg's SQLite database. agent-msg bash scripts (`agent-pub`, `agent-check`, `agent-ack`, `agent-topics`) remain fully compatible.

--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -494,6 +494,25 @@ func renderResumeTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, te
 	return b.String()
 }
 
+// renderManualSessionPrompt builds a prompt for a manual work session.
+// Claude fetches the issue details, summarizes the work, then awaits user instructions.
+func renderManualSessionPrompt(task *db.AutopilotTask, owner, repo string, rw *relatedWork) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "You are starting a manual work session for issue #%d in %s/%s.\n\n", task.IssueNumber, owner, repo)
+	fmt.Fprintf(&b, "1. Run `gh issue view %d -R %s/%s` to fetch the full issue details\n", task.IssueNumber, owner, repo)
+	b.WriteString("2. Summarize the issue and what needs to be done\n")
+	b.WriteString("3. Then tell the user you're ready for their instructions\n\n")
+	fmt.Fprintf(&b, "Worktree: %s\n", task.WorktreePath)
+	fmt.Fprintf(&b, "Branch: %s\n\n", task.Branch)
+
+	if related := renderRelatedWork(task, rw); related != "" {
+		b.WriteString(related)
+	}
+
+	return b.String()
+}
+
 // relatedWork holds dependency graph and sibling task context for autopilot and reviewer agents.
 type relatedWork struct {
 	// depGraph is the raw JSON dependency graph (issue→[deps]) from autopilot_dep_graphs.

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -240,8 +240,8 @@ func (s *Supervisor) ReviewSession(ctx context.Context, taskID int64) (*ReviewSe
 	if task == nil {
 		return nil, fmt.Errorf("task %d not found", taskID)
 	}
-	if task.Status != "review" {
-		return nil, fmt.Errorf("task #%d has status %q — only review tasks can start a review session", task.IssueNumber, task.Status)
+	if task.Status != "review" && task.Status != "reviewed" {
+		return nil, fmt.Errorf("task #%d has status %q — only review/reviewed tasks can start a review session", task.IssueNumber, task.Status)
 	}
 	if task.PRNumber <= 0 {
 		return nil, fmt.Errorf("task #%d has no associated PR", task.IssueNumber)
@@ -330,6 +330,137 @@ func (s *Supervisor) ReviewSession(ctx context.Context, taskID int64) (*ReviewSe
 		WorktreePath: task.WorktreePath,
 		SessionID:    sessionID,
 		PRNumber:     task.PRNumber,
+		IssueNumber:  task.IssueNumber,
+	}, nil
+}
+
+// ManualSession creates a worktree for a manual task and launches a Claude session
+// pre-loaded with issue and dependency context. Returns the session ID so the user can resume it.
+func (s *Supervisor) ManualSession(ctx context.Context, taskID int64) (*ReviewSessionResult, error) {
+	tasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return nil, fmt.Errorf("get tasks: %w", err)
+	}
+
+	var task *db.AutopilotTask
+	for i := range tasks {
+		if tasks[i].ID == taskID {
+			task = &tasks[i]
+			break
+		}
+	}
+	if task == nil {
+		return nil, fmt.Errorf("task %d not found", taskID)
+	}
+	if task.Status != "manual" {
+		return nil, fmt.Errorf("task #%d has status %q — only manual tasks can start a manual session", task.IssueNumber, task.Status)
+	}
+
+	// Set up worktree path and branch.
+	home, _ := os.UserHomeDir()
+	worktreeBase := filepath.Join(home, ".agent-minder", "worktrees", s.project.Name)
+	worktreePath := filepath.Join(worktreeBase, fmt.Sprintf("issue-%d", task.IssueNumber))
+	branch := fmt.Sprintf("manual/issue-%d", task.IssueNumber)
+
+	// Determine base branch.
+	baseBranch := s.project.AutopilotBaseBranch
+	if baseBranch == "" {
+		baseBranch, _ = gitpkg.DefaultBranch(s.repoDir)
+	}
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+
+	// Create worktree if it doesn't exist yet.
+	if _, statErr := os.Stat(worktreePath); os.IsNotExist(statErr) {
+		s.gitSetupMu.Lock()
+		_ = gitpkg.Fetch(s.repoDir)
+		_ = gitpkg.DeleteBranch(s.repoDir, branch)
+		gitErr := gitpkg.WorktreeAdd(s.repoDir, worktreePath, branch, "origin/"+baseBranch)
+		s.gitSetupMu.Unlock()
+		if gitErr != nil {
+			return nil, fmt.Errorf("create worktree: %w", gitErr)
+		}
+	}
+
+	// Persist worktree info on the task (without changing status).
+	task.WorktreePath = worktreePath
+	task.Branch = branch
+	if err := s.store.UpdateAutopilotTaskWorktree(task.ID, worktreePath, branch); err != nil {
+		return nil, fmt.Errorf("update task worktree: %w", err)
+	}
+
+	// Build related work context.
+	var rw *relatedWork
+	dg, dgErr := s.store.GetDepGraph(s.project.ID)
+	siblings, sibErr := s.store.GetAutopilotTasks(s.project.ID)
+	if dgErr == nil || sibErr == nil {
+		rw = &relatedWork{}
+		if dgErr == nil && dg != nil {
+			rw.depGraph = dg.GraphJSON
+		}
+		if sibErr == nil {
+			rw.siblingTasks = siblings
+		}
+	}
+
+	// Build manual session prompt.
+	prompt := renderManualSessionPrompt(task, s.owner, s.repo, rw)
+
+	// Launch claude -p with stream-json so we can capture the session ID.
+	allowedTools := resolveAllowedTools(s.repoDir)
+	args := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--verbose",
+		"--max-turns", "3",
+		"--allowedTools", toCliAllowedTools(allowedTools),
+		"--", prompt,
+	}
+
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	cmd.Dir = worktreePath
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+s.ghToken)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start claude: %w", err)
+	}
+
+	// Parse stream-json output for session_id from the init event.
+	var sessionID string
+	scanner := json.NewDecoder(stdout)
+	for scanner.More() {
+		var raw json.RawMessage
+		if err := scanner.Decode(&raw); err != nil {
+			break
+		}
+		var initEvt struct {
+			Type      string `json:"type"`
+			Subtype   string `json:"subtype"`
+			SessionID string `json:"session_id"`
+		}
+		if json.Unmarshal(raw, &initEvt) == nil && initEvt.Type == "system" && initEvt.Subtype == "init" && initEvt.SessionID != "" {
+			sessionID = initEvt.SessionID
+		}
+	}
+
+	_ = cmd.Wait()
+
+	if sessionID == "" {
+		return &ReviewSessionResult{
+			WorktreePath: worktreePath,
+			IssueNumber:  task.IssueNumber,
+		}, nil
+	}
+
+	return &ReviewSessionResult{
+		WorktreePath: worktreePath,
+		SessionID:    sessionID,
 		IssueNumber:  task.IssueNumber,
 	}, nil
 }

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -826,6 +826,13 @@ func (s *Store) UpdateAutopilotTaskRunning(id int64, worktreePath, branch, agent
 	return err
 }
 
+// UpdateAutopilotTaskWorktree sets the worktree path and branch for a task without changing status.
+func (s *Store) UpdateAutopilotTaskWorktree(id int64, worktreePath, branch string) error {
+	_, err := s.db.Exec(`UPDATE autopilot_tasks SET worktree_path = ?, branch = ? WHERE id = ?`,
+		worktreePath, branch, id)
+	return err
+}
+
 // UpdateAutopilotTaskPR sets the PR number for a completed task.
 func (s *Store) UpdateAutopilotTaskPR(id int64, prNumber int) error {
 	_, err := s.db.Exec(`UPDATE autopilot_tasks SET pr_number = ? WHERE id = ?`, prNumber, id)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -237,7 +237,7 @@ type Model struct {
 
 	// Autopilot.
 	autopilotSupervisor       *autopilot.Supervisor
-	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "resume-or-restart-confirm", "review-confirm", "add-slot-confirm", "completed", "reprepare-choice"
+	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "resume-or-restart-confirm", "review-confirm", "manual-confirm", "add-slot-confirm", "completed", "reprepare-choice"
 	autopilotModeBeforeReview string // saved mode to restore on review-confirm cancel
 	autopilotPrepareResult    *autopilot.PrepareResult
 	autopilotStatus           string
@@ -1231,6 +1231,15 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	}
+	if m.autopilotMode == "manual-confirm" && m.activeTab == tabAutopilot {
+		switch msg.String() {
+		case "enter":
+			return m.launchManualSession()
+		case "esc":
+			m.autopilotMode = m.autopilotModeBeforeReview
+			return m, nil
+		}
+	}
 	if m.autopilotMode == "add-slot-confirm" && m.activeTab == tabAutopilot {
 		switch msg.String() {
 		case "enter":
@@ -1285,7 +1294,8 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// On tab 3 during autopilot, 'r' is task-contextual:
 		//   - failed/stopped → resume-or-restart (offer resume in existing worktree)
 		//   - bailed → restart (no useful work to resume)
-		//   - review → launch review session
+		//   - review/reviewed → launch review session
+		//   - manual → spin off worktree with preloaded context
 		if m.activeTab == tabAutopilot && (m.autopilotMode == "running" || m.autopilotMode == "completed") {
 			task := m.selectedAutopilotTask()
 			if task != nil && (task.Status == "failed" || task.Status == "stopped") {
@@ -1296,9 +1306,14 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.autopilotMode = "restart-confirm"
 				return m, nil
 			}
-			if task != nil && task.Status == "review" {
+			if task != nil && (task.Status == "review" || task.Status == "reviewed") {
 				m.autopilotModeBeforeReview = m.autopilotMode
 				m.autopilotMode = "review-confirm"
+				return m, nil
+			}
+			if task != nil && task.Status == "manual" {
+				m.autopilotModeBeforeReview = m.autopilotMode
+				m.autopilotMode = "manual-confirm"
 				return m, nil
 			}
 			return m, nil
@@ -2580,7 +2595,7 @@ func (m Model) confirmAddSlot() (tea.Model, tea.Cmd) {
 // launchReviewSession restores the worktree and launches a pre-warmed Claude session for review.
 func (m Model) launchReviewSession() (tea.Model, tea.Cmd) {
 	task := m.selectedAutopilotTask()
-	if task == nil || task.Status != "review" {
+	if task == nil || (task.Status != "review" && task.Status != "reviewed") {
 		m.autopilotMode = m.autopilotModeBeforeReview
 		return m, nil
 	}
@@ -2598,6 +2613,31 @@ func (m Model) launchReviewSession() (tea.Model, tea.Cmd) {
 
 	return m, func() tea.Msg {
 		result, err := sup.ReviewSession(context.Background(), taskID)
+		return reviewSessionResultMsg{result: result, err: err}
+	}
+}
+
+// launchManualSession creates a worktree and launches a pre-warmed Claude session for a manual task.
+func (m Model) launchManualSession() (tea.Model, tea.Cmd) {
+	task := m.selectedAutopilotTask()
+	if task == nil || task.Status != "manual" {
+		m.autopilotMode = m.autopilotModeBeforeReview
+		return m, nil
+	}
+
+	sup := m.autopilotSupervisor
+	if sup == nil {
+		m.autopilotMode = m.autopilotModeBeforeReview
+		return m, nil
+	}
+
+	taskID := task.ID
+	issueNum := task.IssueNumber
+	m.autopilotMode = m.autopilotModeBeforeReview
+	m.autopilotStatus = fmt.Sprintf("Spinning off worktree for #%d...", issueNum)
+
+	return m, func() tea.Msg {
+		result, err := sup.ManualSession(context.Background(), taskID)
 		return reviewSessionResultMsg{result: result, err: err}
 	}
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1685,7 +1685,7 @@ func (m Model) computeHeightBudget() (analysisH, eventLogH, autopilotTaskH int) 
 		isRunning := m.autopilotMode == "running" || m.autopilotMode == "stop-confirm" ||
 			m.autopilotMode == "stop-task-confirm" || m.autopilotMode == "restart-confirm" ||
 			m.autopilotMode == "resume-or-restart-confirm" || m.autopilotMode == "review-confirm" ||
-			m.autopilotMode == "completed"
+			m.autopilotMode == "manual-confirm" || m.autopilotMode == "completed"
 		if isRunning {
 			// Slot section.
 			if m.autopilotSupervisor != nil {
@@ -2113,6 +2113,18 @@ func (m Model) renderBottomBar() string {
 			b.WriteString(helpKeyStyle().Render("esc"))
 			b.WriteString(helpStyle().Render(": cancel"))
 			b.WriteString("\n")
+		} else if m.activeTab == tabAutopilot && m.autopilotMode == "manual-confirm" {
+			task := m.selectedAutopilotTask()
+			issueNum := 0
+			if task != nil {
+				issueNum = task.IssueNumber
+			}
+			b.WriteString(headerStyle().Render(fmt.Sprintf("  Spin off worktree for #%d? ", issueNum)))
+			b.WriteString(helpKeyStyle().Render("enter"))
+			b.WriteString(helpStyle().Render(": launch • "))
+			b.WriteString(helpKeyStyle().Render("esc"))
+			b.WriteString(helpStyle().Render(": cancel"))
+			b.WriteString("\n")
 		} else if m.autopilotStatus != "" {
 			b.WriteString(broadcastStyle().Render(fmt.Sprintf("  %s", m.autopilotStatus)))
 			b.WriteString("\n")
@@ -2313,7 +2325,7 @@ var (
 		{"a", "launch autopilot"},
 		{"A", "stop all agents"},
 		{"S", "stop selected"},
-		{"r", "restart/review selected"},
+		{"r", "restart/review/spinoff"},
 		{"b", "bump task limits"},
 		{"c", "copy worktree path"},
 		{"+", "add slot"},


### PR DESCRIPTION
## Summary

- **Manual task spin-off**: Press `r` on a manual task in the autopilot tab to create a worktree (`manual/issue-N` branch), launch a Claude session preloaded with dep graph and issue context, and get a banner to `cd` and `claude --resume`
- **Reviewed task restore**: Press `r` on `reviewed` tasks to launch review sessions (same flow as `review` tasks)
- **README rewrite**: Full rewrite reflecting current state — 3 tabs, settings, autopilot states/actions, deploy command, Claude Code CLI (no API key), schema v25, webhook notifications

## Test plan

- [ ] Build: `go build ./...`
- [ ] Tests: `go test ./...`
- [ ] Manual: start minder with manual tasks, press `r`, verify worktree + banner
- [ ] Manual: select a `reviewed` task, press `r`, verify review session launches
- [ ] Review README for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)