### PR TITLE
Add designer agent and pre-fetch context for all sessions

### DIFF
--- a/agents/designer.md
+++ b/agents/designer.md
@@ -1,0 +1,110 @@
+---
+name: designer
+description: >
+  Conducts deep design interviews for GitHub issues, focusing on UX/UI,
+  product thinking, user flows, edge cases, and integration concerns.
+  Outputs a structured design plan as an issue comment.
+  Install in a repo's .claude/agents/ directory to customize for your project.
+tools: Bash, Read, Glob, Grep
+---
+
+You are a design interview agent. All context — issue details, project architecture, dependency graph, and project goal — is provided in the initial prompt. **Do not explore the codebase or fetch anything on startup.** Confirm you understand the objective, then wait for the user to begin the conversation.
+
+When the user joins, conduct a thorough design discussion. You may explore the codebase during the conversation if the user asks or if you need to answer a specific question, but do not do so preemptively.
+
+## Design interview process
+
+Think of yourself as a product designer and senior engineer conducting a design review. Your goal is to surface decisions, edge cases, and integration concerns that haven't been considered yet.
+
+Work through these dimensions as the conversation progresses:
+
+### 1. User perspective
+- Who are the users affected by this change?
+- What are their goals when they encounter this feature/fix?
+- Walk through the user flow step by step — what does the user see, click, and expect at each point?
+- What happens when things go wrong from the user's perspective? What error states need design?
+- Are there accessibility concerns?
+
+### 2. Use cases and scenarios
+- What is the primary use case? Describe it concretely.
+- What are the secondary/edge use cases?
+- Are there adversarial or unexpected usage patterns to consider?
+- What data states matter? (empty state, single item, many items, stale data, conflicting data)
+
+### 3. Integration and architecture
+- How does this change interact with existing features?
+- What existing code/patterns should this build on vs. diverge from?
+- Are there shared components, state, or data models that will be affected?
+- What are the API boundaries? Do existing endpoints need changes or new ones?
+- Are there performance implications (loading states, pagination, caching)?
+
+### 4. Gotchas and risks
+- What could go wrong during implementation?
+- What assumptions are being made that might not hold?
+- Are there race conditions, ordering dependencies, or timing issues?
+- What happens during partial failures or network issues?
+- Are there migration or backward compatibility concerns?
+
+### 5. Scope and decomposition
+- Is this issue the right size, or should it be split?
+- What is the minimum viable version vs. the full vision?
+- Are there natural phases or milestones within this work?
+- What can be deferred without compromising the core value?
+
+## Output format
+
+When the user is ready to finalize, post a structured design plan as a comment on the issue using `gh issue comment`. Use this format:
+
+```markdown
+## Design Plan
+
+### Summary
+<2-3 sentences capturing the core design decisions>
+
+### User Flow
+<Step-by-step description of the primary user experience>
+
+### Key Decisions
+- **<Decision 1>**: <chosen approach> — <why>
+- **<Decision 2>**: <chosen approach> — <why>
+
+### Edge Cases & Error States
+- <scenario>: <how to handle>
+
+### Integration Points
+- <component/system>: <what changes and why>
+
+### Implementation Phases
+1. **Phase 1** — <description> (can be its own issue if splitting)
+2. **Phase 2** — <description>
+
+### Open Questions
+- <anything that still needs human input>
+
+### Risks
+- <risk>: <mitigation>
+```
+
+## Issue splitting
+
+If the design analysis reveals that the issue should be split into smaller, more focused issues:
+
+1. Create new issues with `gh issue create` for each sub-task
+2. Reference the parent issue in each new issue body
+3. Apply the same milestone and labels as the parent
+4. Update the parent issue comment to reference the new sub-issues
+5. If the original issue becomes a pure tracking/umbrella issue, note that in your comment
+
+## Interaction with the user
+
+- Do NOT post the issue comment until the user explicitly confirms
+- Ask about open questions rather than assuming
+- Incorporate feedback iteratively
+- Be opinionated — take positions on design decisions rather than listing options without recommendations
+
+## Important constraints
+
+- You are a **designer and analyst**, not an implementer — do NOT write implementation code
+- Do NOT modify any files in the repository
+- Focus on the **what** and **why**, not the **how** of implementation
+- Ground your analysis in the actual codebase, not hypotheticals

--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -50,6 +50,7 @@ type AgentName string
 const (
 	AgentAutopilot AgentName = "autopilot"
 	AgentReviewer  AgentName = "reviewer"
+	AgentDesigner  AgentName = "designer"
 )
 
 // defaultAgentDef is the built-in agent definition embedded in the binary.
@@ -335,10 +336,126 @@ If you encounter issues that prevent a thorough review:
 - **Permission failures**: If a tool call is denied, try 2-3 alternatives. If those also fail, complete your review without fixes and note the permission issue in your assessment.
 `
 
+// defaultDesignerDef is the built-in designer agent definition embedded in the binary.
+// It serves as the last-resort fallback when neither repo-level nor user-level
+// designer definitions exist. This content is identical to agents/designer.md in the repo.
+const defaultDesignerDef = `---
+name: designer
+description: >
+  Conducts deep design interviews for GitHub issues, focusing on UX/UI,
+  product thinking, user flows, edge cases, and integration concerns.
+  Outputs a structured design plan as an issue comment.
+  Install in a repo's .claude/agents/ directory to customize for your project.
+tools: Bash, Read, Glob, Grep
+---
+
+You are a design interview agent. All context — issue details, project architecture, dependency graph, and project goal — is provided in the initial prompt. **Do not explore the codebase or fetch anything on startup.** Confirm you understand the objective, then wait for the user to begin the conversation.
+
+When the user joins, conduct a thorough design discussion. You may explore the codebase during the conversation if the user asks or if you need to answer a specific question, but do not do so preemptively.
+
+## Design interview process
+
+Think of yourself as a product designer and senior engineer conducting a design review. Your goal is to surface decisions, edge cases, and integration concerns that haven't been considered yet.
+
+Work through these dimensions as the conversation progresses:
+
+### 1. User perspective
+- Who are the users affected by this change?
+- What are their goals when they encounter this feature/fix?
+- Walk through the user flow step by step — what does the user see, click, and expect at each point?
+- What happens when things go wrong from the user's perspective? What error states need design?
+- Are there accessibility concerns?
+
+### 2. Use cases and scenarios
+- What is the primary use case? Describe it concretely.
+- What are the secondary/edge use cases?
+- Are there adversarial or unexpected usage patterns to consider?
+- What data states matter? (empty state, single item, many items, stale data, conflicting data)
+
+### 3. Integration and architecture
+- How does this change interact with existing features?
+- What existing code/patterns should this build on vs. diverge from?
+- Are there shared components, state, or data models that will be affected?
+- What are the API boundaries? Do existing endpoints need changes or new ones?
+- Are there performance implications (loading states, pagination, caching)?
+
+### 4. Gotchas and risks
+- What could go wrong during implementation?
+- What assumptions are being made that might not hold?
+- Are there race conditions, ordering dependencies, or timing issues?
+- What happens during partial failures or network issues?
+- Are there migration or backward compatibility concerns?
+
+### 5. Scope and decomposition
+- Is this issue the right size, or should it be split?
+- What is the minimum viable version vs. the full vision?
+- Are there natural phases or milestones within this work?
+- What can be deferred without compromising the core value?
+
+## Output format
+
+When the user is ready to finalize, post a structured design plan as a comment on the issue using ` + "`gh issue comment`" + `. Use this format:
+
+` + "```" + `markdown
+## Design Plan
+
+### Summary
+<2-3 sentences capturing the core design decisions>
+
+### User Flow
+<Step-by-step description of the primary user experience>
+
+### Key Decisions
+- **<Decision 1>**: <chosen approach> — <why>
+- **<Decision 2>**: <chosen approach> — <why>
+
+### Edge Cases & Error States
+- <scenario>: <how to handle>
+
+### Integration Points
+- <component/system>: <what changes and why>
+
+### Implementation Phases
+1. **Phase 1** — <description> (can be its own issue if splitting)
+2. **Phase 2** — <description>
+
+### Open Questions
+- <anything that still needs human input>
+
+### Risks
+- <risk>: <mitigation>
+` + "```" + `
+
+## Issue splitting
+
+If the design analysis reveals that the issue should be split into smaller, more focused issues:
+
+1. Create new issues with ` + "`gh issue create`" + ` for each sub-task
+2. Reference the parent issue in each new issue body
+3. Apply the same milestone and labels as the parent
+4. Update the parent issue comment to reference the new sub-issues
+5. If the original issue becomes a pure tracking/umbrella issue, note that in your comment
+
+## Interaction with the user
+
+- Do NOT post the issue comment until the user explicitly confirms
+- Ask about open questions rather than assuming
+- Incorporate feedback iteratively
+- Be opinionated — take positions on design decisions rather than listing options without recommendations
+
+## Important constraints
+
+- You are a **designer and analyst**, not an implementer — do NOT write implementation code
+- Do NOT modify any files in the repository
+- Focus on the **what** and **why**, not the **how** of implementation
+- Ground your analysis in the actual codebase, not hypotheticals
+`
+
 // builtInDefs maps agent names to their built-in default definitions.
 var builtInDefs = map[AgentName]string{
 	AgentAutopilot: defaultAgentDef,
 	AgentReviewer:  defaultReviewerDef,
+	AgentDesigner:  defaultDesignerDef,
 }
 
 // DetectAgentDef probes the three-tier failover chain without writing anything.
@@ -451,7 +568,7 @@ func toCliAllowedTools(tools []string) string {
 
 // renderTaskContext builds a minimal prompt with only dynamic per-task context.
 // Used when a .claude/agents/autopilot.md agent definition provides the behavioral instructions.
-func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, rw *relatedWork) string {
+func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, rw *relatedWork, issueComments string) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "## Task Context\n\n")
@@ -460,6 +577,12 @@ func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testComm
 
 	if task.IssueBody != "" {
 		b.WriteString(task.IssueBody)
+		b.WriteString("\n\n")
+	}
+
+	if issueComments != "" {
+		b.WriteString("## Issue Discussion\n\n")
+		b.WriteString(issueComments)
 		b.WriteString("\n\n")
 	}
 
@@ -492,7 +615,7 @@ func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testComm
 
 // renderResumeTaskContext builds a continuation prompt for resuming work in an existing worktree.
 // It includes context about the prior failure and instructs the agent to pick up where it left off.
-func renderResumeTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, rw *relatedWork) string {
+func renderResumeTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, rw *relatedWork, issueComments string) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "## Resuming Previous Work\n\n")
@@ -508,26 +631,148 @@ func renderResumeTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, te
 	b.WriteString("continue from where it left off, and open a PR when ready.\n\n")
 
 	// Include the standard task context.
-	b.WriteString(renderTaskContext(task, baseBranch, owner, repo, testCommand, rw))
+	b.WriteString(renderTaskContext(task, baseBranch, owner, repo, testCommand, rw, issueComments))
 
 	return b.String()
 }
 
 // renderManualSessionPrompt builds a prompt for a manual work session.
-// Claude fetches the issue details, summarizes the work, then awaits user instructions.
-func renderManualSessionPrompt(task *db.AutopilotTask, owner, repo string, rw *relatedWork) string {
+// All context is pre-loaded so the agent starts ready for conversation.
+func renderManualSessionPrompt(task *db.AutopilotTask, owner, repo, projectGoal string, rw *relatedWork, issueComments, claudeMD string) string {
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "You are starting a manual work session for issue #%d in %s/%s.\n\n", task.IssueNumber, owner, repo)
-	fmt.Fprintf(&b, "1. Run `gh issue view %d -R %s/%s` to fetch the full issue details\n", task.IssueNumber, owner, repo)
-	b.WriteString("2. Summarize the issue and what needs to be done\n")
-	b.WriteString("3. Then tell the user you're ready for their instructions\n\n")
-	fmt.Fprintf(&b, "Worktree: %s\n", task.WorktreePath)
+	fmt.Fprintf(&b, "You are starting a manual work session for issue #%d in %s/%s.\n", task.IssueNumber, owner, repo)
+	b.WriteString("All context you need is provided below. Do NOT fetch the issue or explore yet.\n")
+	b.WriteString("Confirm you understand the objective, then await the user's instructions.\n\n")
+
+	fmt.Fprintf(&b, "## Issue #%d — %s\n\n", task.IssueNumber, task.IssueTitle)
+
+	if task.IssueBody != "" {
+		b.WriteString(task.IssueBody)
+		b.WriteString("\n\n")
+	}
+
+	if issueComments != "" {
+		b.WriteString("## Issue Discussion\n\n")
+		b.WriteString(issueComments)
+		b.WriteString("\n\n")
+	}
+
+	if projectGoal != "" {
+		fmt.Fprintf(&b, "## Project Goal\n\n%s\n\n", projectGoal)
+	}
+
+	if claudeMD != "" {
+		b.WriteString("## Project Architecture (CLAUDE.md)\n\n")
+		b.WriteString(claudeMD)
+		b.WriteString("\n\n")
+	}
+
+	fmt.Fprintf(&b, "## Worktree\n\n")
+	fmt.Fprintf(&b, "Path: %s\n", task.WorktreePath)
 	fmt.Fprintf(&b, "Branch: %s\n\n", task.Branch)
 
 	if related := renderRelatedWork(task, rw); related != "" {
 		b.WriteString(related)
 	}
+
+	return b.String()
+}
+
+// renderReviewSessionPrompt builds a prompt for an interactive review session.
+// All context is pre-loaded so the agent starts ready for conversation.
+func renderReviewSessionPrompt(task *db.AutopilotTask, owner, repo, projectGoal string, rw *relatedWork, issueComments, prDetails, prDiff, claudeMD string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "You are starting a review session for PR #%d (issue #%d) in %s/%s.\n", task.PRNumber, task.IssueNumber, owner, repo)
+	b.WriteString("All context you need is provided below. Do NOT fetch the PR or issue yet.\n")
+	b.WriteString("Confirm you understand the PR, then await the user's review instructions.\n\n")
+
+	fmt.Fprintf(&b, "## Issue #%d — %s\n\n", task.IssueNumber, task.IssueTitle)
+
+	if task.IssueBody != "" {
+		b.WriteString(task.IssueBody)
+		b.WriteString("\n\n")
+	}
+
+	if issueComments != "" {
+		b.WriteString("## Issue Discussion\n\n")
+		b.WriteString(issueComments)
+		b.WriteString("\n\n")
+	}
+
+	if prDetails != "" {
+		fmt.Fprintf(&b, "## PR #%d Details\n\n", task.PRNumber)
+		b.WriteString(prDetails)
+		b.WriteString("\n\n")
+	}
+
+	if prDiff != "" {
+		fmt.Fprintf(&b, "## PR #%d Diff\n\n```diff\n", task.PRNumber)
+		b.WriteString(prDiff)
+		b.WriteString("```\n\n")
+	}
+
+	if projectGoal != "" {
+		fmt.Fprintf(&b, "## Project Goal\n\n%s\n\n", projectGoal)
+	}
+
+	if claudeMD != "" {
+		b.WriteString("## Project Architecture (CLAUDE.md)\n\n")
+		b.WriteString(claudeMD)
+		b.WriteString("\n\n")
+	}
+
+	fmt.Fprintf(&b, "## Worktree\n\n")
+	fmt.Fprintf(&b, "Path: %s\n", task.WorktreePath)
+	fmt.Fprintf(&b, "Branch: %s\n\n", task.Branch)
+
+	if related := renderRelatedWork(task, rw); related != "" {
+		b.WriteString(related)
+	}
+
+	return b.String()
+}
+
+// renderDesignSessionPrompt builds a prompt for a design interview session.
+// All context is pre-loaded so the agent can start immediately without exploring.
+func renderDesignSessionPrompt(task *db.AutopilotTask, owner, repo, projectGoal string, rw *relatedWork, issueComments, claudeMD string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "You are a design interview agent for issue #%d in %s/%s.\n", task.IssueNumber, owner, repo)
+	b.WriteString("All context you need is provided below. Do NOT explore the codebase or fetch anything yet.\n\n")
+	b.WriteString("Confirm you understand the objective, then await the user's first message.\n\n")
+
+	fmt.Fprintf(&b, "## Issue #%d — %s\n\n", task.IssueNumber, task.IssueTitle)
+
+	if task.IssueBody != "" {
+		b.WriteString(task.IssueBody)
+		b.WriteString("\n\n")
+	}
+
+	if issueComments != "" {
+		b.WriteString("## Issue Discussion\n\n")
+		b.WriteString(issueComments)
+		b.WriteString("\n\n")
+	}
+
+	if projectGoal != "" {
+		fmt.Fprintf(&b, "## Project Goal\n\n%s\n\n", projectGoal)
+	}
+
+	if claudeMD != "" {
+		b.WriteString("## Project Architecture (CLAUDE.md)\n\n")
+		b.WriteString(claudeMD)
+		b.WriteString("\n\n")
+	}
+
+	if related := renderRelatedWork(task, rw); related != "" {
+		b.WriteString(related)
+	}
+
+	fmt.Fprintf(&b, "## Commands (for later use)\n\n")
+	fmt.Fprintf(&b, "Post comment: gh issue comment %d -R %s/%s --body \"<plan>\"\n", task.IssueNumber, owner, repo)
+	fmt.Fprintf(&b, "Create sub-issue: gh issue create -R %s/%s --title \"<title>\" --body \"<body>\"\n", owner, repo)
 
 	return b.String()
 }
@@ -630,7 +875,7 @@ func detectTestCommand(repoDir string) string {
 // renderReviewTaskContext builds a prompt with review-specific context for the reviewer agent.
 // It provides the PR number, issue details, project goal, test command, dependency graph,
 // sibling task statuses, and commands for the review workflow.
-func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal, testCommand string, rw *relatedWork) string {
+func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal, testCommand string, rw *relatedWork, issueComments string) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "## Review Context\n\n")
@@ -644,6 +889,12 @@ func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, pr
 	if task.IssueBody != "" {
 		fmt.Fprintf(&b, "## Issue Description\n\n")
 		b.WriteString(task.IssueBody)
+		b.WriteString("\n\n")
+	}
+
+	if issueComments != "" {
+		b.WriteString("## Issue Discussion\n\n")
+		b.WriteString(issueComments)
 		b.WriteString("\n\n")
 	}
 
@@ -673,8 +924,8 @@ func renderReviewTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, pr
 }
 
 // buildReviewClaudeArgs constructs the CLI arguments for launching a reviewer agent.
-func buildReviewClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork) []string {
-	prompt := renderReviewTaskContext(task, baseBranch, owner, repo, projectGoal, testCommand, rw)
+func buildReviewClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, projectGoal, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork, issueComments string) []string {
+	prompt := renderReviewTaskContext(task, baseBranch, owner, repo, projectGoal, testCommand, rw, issueComments)
 	return []string{
 		"--agent", "reviewer",
 		"-p",

--- a/internal/autopilot/prompt_test.go
+++ b/internal/autopilot/prompt_test.go
@@ -101,7 +101,7 @@ func TestRenderTaskContext(t *testing.T) {
 		Branch:       "agent/issue-42",
 	}
 
-	ctx := renderTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil)
+	ctx := renderTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil, "")
 
 	checks := []string{
 		"#42",
@@ -131,7 +131,7 @@ func TestRenderTaskContext(t *testing.T) {
 	}
 
 	// Empty test command should omit the section entirely.
-	ctxNoTest := renderTaskContext(task, "main", "myorg", "myrepo", "", nil)
+	ctxNoTest := renderTaskContext(task, "main", "myorg", "myrepo", "", nil, "")
 	if strings.Contains(ctxNoTest, "## Test command") {
 		t.Error("task context should omit test command section when empty")
 	}
@@ -146,7 +146,7 @@ func TestRenderTaskContextEmptyBody(t *testing.T) {
 		Branch:       "agent/issue-1",
 	}
 
-	ctx := renderTaskContext(task, "main", "owner", "repo", "", nil)
+	ctx := renderTaskContext(task, "main", "owner", "repo", "", nil, "")
 
 	if strings.Contains(ctx, "\n\n\n\n") {
 		t.Error("task context has excessive blank lines when body is empty")
@@ -165,7 +165,7 @@ func TestRenderTaskContextNoBehavioralInstructions(t *testing.T) {
 		Branch:       "agent/issue-42",
 	}
 
-	ctx := renderTaskContext(task, "main", "org", "repo", "", nil)
+	ctx := renderTaskContext(task, "main", "org", "repo", "", nil, "")
 
 	// Task context must NOT contain behavioral instructions — those belong in the agent definition.
 	behavioral := []string{
@@ -303,7 +303,7 @@ func TestBuildClaudeArgs(t *testing.T) {
 
 	t.Run("always uses --agent autopilot", func(t *testing.T) {
 		tools := []string{"Read", "Edit", "Write", "Bash(git *)"}
-		args := buildClaudeArgs(task, "main", "org", "repo", "go test ./...", 50, 3.00, tools, nil)
+		args := buildClaudeArgs(task, "main", "org", "repo", "go test ./...", 50, 3.00, tools, nil, "")
 
 		// Should always use --agent autopilot as first args.
 		if args[0] != "--agent" || args[1] != "autopilot" {
@@ -354,7 +354,7 @@ func TestBuildClaudeArgs(t *testing.T) {
 	})
 
 	t.Run("includes max turns and budget", func(t *testing.T) {
-		args := buildClaudeArgs(task, "main", "org", "repo", "", 75, 5.50, defaultAllowedTools, nil)
+		args := buildClaudeArgs(task, "main", "org", "repo", "", 75, 5.50, defaultAllowedTools, nil, "")
 		joined := strings.Join(args, " ")
 
 		if !strings.Contains(joined, "--max-turns 75") {
@@ -729,7 +729,7 @@ func TestRenderResumeTaskContext(t *testing.T) {
 		FailureDetail: "used 50 of 50 turns",
 	}
 
-	prompt := renderResumeTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil)
+	prompt := renderResumeTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil, "")
 
 	// Should contain resume header.
 	if !strings.Contains(prompt, "Resuming Previous Work") {
@@ -768,7 +768,7 @@ func TestRenderResumeTaskContextNoFailure(t *testing.T) {
 		Branch:       "agent/issue-10",
 	}
 
-	prompt := renderResumeTaskContext(task, "main", "org", "repo", "", nil)
+	prompt := renderResumeTaskContext(task, "main", "org", "repo", "", nil, "")
 
 	if !strings.Contains(prompt, "Resuming Previous Work") {
 		t.Error("should contain resume header")
@@ -795,7 +795,7 @@ func TestBuildResumeClaudeArgs(t *testing.T) {
 		FailureDetail: "spent $3.00 of $3.00 budget",
 	}
 
-	args := buildResumeClaudeArgs(task, "main", "org", "repo", "go test ./...", 50, 3.00, defaultAllowedTools, nil)
+	args := buildResumeClaudeArgs(task, "main", "org", "repo", "go test ./...", 50, 3.00, defaultAllowedTools, nil, "")
 	joined := strings.Join(args, " ")
 
 	// Should use --agent autopilot.
@@ -914,7 +914,7 @@ func TestRenderReviewTaskContext(t *testing.T) {
 		PRNumber:     99,
 	}
 
-	ctx := renderReviewTaskContext(task, "main", "myorg", "myrepo", "Build a secure healthcare platform", "go test ./...", nil)
+	ctx := renderReviewTaskContext(task, "main", "myorg", "myrepo", "Build a secure healthcare platform", "go test ./...", nil, "")
 
 	checks := []string{
 		"#99", // PR number
@@ -949,7 +949,7 @@ func TestRenderReviewTaskContextEmptyGoal(t *testing.T) {
 		PRNumber:     15,
 	}
 
-	ctx := renderReviewTaskContext(task, "main", "org", "repo", "", "", nil)
+	ctx := renderReviewTaskContext(task, "main", "org", "repo", "", "", nil, "")
 
 	if strings.Contains(ctx, "Project Goal") {
 		t.Error("should not include project goal section when empty")
@@ -970,7 +970,7 @@ func TestBuildReviewClaudeArgs(t *testing.T) {
 	}
 
 	tools := []string{"Read", "Edit", "Write", "Bash(git *)"}
-	args := buildReviewClaudeArgs(task, "main", "org", "repo", "Project goal", "npm test", 30, 2.00, tools, nil)
+	args := buildReviewClaudeArgs(task, "main", "org", "repo", "Project goal", "npm test", 30, 2.00, tools, nil, "")
 
 	// Should use --agent reviewer.
 	if args[0] != "--agent" || args[1] != "reviewer" {
@@ -1098,7 +1098,7 @@ func TestRenderReviewTaskContextWithRelatedWork(t *testing.T) {
 		},
 	}
 
-	ctx := renderReviewTaskContext(task, "main", "org", "repo", "Goal", "", rw)
+	ctx := renderReviewTaskContext(task, "main", "org", "repo", "Goal", "", rw, "")
 
 	if !strings.Contains(ctx, "Related Work") {
 		t.Error("should contain Related Work section")
@@ -1148,14 +1148,14 @@ func TestPrintPrompts(t *testing.T) {
 	fmt.Println(renderPrompt(task, "main", "myorg", "myrepo"))
 
 	fmt.Printf("\n%s\n  TASK CONTEXT (used with --agent autopilot)\n%s\n\n", sep, sep)
-	fmt.Println(renderTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil))
+	fmt.Println(renderTaskContext(task, "main", "myorg", "myrepo", "go test ./...", nil, ""))
 
 	fmt.Printf("\n%s\n  BUILT-IN DEFAULT AGENT DEFINITION\n%s\n\n", sep, sep)
 	fmt.Print(defaultAgentDef)
 
 	fmt.Printf("\n%s\n  REVIEW TASK CONTEXT (used with --agent reviewer)\n%s\n\n", sep, sep)
 	task.PRNumber = 123
-	fmt.Println(renderReviewTaskContext(task, "main", "myorg", "myrepo", "Build a secure healthcare platform", "go test ./...", nil))
+	fmt.Println(renderReviewTaskContext(task, "main", "myorg", "myrepo", "Build a secure healthcare platform", "go test ./...", nil, ""))
 
 	fmt.Printf("\n%s\n  BUILT-IN DEFAULT REVIEWER DEFINITION\n%s\n\n", sep, sep)
 	fmt.Print(defaultReviewerDef)

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -259,22 +259,25 @@ func (s *Supervisor) ReviewSession(ctx context.Context, taskID int64) (*ReviewSe
 		}
 	}
 
-	// Build a review prompt.
-	prompt := fmt.Sprintf(
-		"You are starting a review session for PR #%d (issue #%d) in %s/%s.\n\n"+
-			"1. Run `gh pr view %d -R %s/%s` to fetch the PR details\n"+
-			"2. Run `gh pr diff %d -R %s/%s` to see the changes\n"+
-			"3. Summarize what the PR does and note any concerns\n"+
-			"4. Then tell the user you're ready for their review instructions\n\n"+
-			"Worktree: %s\nBranch: %s",
-		task.PRNumber, task.IssueNumber, s.owner, s.repo,
-		task.PRNumber, s.owner, s.repo,
-		task.PRNumber, s.owner, s.repo,
-		task.WorktreePath, task.Branch,
-	)
+	// Pre-fetch all context so the agent starts ready for conversation.
+	issueComments := s.fetchIssueComments(ctx, task.IssueNumber, task.WorktreePath)
+	prDetails := s.fetchPRDetails(ctx, task.PRNumber, task.WorktreePath)
+	prDiff := s.fetchPRDiff(ctx, task.PRNumber, task.WorktreePath)
+	claudeMD := s.readClaudeMD(task.WorktreePath)
 
-	// Launch claude -p with stream-json so we can capture the session ID.
-	// Use --allowedTools for least-privilege access scoped to review needs.
+	// Build related work context — reuse the already-loaded tasks as siblings.
+	var rw *relatedWork
+	dg, dgErr := s.store.GetDepGraph(s.project.ID)
+	if dgErr == nil || len(tasks) > 0 {
+		rw = &relatedWork{}
+		if dgErr == nil && dg != nil {
+			rw.depGraph = dg.GraphJSON
+		}
+		rw.siblingTasks = tasks
+	}
+
+	prompt := renderReviewSessionPrompt(task, s.owner, s.repo, s.project.GoalDescription, rw, issueComments, prDetails, prDiff, claudeMD)
+
 	allowedTools := resolveAllowedTools(s.repoDir)
 	args := []string{
 		"-p",
@@ -392,22 +395,22 @@ func (s *Supervisor) ManualSession(ctx context.Context, taskID int64) (*ReviewSe
 		return nil, fmt.Errorf("update task worktree: %w", err)
 	}
 
-	// Build related work context.
+	// Pre-fetch all context so the agent starts ready for conversation.
+	issueComments := s.fetchIssueComments(ctx, task.IssueNumber, worktreePath)
+	claudeMD := s.readClaudeMD(worktreePath)
+
+	// Build related work context — reuse the already-loaded tasks as siblings.
 	var rw *relatedWork
 	dg, dgErr := s.store.GetDepGraph(s.project.ID)
-	siblings, sibErr := s.store.GetAutopilotTasks(s.project.ID)
-	if dgErr == nil || sibErr == nil {
+	if dgErr == nil || len(tasks) > 0 {
 		rw = &relatedWork{}
 		if dgErr == nil && dg != nil {
 			rw.depGraph = dg.GraphJSON
 		}
-		if sibErr == nil {
-			rw.siblingTasks = siblings
-		}
+		rw.siblingTasks = tasks
 	}
 
-	// Build manual session prompt.
-	prompt := renderManualSessionPrompt(task, s.owner, s.repo, rw)
+	prompt := renderManualSessionPrompt(task, s.owner, s.repo, s.project.GoalDescription, rw, issueComments, claudeMD)
 
 	// Launch claude -p with stream-json so we can capture the session ID.
 	allowedTools := resolveAllowedTools(s.repoDir)
@@ -465,6 +468,190 @@ func (s *Supervisor) ManualSession(ctx context.Context, taskID int64) (*ReviewSe
 		SessionID:    sessionID,
 		IssueNumber:  task.IssueNumber,
 	}, nil
+}
+
+// DesignSession creates a worktree for a task and launches a Claude session with the
+// designer agent for an interactive design interview. Works on any non-terminal task status.
+// Returns the session ID so the user can resume it.
+func (s *Supervisor) DesignSession(ctx context.Context, taskID int64) (*ReviewSessionResult, error) {
+	tasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return nil, fmt.Errorf("get tasks: %w", err)
+	}
+
+	var task *db.AutopilotTask
+	for i := range tasks {
+		if tasks[i].ID == taskID {
+			task = &tasks[i]
+			break
+		}
+	}
+	if task == nil {
+		return nil, fmt.Errorf("task %d not found", taskID)
+	}
+
+	home, _ := os.UserHomeDir()
+	worktreeBase := filepath.Join(home, ".agent-minder", "worktrees", s.project.Name)
+	worktreePath := filepath.Join(worktreeBase, fmt.Sprintf("issue-%d", task.IssueNumber))
+	branch := fmt.Sprintf("design/issue-%d", task.IssueNumber)
+
+	baseBranch := s.project.AutopilotBaseBranch
+	if baseBranch == "" {
+		baseBranch, _ = gitpkg.DefaultBranch(s.repoDir)
+	}
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+
+	if _, statErr := os.Stat(worktreePath); os.IsNotExist(statErr) {
+		s.gitSetupMu.Lock()
+		_ = gitpkg.Fetch(s.repoDir)
+		_ = gitpkg.DeleteBranch(s.repoDir, branch)
+		gitErr := gitpkg.WorktreeAdd(s.repoDir, worktreePath, branch, "origin/"+baseBranch)
+		s.gitSetupMu.Unlock()
+		if gitErr != nil {
+			return nil, fmt.Errorf("create worktree: %w", gitErr)
+		}
+	}
+
+	// Persist worktree info on the task (without changing status).
+	task.WorktreePath = worktreePath
+	task.Branch = branch
+	if err := s.store.UpdateAutopilotTaskWorktree(task.ID, worktreePath, branch); err != nil {
+		return nil, fmt.Errorf("update task worktree: %w", err)
+	}
+
+	// Reuse the already-loaded tasks as siblings for related work context.
+	var rw *relatedWork
+	dg, dgErr := s.store.GetDepGraph(s.project.ID)
+	if dgErr == nil || len(tasks) > 0 {
+		rw = &relatedWork{}
+		if dgErr == nil && dg != nil {
+			rw.depGraph = dg.GraphJSON
+		}
+		rw.siblingTasks = tasks
+	}
+
+	// Pre-fetch issue comments and CLAUDE.md so the agent has full context
+	// without needing to explore — the session starts ready for conversation.
+	issueComments := s.fetchIssueComments(ctx, task.IssueNumber, worktreePath)
+	claudeMD := s.readClaudeMD(worktreePath)
+
+	prompt := renderDesignSessionPrompt(task, s.owner, s.repo, s.project.GoalDescription, rw, issueComments, claudeMD)
+
+	if _, err := ensureAgentDefByName(worktreePath, AgentDesigner); err != nil {
+		debugLog("design-session: ensure agent def", "error", err)
+	}
+
+	allowedTools := resolveAllowedTools(s.repoDir)
+	args := []string{
+		"--agent", "designer",
+		"-p",
+		"--output-format", "stream-json",
+		"--verbose",
+		"--max-turns", "3",
+		"--allowedTools", toCliAllowedTools(allowedTools),
+		"--", prompt,
+	}
+
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	cmd.Dir = worktreePath
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+s.ghToken)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start claude: %w", err)
+	}
+
+	// Parse stream-json output for session_id from the init event.
+	var sessionID string
+	scanner := json.NewDecoder(stdout)
+	for scanner.More() {
+		var raw json.RawMessage
+		if err := scanner.Decode(&raw); err != nil {
+			break
+		}
+		var initEvt struct {
+			Type      string `json:"type"`
+			Subtype   string `json:"subtype"`
+			SessionID string `json:"session_id"`
+		}
+		if json.Unmarshal(raw, &initEvt) == nil && initEvt.Type == "system" && initEvt.Subtype == "init" && initEvt.SessionID != "" {
+			sessionID = initEvt.SessionID
+		}
+	}
+
+	_ = cmd.Wait()
+
+	if sessionID == "" {
+		return &ReviewSessionResult{
+			WorktreePath: worktreePath,
+			IssueNumber:  task.IssueNumber,
+		}, nil
+	}
+
+	return &ReviewSessionResult{
+		WorktreePath: worktreePath,
+		SessionID:    sessionID,
+		IssueNumber:  task.IssueNumber,
+	}, nil
+}
+
+// fetchIssueComments shells out to gh to get the full issue view with comments.
+// Returns empty string on any error — the design session still works, just with less context.
+func (s *Supervisor) fetchIssueComments(ctx context.Context, issueNumber int, workDir string) string {
+	cmd := exec.CommandContext(ctx, "gh", "issue", "view", strconv.Itoa(issueNumber),
+		"--comments", "-R", s.owner+"/"+s.repo)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+s.ghToken)
+	out, err := cmd.Output()
+	if err != nil {
+		debugLog("design-session: fetch issue comments", "error", err, "issue", issueNumber)
+		return ""
+	}
+	return string(out)
+}
+
+// fetchPRDetails shells out to gh to get PR metadata (title, body, status, files).
+func (s *Supervisor) fetchPRDetails(ctx context.Context, prNumber int, workDir string) string {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", strconv.Itoa(prNumber),
+		"-R", s.owner+"/"+s.repo)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+s.ghToken)
+	out, err := cmd.Output()
+	if err != nil {
+		debugLog("review-session: fetch PR details", "error", err, "pr", prNumber)
+		return ""
+	}
+	return string(out)
+}
+
+// fetchPRDiff shells out to gh to get the PR diff.
+func (s *Supervisor) fetchPRDiff(ctx context.Context, prNumber int, workDir string) string {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "diff", strconv.Itoa(prNumber),
+		"-R", s.owner+"/"+s.repo)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+s.ghToken)
+	out, err := cmd.Output()
+	if err != nil {
+		debugLog("review-session: fetch PR diff", "error", err, "pr", prNumber)
+		return ""
+	}
+	return string(out)
+}
+
+// readClaudeMD reads the CLAUDE.md file from the worktree root.
+// Returns empty string if the file doesn't exist or can't be read.
+func (s *Supervisor) readClaudeMD(worktreePath string) string {
+	data, err := os.ReadFile(filepath.Join(worktreePath, "CLAUDE.md"))
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 // RestartTask cleans up a bailed or stopped task and re-queues it.
@@ -2556,11 +2743,14 @@ func (s *Supervisor) runAgent(ctx context.Context, slotIdx int, task *db.Autopil
 		}
 	}
 
+	// Pre-fetch issue comments so the agent has full context without spending a turn.
+	issueComments := s.fetchIssueComments(ctx, task.IssueNumber, task.WorktreePath)
+
 	var args []string
 	if isResume {
-		args = buildResumeClaudeArgs(task, baseBranch, s.owner, s.repo, testCommand, maxTurns, maxBudget, allowedTools, rw)
+		args = buildResumeClaudeArgs(task, baseBranch, s.owner, s.repo, testCommand, maxTurns, maxBudget, allowedTools, rw, issueComments)
 	} else {
-		args = buildClaudeArgs(task, baseBranch, s.owner, s.repo, testCommand, maxTurns, maxBudget, allowedTools, rw)
+		args = buildClaudeArgs(task, baseBranch, s.owner, s.repo, testCommand, maxTurns, maxBudget, allowedTools, rw, issueComments)
 	}
 
 	debugStep := "launch"
@@ -2942,7 +3132,10 @@ func (s *Supervisor) runReviewAgent(ctx context.Context, slotIdx int, task *db.A
 		}
 	}
 
-	args := buildReviewClaudeArgs(task, baseBranch, s.owner, s.repo, projectGoal, testCommand, maxTurns, maxBudget, allowedTools, rw)
+	// Pre-fetch issue comments so the reviewer has full context without spending a turn.
+	issueComments := s.fetchIssueComments(ctx, task.IssueNumber, task.WorktreePath)
+
+	args := buildReviewClaudeArgs(task, baseBranch, s.owner, s.repo, projectGoal, testCommand, maxTurns, maxBudget, allowedTools, rw, issueComments)
 
 	debugLog("review agent command",
 		"stage", "autopilot", "step", "review-launch",
@@ -3348,8 +3541,8 @@ var userHomeDir = os.UserHomeDir
 // Instead of --dangerously-skip-permissions, each tool from allowedTools is
 // passed as a separate --allowedTools flag, giving the agent least-privilege
 // access scoped to the tools it actually needs.
-func buildClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork) []string {
-	prompt := renderTaskContext(task, baseBranch, owner, repo, testCommand, rw)
+func buildClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork, issueComments string) []string {
+	prompt := renderTaskContext(task, baseBranch, owner, repo, testCommand, rw, issueComments)
 	return []string{
 		"--agent", "autopilot",
 		"-p",
@@ -3364,8 +3557,8 @@ func buildClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, testComman
 
 // buildResumeClaudeArgs constructs the argument list for resuming a claude agent
 // in an existing worktree. Uses a continuation prompt instead of a fresh start prompt.
-func buildResumeClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork) []string {
-	prompt := renderResumeTaskContext(task, baseBranch, owner, repo, testCommand, rw)
+func buildResumeClaudeArgs(task *db.AutopilotTask, baseBranch, owner, repo, testCommand string, maxTurns int, maxBudget float64, allowedTools []string, rw *relatedWork, issueComments string) []string {
+	prompt := renderResumeTaskContext(task, baseBranch, owner, repo, testCommand, rw, issueComments)
 	return []string{
 		"--agent", "autopilot",
 		"-p",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4,7 +4,7 @@ package tui
 import (
 	"context"
 	"fmt"
-	"os/exec"
+
 	"strings"
 	"time"
 
@@ -237,7 +237,7 @@ type Model struct {
 
 	// Autopilot.
 	autopilotSupervisor       *autopilot.Supervisor
-	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "resume-or-restart-confirm", "review-confirm", "manual-confirm", "add-slot-confirm", "completed", "reprepare-choice"
+	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "resume-or-restart-confirm", "review-confirm", "manual-confirm", "design-confirm", "add-slot-confirm", "completed", "reprepare-choice"
 	autopilotModeBeforeReview string // saved mode to restore on review-confirm cancel
 	autopilotPrepareResult    *autopilot.PrepareResult
 	autopilotStatus           string
@@ -278,8 +278,9 @@ type Model struct {
 	logViewerAtBottom bool
 	logViewerStatus   string
 
-	// Warning banner (persistent, dismissible with 'w').
-	warningBanner string
+	// Warning banner (persistent, dismissible with 'd').
+	warningBanner   string
+	bannerClipboard string // command to copy to clipboard when banner is dismissed
 }
 
 // safeViewportKeyMap returns a viewport KeyMap that only uses arrow keys and
@@ -654,15 +655,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return clearAutopilotStatusMsg{}
 			})
 		} else if msg.result.SessionID != "" {
-			m.warningBanner = fmt.Sprintf(
-				"Review ready for #%d — cd %s && claude --resume %s",
-				msg.result.IssueNumber, msg.result.WorktreePath, msg.result.SessionID,
-			)
+			clipCmd := fmt.Sprintf("cd %s && claude --resume %s", msg.result.WorktreePath, msg.result.SessionID)
+			m.warningBanner = fmt.Sprintf("Session ready for #%d — %s", msg.result.IssueNumber, clipCmd)
+			m.bannerClipboard = clipCmd
 		} else {
-			m.warningBanner = fmt.Sprintf(
-				"Worktree restored for #%d — cd %s && claude",
-				msg.result.IssueNumber, msg.result.WorktreePath,
-			)
+			clipCmd := fmt.Sprintf("cd %s && claude", msg.result.WorktreePath)
+			m.warningBanner = fmt.Sprintf("Worktree restored for #%d — %s", msg.result.IssueNumber, clipCmd)
+			m.bannerClipboard = clipCmd
 		}
 		m.autopilotStatus = ""
 		return m, nil
@@ -931,6 +930,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.autopilotStatus = ""
 		return m, nil
 
+	case clearBannerMsg:
+		m.warningBanner = ""
+		return m, nil
+
 	case logRefreshMsg:
 		if !m.showLogViewer {
 			return m, nil
@@ -1052,7 +1055,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tickEvery()
 
 	case autopilotTickMsg:
-		if m.autopilotMode == "running" || m.autopilotMode == "stop-task-confirm" || m.autopilotMode == "restart-confirm" || m.autopilotMode == "resume-or-restart-confirm" || m.autopilotMode == "review-confirm" {
+		if m.autopilotMode == "running" || m.autopilotMode == "stop-task-confirm" || m.autopilotMode == "restart-confirm" || m.autopilotMode == "resume-or-restart-confirm" || m.autopilotMode == "review-confirm" || m.autopilotMode == "design-confirm" {
 			m.rebuildAutopilotTaskContent()
 			return m, autopilotTick()
 		}
@@ -1062,6 +1065,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+type clearBannerMsg struct{}
 type clearBroadcastStatusMsg struct{}
 type clearOnboardStatusMsg struct{}
 type clearRebuildDepsStatusMsg struct{}
@@ -1240,6 +1244,15 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	}
+	if m.autopilotMode == "design-confirm" && m.activeTab == tabAutopilot {
+		switch msg.String() {
+		case "enter":
+			return m.launchDesignSession()
+		case "esc":
+			m.autopilotMode = m.autopilotModeBeforeReview
+			return m, nil
+		}
+	}
 	if m.autopilotMode == "add-slot-confirm" && m.activeTab == tabAutopilot {
 		switch msg.String() {
 		case "enter":
@@ -1279,6 +1292,17 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.resizeViewports()
 		return m, nil
 	case "d":
+		if m.bannerClipboard != "" {
+			if err := copyToClipboard(m.bannerClipboard); err == nil {
+				m.warningBanner = "Command copied to clipboard"
+			} else {
+				m.warningBanner = ""
+			}
+			m.bannerClipboard = ""
+			return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+				return clearBannerMsg{}
+			})
+		}
 		m.warningBanner = ""
 		return m, nil
 	case "q", "ctrl+c":
@@ -1331,6 +1355,16 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			p.PollNow(context.Background())
 			return nil
 		})
+	case "g":
+		// Design interview: available on any task during autopilot running/completed.
+		if m.activeTab == tabAutopilot && (m.autopilotMode == "running" || m.autopilotMode == "completed") {
+			task := m.selectedAutopilotTask()
+			if task != nil {
+				m.autopilotModeBeforeReview = m.autopilotMode
+				m.autopilotMode = "design-confirm"
+				return m, nil
+			}
+		}
 	case "e":
 		if m.activeTab == tabAnalysis {
 			m.analysisExpanded = !m.analysisExpanded
@@ -1590,10 +1624,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if task == nil || task.WorktreePath == "" {
 			return m, nil
 		}
-		// Copy worktree path to clipboard via pbcopy.
-		cmd := exec.Command("pbcopy")
-		cmd.Stdin = strings.NewReader(task.WorktreePath)
-		if err := cmd.Run(); err == nil {
+		if err := copyToClipboard(task.WorktreePath); err == nil {
 			m.autopilotStatus = fmt.Sprintf("Copied: %s", task.WorktreePath)
 		} else {
 			m.autopilotStatus = fmt.Sprintf("Copy failed: %v", err)
@@ -2638,6 +2669,31 @@ func (m Model) launchManualSession() (tea.Model, tea.Cmd) {
 
 	return m, func() tea.Msg {
 		result, err := sup.ManualSession(context.Background(), taskID)
+		return reviewSessionResultMsg{result: result, err: err}
+	}
+}
+
+// launchDesignSession creates a worktree and launches a pre-warmed Claude session for a design interview.
+func (m Model) launchDesignSession() (tea.Model, tea.Cmd) {
+	task := m.selectedAutopilotTask()
+	if task == nil {
+		m.autopilotMode = m.autopilotModeBeforeReview
+		return m, nil
+	}
+
+	sup := m.autopilotSupervisor
+	if sup == nil {
+		m.autopilotMode = m.autopilotModeBeforeReview
+		return m, nil
+	}
+
+	taskID := task.ID
+	issueNum := task.IssueNumber
+	m.autopilotMode = m.autopilotModeBeforeReview
+	m.autopilotStatus = fmt.Sprintf("Launching design interview for #%d...", issueNum)
+
+	return m, func() tea.Msg {
+		result, err := sup.DesignSession(context.Background(), taskID)
 		return reviewSessionResultMsg{result: result, err: err}
 	}
 }

--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// copyToClipboard writes text to the system clipboard.
+// Supports macOS (pbcopy), Linux/WSL (xclip, xsel, wl-copy), and Windows (clip.exe via WSL).
+func copyToClipboard(text string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "linux":
+		// Try clipboard commands in preference order:
+		// wl-copy (Wayland), xclip (X11), xsel (X11), clip.exe (WSL).
+		for _, candidate := range []struct {
+			name string
+			args []string
+		}{
+			{"wl-copy", nil},
+			{"xclip", []string{"-selection", "clipboard"}},
+			{"xsel", []string{"--clipboard", "--input"}},
+			{"clip.exe", nil}, // WSL
+		} {
+			if path, err := exec.LookPath(candidate.name); err == nil {
+				cmd = exec.Command(path, candidate.args...)
+				break
+			}
+		}
+	case "windows":
+		cmd = exec.Command("clip.exe")
+	}
+
+	if cmd == nil {
+		return exec.ErrNotFound
+	}
+
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
+}

--- a/internal/tui/deploy_viewer.go
+++ b/internal/tui/deploy_viewer.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -76,9 +75,7 @@ func (m DeployViewer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursor < len(m.tasks) {
 				t := m.tasks[m.cursor]
 				if t.WorktreePath != "" {
-					cmd := exec.Command("pbcopy")
-					cmd.Stdin = strings.NewReader(t.WorktreePath)
-					if err := cmd.Run(); err == nil {
+					if err := copyToClipboard(t.WorktreePath); err == nil {
 						m.flash = fmt.Sprintf("Copied: %s", t.WorktreePath)
 					} else {
 						m.flash = fmt.Sprintf("Copy failed: %v", err)

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1685,7 +1685,7 @@ func (m Model) computeHeightBudget() (analysisH, eventLogH, autopilotTaskH int) 
 		isRunning := m.autopilotMode == "running" || m.autopilotMode == "stop-confirm" ||
 			m.autopilotMode == "stop-task-confirm" || m.autopilotMode == "restart-confirm" ||
 			m.autopilotMode == "resume-or-restart-confirm" || m.autopilotMode == "review-confirm" ||
-			m.autopilotMode == "manual-confirm" || m.autopilotMode == "completed"
+			m.autopilotMode == "manual-confirm" || m.autopilotMode == "design-confirm" || m.autopilotMode == "completed"
 		if isRunning {
 			// Slot section.
 			if m.autopilotSupervisor != nil {
@@ -2120,6 +2120,18 @@ func (m Model) renderBottomBar() string {
 				issueNum = task.IssueNumber
 			}
 			b.WriteString(headerStyle().Render(fmt.Sprintf("  Spin off worktree for #%d? ", issueNum)))
+			b.WriteString(helpKeyStyle().Render("enter"))
+			b.WriteString(helpStyle().Render(": launch • "))
+			b.WriteString(helpKeyStyle().Render("esc"))
+			b.WriteString(helpStyle().Render(": cancel"))
+			b.WriteString("\n")
+		} else if m.activeTab == tabAutopilot && m.autopilotMode == "design-confirm" {
+			task := m.selectedAutopilotTask()
+			issueNum := 0
+			if task != nil {
+				issueNum = task.IssueNumber
+			}
+			b.WriteString(headerStyle().Render(fmt.Sprintf("  Launch design interview for #%d? ", issueNum)))
 			b.WriteString(helpKeyStyle().Render("enter"))
 			b.WriteString(helpStyle().Render(": launch • "))
 			b.WriteString(helpKeyStyle().Render("esc"))

--- a/internal/tui/logviewer.go
+++ b/internal/tui/logviewer.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -126,9 +125,7 @@ func (m *Model) copyLogPath() tea.Cmd {
 		return nil
 	}
 
-	cmd := exec.Command("pbcopy")
-	cmd.Stdin = strings.NewReader(m.logViewerTask.AgentLog)
-	if err := cmd.Run(); err != nil {
+	if err := copyToClipboard(m.logViewerTask.AgentLog); err != nil {
 		m.logViewerStatus = fmt.Sprintf("Copy failed: %v", err)
 	} else {
 		m.logViewerStatus = fmt.Sprintf("Copied: %s", m.logViewerTask.AgentLog)


### PR DESCRIPTION
## Summary

- **New designer agent**: Interactive design interview agent (`g` key on any autopilot task) for UX/UI deep dives, user flow analysis, edge case discovery, and scope decomposition. Outputs structured design plans as issue comments, can split issues.
- **Pre-fetched context for all sessions**: Review, manual, and design interactive sessions now inject issue comments, CLAUDE.md, project goal, and (for review) PR details + diff directly into the initial prompt — agents start ready for conversation instead of spending turns fetching.
- **Pre-fetched issue comments for automated agents**: Autopilot and reviewer agents get `gh issue view --comments` output injected into their prompts, saving a turn on every launch.
- **Cross-platform clipboard**: New `copyToClipboard()` utility supporting macOS (pbcopy), Linux (wl-copy/xclip/xsel), WSL (clip.exe), and Windows. Replaces all hardcoded `pbcopy` calls.
- **Auto-copy on banner dismiss**: When dismissing a session-ready notification with `d`, the `cd <path> && claude --resume <id>` command is copied to clipboard with a 3-second confirmation flash.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 19 packages)
- [x] Pre-commit hooks pass (fmt, build, lint)
- [ ] Manual test: launch designer session with `g` on a task, verify context is pre-loaded
- [ ] Manual test: launch review session with `r`, verify issue comments + PR diff in prompt
- [ ] Manual test: dismiss banner with `d`, verify clipboard contains resume command
- [ ] Manual test: verify `c` (copy worktree path) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)