### PR TITLE
Add design interview keybinding to help overlay

### DIFF
--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -2399,6 +2399,7 @@ var (
 		{"A", "stop all agents"},
 		{"S", "stop selected"},
 		{"r", "restart/review/spinoff"},
+		{"g", "design interview"},
 		{"b", "bump task limits"},
 		{"c", "copy worktree path"},
 		{"+", "add slot"},


### PR DESCRIPTION
## Summary

- Adds `g: design interview` to the autopilot tab help overlay (`?` key), between `r: restart/review/spinoff` and `b: bump task limits`

## Test plan

- [ ] Press `?` on autopilot tab, verify `g` appears in the hint list

🤖 Generated with [Claude Code](https://claude.com/claude-code)