### PR TITLE
Detect skip-label changes and reclassify autopilot tasks

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -1689,8 +1689,9 @@ func (s *Supervisor) Launch(ctx context.Context) {
 			case <-reviewCheckTicker.C:
 				s.checkReviewTasks(ctx)
 				s.checkManualTasks(ctx)
+				labelChanges := s.checkLabelChanges(ctx)
 				unblocked := s.unblockSatisfiedTasks()
-				if unblocked > 0 {
+				if unblocked > 0 || labelChanges > 0 {
 					s.fillSlots(ctx)
 				}
 			default:
@@ -3427,6 +3428,85 @@ func (s *Supervisor) checkManualTasks(ctx context.Context) int {
 	}
 
 	return promoted
+}
+
+// checkLabelChanges detects when labels change on tasks and reclassifies them.
+// - Manual tasks that lose the skip label → queued (so they get agent slots)
+// - Queued/blocked tasks that gain the skip label → manual
+// Returns the number of tasks reclassified.
+func (s *Supervisor) checkLabelChanges(ctx context.Context) int {
+	tasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return 0
+	}
+
+	matcher := newSkipMatcher(s.project.AutopilotSkipLabel)
+	ghClient := s.newGHClient()
+	reclassified := 0
+
+	for _, task := range tasks {
+		switch task.Status {
+		case "manual":
+			// Check if skip label was removed — task should become an agent task.
+			item, err := ghClient.FetchItem(ctx, task.Owner, task.Repo, task.IssueNumber)
+			if err != nil || item.State != "open" {
+				continue
+			}
+
+			isStillManual := matcher.matches(item.Labels) ||
+				hasLabel(item.Labels, "in-progress") ||
+				hasLabel(item.Labels, "needs-review") ||
+				hasLabel(item.Labels, "blocked")
+
+			if !isStillManual {
+				_ = s.store.UpdateAutopilotTaskStatus(task.ID, "queued")
+				_ = s.store.UpdateAutopilotTaskDeps(task.ID, "[]")
+				s.updateDepGraphEntry(task.IssueNumber, json.RawMessage("[]"))
+				s.emitEvent("info", fmt.Sprintf("Task #%d skip label removed — queued for agent work", task.IssueNumber), &task)
+				reclassified++
+			}
+
+		case "queued", "blocked":
+			// Check if skip label was added — task should become manual.
+			item, err := ghClient.FetchItem(ctx, task.Owner, task.Repo, task.IssueNumber)
+			if err != nil || item.State != "open" {
+				continue
+			}
+
+			shouldBeManual := matcher.matches(item.Labels)
+			if shouldBeManual {
+				_ = s.store.UpdateAutopilotTaskStatus(task.ID, "manual")
+				_ = s.store.UpdateAutopilotTaskDeps(task.ID, `"manual"`)
+				s.updateDepGraphEntry(task.IssueNumber, json.RawMessage(`"manual"`))
+				s.emitEvent("info", fmt.Sprintf("Task #%d skip label added — moved to manual", task.IssueNumber), &task)
+				reclassified++
+			}
+		}
+	}
+
+	return reclassified
+}
+
+// updateDepGraphEntry updates a single entry in the stored dependency graph.
+func (s *Supervisor) updateDepGraphEntry(issueNumber int, value json.RawMessage) {
+	dg, err := s.store.GetDepGraph(s.project.ID)
+	if err != nil || dg == nil {
+		return
+	}
+
+	var graph map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(dg.GraphJSON), &graph); err != nil {
+		return
+	}
+
+	graph[strconv.Itoa(issueNumber)] = value
+
+	updated, err := json.Marshal(graph)
+	if err != nil {
+		return
+	}
+
+	_ = s.store.SaveDepGraph(s.project.ID, string(updated), dg.OptionName)
 }
 
 func (s *Supervisor) inspectOutcome(ctx context.Context, task *db.AutopilotTask, exitCode int) string {

--- a/internal/autopilot/supervisor_coverage_test.go
+++ b/internal/autopilot/supervisor_coverage_test.go
@@ -5498,6 +5498,210 @@ func TestAutoMerge_HappyPath_MergesAndPromotes(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// checkLabelChanges — skip label removal/addition
+// ---------------------------------------------------------------------------
+
+func TestCheckLabelChanges_ManualToQueued(t *testing.T) {
+	// Simulate an issue that was manual (had no-agent label) but label was removed.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// PR lookup returns 404 (it's an issue, not a PR).
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pulls/"):
+			w.WriteHeader(404)
+			_, _ = fmt.Fprintf(w, `{"message":"Not Found"}`)
+
+		// Issue lookup — no skip label anymore.
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/issues/42"):
+			w.WriteHeader(200)
+			_, _ = fmt.Fprintf(w, `{"number":42,"title":"Design work","state":"open","labels":[{"name":"enhancement"}]}`)
+
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+
+	store := openTestStore(t)
+	project := createTestProject(t, store)
+	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "fake-token")
+	sup.ghClientFactory = func(token string) *ghpkg.Client {
+		return ghpkg.NewClientWithBaseURL(token, ts.URL+"/")
+	}
+
+	// Save a dep graph with #42 as manual.
+	_ = store.SaveDepGraph(project.ID, `{"42":"manual","10":[42]}`, "Conservative")
+
+	task := &db.AutopilotTask{
+		ProjectID:    project.ID,
+		Owner:        "owner",
+		Repo:         "repo",
+		IssueNumber:  42,
+		IssueTitle:   "Design work",
+		Dependencies: `"manual"`,
+		Status:       "manual",
+	}
+	if err := store.CreateAutopilotTask(task); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain events.
+	go func() {
+		for range sup.Events() {
+		}
+	}()
+
+	changed := sup.checkLabelChanges(context.Background())
+
+	if changed != 1 {
+		t.Errorf("checkLabelChanges = %d, want 1", changed)
+	}
+
+	// Verify task is now queued with empty deps.
+	tasks, _ := store.GetAutopilotTasks(project.ID)
+	for _, tk := range tasks {
+		if tk.IssueNumber == 42 {
+			if tk.Status != "queued" {
+				t.Errorf("task status = %q, want queued", tk.Status)
+			}
+			if tk.Dependencies != "[]" {
+				t.Errorf("task deps = %q, want []", tk.Dependencies)
+			}
+		}
+	}
+
+	// Verify dep graph updated.
+	dg, _ := store.GetDepGraph(project.ID)
+	if dg == nil {
+		t.Fatal("dep graph should exist")
+	}
+	if !strings.Contains(dg.GraphJSON, `"42":[]`) {
+		t.Errorf("dep graph should have 42:[], got %s", dg.GraphJSON)
+	}
+}
+
+func TestCheckLabelChanges_QueuedToManual(t *testing.T) {
+	// Simulate a queued task that gains the no-agent label.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pulls/"):
+			w.WriteHeader(404)
+			_, _ = fmt.Fprintf(w, `{"message":"Not Found"}`)
+
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/issues/10"):
+			w.WriteHeader(200)
+			_, _ = fmt.Fprintf(w, `{"number":10,"title":"Some task","state":"open","labels":[{"name":"no-agent"},{"name":"enhancement"}]}`)
+
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+
+	store := openTestStore(t)
+	project := createTestProject(t, store)
+	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "fake-token")
+	sup.ghClientFactory = func(token string) *ghpkg.Client {
+		return ghpkg.NewClientWithBaseURL(token, ts.URL+"/")
+	}
+
+	_ = store.SaveDepGraph(project.ID, `{"10":[]}`, "Conservative")
+
+	task := &db.AutopilotTask{
+		ProjectID:    project.ID,
+		Owner:        "owner",
+		Repo:         "repo",
+		IssueNumber:  10,
+		IssueTitle:   "Some task",
+		Dependencies: "[]",
+		Status:       "queued",
+	}
+	if err := store.CreateAutopilotTask(task); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		for range sup.Events() {
+		}
+	}()
+
+	changed := sup.checkLabelChanges(context.Background())
+
+	if changed != 1 {
+		t.Errorf("checkLabelChanges = %d, want 1", changed)
+	}
+
+	tasks, _ := store.GetAutopilotTasks(project.ID)
+	for _, tk := range tasks {
+		if tk.IssueNumber == 10 {
+			if tk.Status != "manual" {
+				t.Errorf("task status = %q, want manual", tk.Status)
+			}
+		}
+	}
+}
+
+func TestCheckLabelChanges_StillManual(t *testing.T) {
+	// Issue still has the no-agent label — no change.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pulls/"):
+			w.WriteHeader(404)
+			_, _ = fmt.Fprintf(w, `{"message":"Not Found"}`)
+
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/issues/42"):
+			w.WriteHeader(200)
+			_, _ = fmt.Fprintf(w, `{"number":42,"title":"Manual work","state":"open","labels":[{"name":"no-agent"}]}`)
+
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+
+	store := openTestStore(t)
+	project := createTestProject(t, store)
+	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "fake-token")
+	sup.ghClientFactory = func(token string) *ghpkg.Client {
+		return ghpkg.NewClientWithBaseURL(token, ts.URL+"/")
+	}
+
+	task := &db.AutopilotTask{
+		ProjectID:    project.ID,
+		Owner:        "owner",
+		Repo:         "repo",
+		IssueNumber:  42,
+		IssueTitle:   "Manual work",
+		Dependencies: `"manual"`,
+		Status:       "manual",
+	}
+	if err := store.CreateAutopilotTask(task); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		for range sup.Events() {
+		}
+	}()
+
+	changed := sup.checkLabelChanges(context.Background())
+
+	if changed != 0 {
+		t.Errorf("checkLabelChanges = %d, want 0 (still has skip label)", changed)
+	}
+}
+
+func TestCheckLabelChanges_NoTasks(t *testing.T) {
+	store := openTestStore(t)
+	project := createTestProject(t, store)
+	sup := New(store, project, nil, "/tmp/repo", "owner", "repo", "fake-token")
+
+	changed := sup.checkLabelChanges(context.Background())
+	if changed != 0 {
+		t.Errorf("checkLabelChanges = %d, want 0 (no tasks)", changed)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `checkLabelChanges()` to the 30s ticker loop that detects when the skip label (`no-agent`) is added/removed from issues
- Manual tasks that lose the skip label transition to "queued" and get picked up for agent work
- Queued/blocked tasks that gain the skip label transition to "manual"
- Stored dep graph is patched inline to stay consistent

Closes #283

## Test plan
- [x] `TestCheckLabelChanges_ManualToQueued` — skip label removed → task queued, dep graph updated
- [x] `TestCheckLabelChanges_QueuedToManual` — skip label added → task becomes manual
- [x] `TestCheckLabelChanges_StillManual` — no change when label still present
- [x] `TestCheckLabelChanges_NoTasks` — no-op with empty task list
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)