### PR TITLE
Wire headless analysis poller into deploy daemon

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strconv"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/dustinlange/agent-minder/internal/discovery"
 	gitpkg "github.com/dustinlange/agent-minder/internal/git"
 	ghpkg "github.com/dustinlange/agent-minder/internal/github"
+	"github.com/dustinlange/agent-minder/internal/poller"
 	"github.com/spf13/cobra"
 )
 
@@ -435,6 +437,10 @@ func runDeployDaemon() error {
 	completer := claudecli.NewCLICompleter()
 	supervisor := autopilot.New(store, project, completer, repoDir, owner, repo, ghToken)
 
+	// Create analysis poller (publisher nil — bus publishing optional in daemon mode).
+	analysisPoller := poller.New(store, project, completer, nil)
+	analysisPoller.SetAutopilotDepGraphFunc(supervisor.DepGraph)
+
 	// Signal handling.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -448,8 +454,27 @@ func runDeployDaemon() error {
 		cancel()
 	}()
 
+	// Start the analysis poller (runs status polls on timer, analysis on-demand).
+	analysisPoller.Start(ctx)
+	defer analysisPoller.Stop()
+
 	// Launch — tasks are already queued with empty deps, so they'll fill immediately.
 	supervisor.Launch(ctx)
+
+	// In-progress guard for on-demand analysis trigger.
+	var pollInProgress atomic.Bool
+	triggerPoll := func() error {
+		if !pollInProgress.CompareAndSwap(false, true) {
+			return fmt.Errorf("analysis already in progress")
+		}
+		go func() {
+			defer pollInProgress.Store(false)
+			log.Printf("On-demand analysis poll triggered via API")
+			analysisPoller.PollNow(ctx)
+			log.Printf("On-demand analysis poll completed")
+		}()
+		return nil
+	}
 
 	// Start HTTP API server if --serve is set.
 	var apiServer *api.Server
@@ -463,11 +488,12 @@ func runDeployDaemon() error {
 			apiKeyVal = os.Getenv("MINDER_API_KEY")
 		}
 		apiServer = api.New(api.Config{
-			Store:     store,
-			ProjectID: project.ID,
-			DeployID:  deployID,
-			APIKey:    apiKeyVal,
-			BindAddr:  serveAddr,
+			Store:       store,
+			ProjectID:   project.ID,
+			DeployID:    deployID,
+			APIKey:      apiKeyVal,
+			BindAddr:    serveAddr,
+			TriggerPoll: triggerPoll,
 			StopDaemon: func() {
 				log.Printf("Stop requested via API")
 				supervisor.Stop()
@@ -483,10 +509,17 @@ func runDeployDaemon() error {
 		}()
 	}
 
-	// Drain events to log.
+	// Drain supervisor events to log.
 	go func() {
 		for evt := range supervisor.Events() {
 			log.Printf("[%s] %s", evt.Type, evt.Summary)
+		}
+	}()
+
+	// Drain poller events to log.
+	go func() {
+		for evt := range analysisPoller.Events() {
+			log.Printf("[analysis/%s] %s", evt.Type, evt.Summary)
 		}
 	}()
 

--- a/cmd/deploy_analyze.go
+++ b/cmd/deploy_analyze.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dustinlange/agent-minder/internal/api"
+	"github.com/spf13/cobra"
+)
+
+var deployAnalyzeCmd = &cobra.Command{
+	Use:   "analyze",
+	Short: "Trigger on-demand LLM analysis of the deployment",
+	Long: `Trigger an on-demand LLM analysis poll on a remote deploy daemon.
+The analysis gathers current git activity, tracked items, and autopilot state,
+then runs the analyzer LLM to produce an intelligent briefing.
+
+Requires --remote (or MINDER_REMOTE) to connect to the daemon.`,
+	Example: `  # Trigger analysis and wait for result
+  agent-minder deploy analyze --remote vps:7749
+
+  # Just trigger (don't wait)
+  agent-minder deploy analyze --remote vps:7749 --no-wait
+
+  # Show recent analysis results without triggering
+  agent-minder deploy analyze --remote vps:7749 --history`,
+	RunE: runDeployAnalyze,
+}
+
+var (
+	analyzeNoWait  bool
+	analyzeHistory bool
+)
+
+func init() {
+	deployCmd.AddCommand(deployAnalyzeCmd)
+	deployAnalyzeCmd.Flags().BoolVar(&analyzeNoWait, "no-wait", false, "Trigger analysis without waiting for result")
+	deployAnalyzeCmd.Flags().BoolVar(&analyzeHistory, "history", false, "Show recent analysis results without triggering a new one")
+}
+
+func runDeployAnalyze(_ *cobra.Command, _ []string) error {
+	client := remoteClient()
+	if client == nil {
+		return fmt.Errorf("--remote (or MINDER_REMOTE) required for deploy analyze")
+	}
+
+	// History-only mode: just show recent results.
+	if analyzeHistory {
+		return showAnalysisResults(client)
+	}
+
+	// Trigger a new analysis poll.
+	if err := client.TriggerPoll(); err != nil {
+		if strings.Contains(err.Error(), "409") || strings.Contains(err.Error(), "conflict") {
+			fmt.Println("Analysis already in progress — use --history to check results.")
+			return nil
+		}
+		return fmt.Errorf("trigger analysis: %w", err)
+	}
+
+	if analyzeNoWait {
+		fmt.Println("Analysis triggered. Check results with: deploy analyze --history --remote ...")
+		return nil
+	}
+
+	// Poll for results — the analysis typically takes 30-60s.
+	fmt.Print("Analysis triggered, waiting for result")
+	startTime := time.Now()
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		fmt.Print(".")
+		results, err := client.GetAnalysis(1)
+		if err != nil {
+			continue
+		}
+		if len(results) > 0 {
+			polledAt, err := time.Parse("2006-01-02 15:04:05", results[0].PolledAt)
+			if err == nil && polledAt.After(startTime.Add(-2*time.Second)) {
+				fmt.Println()
+				printAnalysisResult(results[0])
+				return nil
+			}
+		}
+		// Timeout after 3 minutes.
+		if time.Since(startTime) > 3*time.Minute {
+			fmt.Println()
+			fmt.Println("Timed out waiting for analysis. Check results with: deploy analyze --history --remote ...")
+			return nil
+		}
+	}
+	return nil
+}
+
+func showAnalysisResults(client *api.Client) error {
+	results, err := client.GetAnalysis(5)
+	if err != nil {
+		return fmt.Errorf("get analysis: %w", err)
+	}
+	if len(results) == 0 {
+		fmt.Println("No analysis results yet. Trigger one with: deploy analyze --remote ...")
+		return nil
+	}
+
+	for i, r := range results {
+		if i > 0 {
+			fmt.Println(strings.Repeat("─", 60))
+		}
+		printAnalysisResult(r)
+	}
+	return nil
+}
+
+func printAnalysisResult(r api.AnalysisResponse) {
+	fmt.Printf("Analysis at %s\n", r.PolledAt)
+	if r.NewCommits > 0 || r.NewMessages > 0 {
+		fmt.Printf("  Activity: %d commits, %d messages\n", r.NewCommits, r.NewMessages)
+	}
+	if r.Analysis != "" {
+		fmt.Println()
+		fmt.Println(r.Analysis)
+	} else {
+		fmt.Println("  (no analysis text)")
+	}
+	fmt.Println()
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -102,6 +102,35 @@ func (c *Client) GetTask(id string) (*TaskResponse, error) {
 	return &resp, nil
 }
 
+// AnalysisResponse represents a single poll result from GET /analysis.
+type AnalysisResponse struct {
+	ID             int64  `json:"id"`
+	NewCommits     int    `json:"new_commits"`
+	NewMessages    int    `json:"new_messages"`
+	ConcernsRaised int    `json:"concerns_raised"`
+	Analysis       string `json:"analysis"`
+	BusMessageSent bool   `json:"bus_message_sent"`
+	PolledAt       string `json:"polled_at"`
+}
+
+// TriggerPoll calls POST /analysis/poll on the remote daemon to trigger an on-demand analysis.
+func (c *Client) TriggerPoll() error {
+	return c.post("/analysis/poll", nil)
+}
+
+// GetAnalysis calls GET /analysis on the remote daemon.
+func (c *Client) GetAnalysis(limit int) ([]AnalysisResponse, error) {
+	path := "/analysis"
+	if limit > 0 {
+		path = fmt.Sprintf("/analysis?limit=%d", limit)
+	}
+	var resp []AnalysisResponse
+	if err := c.get(path, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // Stop calls POST /stop on the remote daemon to initiate graceful shutdown.
 func (c *Client) Stop() error {
 	return c.post("/stop", nil)

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -148,3 +148,85 @@ func TestClient_ServerError(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, err.Error())
 	}
 }
+
+func TestClient_TriggerPoll(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/analysis/poll" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"poll triggered"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "")
+	err := client.TriggerPoll()
+	if err != nil {
+		t.Fatalf("TriggerPoll: %v", err)
+	}
+	if !called {
+		t.Error("trigger handler was not called")
+	}
+}
+
+func TestClient_TriggerPoll_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(errorResponse{"conflict", "analysis already in progress"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "")
+	err := client.TriggerPoll()
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	expected := "remote error (409): analysis already in progress"
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestClient_GetAnalysis(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/analysis" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("limit") != "3" {
+			t.Errorf("expected limit=3, got %s", r.URL.Query().Get("limit"))
+		}
+		results := []AnalysisResponse{
+			{
+				ID:         1,
+				NewCommits: 5,
+				Analysis:   "All systems nominal",
+				PolledAt:   "2026-03-24 12:00:00",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(results)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "")
+	results, err := client.GetAnalysis(3)
+	if err != nil {
+		t.Fatalf("GetAnalysis: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Analysis != "All systems nominal" {
+		t.Errorf("unexpected analysis: %s", results[0].Analysis)
+	}
+	if results[0].NewCommits != 5 {
+		t.Errorf("expected 5 commits, got %d", results[0].NewCommits)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -28,8 +28,9 @@ type Server struct {
 	srv       *http.Server
 
 	// triggerPoll is called to trigger a manual analysis poll cycle.
+	// Returns an error if a poll is already in progress.
 	// May be nil if not wired up.
-	triggerPoll func()
+	triggerPoll func() error
 
 	// stopDaemon is called to initiate graceful daemon shutdown.
 	// May be nil if not wired up.
@@ -51,7 +52,7 @@ type Config struct {
 	DeployID       string
 	APIKey         string
 	BindAddr       string
-	TriggerPoll    func()
+	TriggerPoll    func() error
 	StopDaemon     func()
 	BudgetResume   func()
 	IsBudgetPaused func() bool
@@ -370,7 +371,10 @@ func (s *Server) handleTriggerPoll(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusNotImplemented, errorResponse{"not_implemented", "poll trigger not wired up"})
 		return
 	}
-	s.triggerPoll()
+	if err := s.triggerPoll(); err != nil {
+		writeJSON(w, http.StatusConflict, errorResponse{"conflict", err.Error()})
+		return
+	}
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "poll triggered"})
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -337,7 +338,7 @@ func TestTriggerPoll_Wired(t *testing.T) {
 		ProjectID:   project.ID,
 		DeployID:    "poll-deploy",
 		APIKey:      "",
-		TriggerPoll: func() { triggered = true },
+		TriggerPoll: func() error { triggered = true; return nil },
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/analysis/poll", nil)
@@ -349,6 +350,44 @@ func TestTriggerPoll_Wired(t *testing.T) {
 	}
 	if !triggered {
 		t.Error("expected triggerPoll to be called")
+	}
+}
+
+func TestTriggerPoll_InProgress(t *testing.T) {
+	store := openTestDB(t)
+	project := &db.Project{
+		Name:                "poll-busy",
+		IsDeploy:            true,
+		GoalType:            "deploy",
+		RefreshIntervalSec:  300,
+		StatusIntervalSec:   300,
+		AnalysisIntervalSec: 1800,
+	}
+	if err := store.CreateProject(project); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	srv := New(Config{
+		Store:     store,
+		ProjectID: project.ID,
+		DeployID:  "poll-busy",
+		APIKey:    "",
+		TriggerPoll: func() error {
+			return fmt.Errorf("analysis already in progress")
+		},
+	})
+
+	rr := doRequest(t, srv, http.MethodPost, "/analysis/poll")
+	if rr.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", rr.Code)
+	}
+
+	var resp errorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Error != "conflict" {
+		t.Errorf("expected error 'conflict', got %q", resp.Error)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #283

- Wire the existing `Poller` into `runDeployDaemon()` alongside the autopilot supervisor — status polls run on a timer to keep tracked items fresh (no LLM cost), LLM analysis is on-demand only
- `POST /analysis/poll` now triggers async analysis with an atomic in-progress guard (returns 409 if already running)
- `TriggerPoll` callback signature changed from `func()` to `func() error` to support conflict reporting
- Add `deploy analyze` CLI subcommand with `--no-wait` (fire-and-forget) and `--history` (show recent results) flags
- Add `TriggerPoll()` and `GetAnalysis()` client methods with `AnalysisResponse` type

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New server test: `TestTriggerPoll_InProgress` verifies 409 conflict response
- [x] New client tests: `TestClient_TriggerPoll`, `TestClient_TriggerPoll_Conflict`, `TestClient_GetAnalysis`
- [ ] Manual: `deploy analyze --remote <addr>` triggers analysis and waits for result
- [ ] Manual: concurrent `POST /analysis/poll` returns 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)