### PR TITLE
Fix review session to use reviewer agent def and include PR comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Review session uses reviewer agent def and PR context**: The `r` (review session) command now launches Claude with `--agent reviewer` and includes PR body and comments in the initial prompt, matching the automated review path. Previously the session used no agent definition and omitted PR comments. (#348)
 - **Max turns fallback detection**: When an agent's stream-json result event is missing (nil result), the supervisor now counts assistant events from the log file to detect turn limit exhaustion. Previously these agents were misclassified as "bailed" instead of "failed" with reason "max_turns". (#340)
 - **Autopilot settings display**: Settings panel and autopilot confirm screen now show effective defaults (150 turns, $10.00 budget) instead of raw DB zeros when no override is configured. Bumped default fallbacks from 50→150 turns and $3.00→$10.00. (#341)
 - **Worktree preserved until PR merge**: Worktrees for review tasks are no longer deleted immediately when the agent posts a PR. They are now cleaned up only when the task reaches `done` (PR merged), preventing disruption to users with active terminal sessions in the worktree. (#342)

--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -681,7 +681,7 @@ func renderManualSessionPrompt(task *db.AutopilotTask, owner, repo, projectGoal 
 
 // renderReviewSessionPrompt builds a prompt for an interactive review session.
 // All context is pre-loaded so the agent starts ready for conversation.
-func renderReviewSessionPrompt(task *db.AutopilotTask, owner, repo, projectGoal string, rw *relatedWork, issueComments, prDetails, prDiff, claudeMD string) string {
+func renderReviewSessionPrompt(task *db.AutopilotTask, owner, repo, projectGoal string, rw *relatedWork, issueComments, prDetails, prComments, prDiff, claudeMD string) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "You are starting a review session for PR #%d (issue #%d) in %s/%s.\n", task.PRNumber, task.IssueNumber, owner, repo)
@@ -704,6 +704,12 @@ func renderReviewSessionPrompt(task *db.AutopilotTask, owner, repo, projectGoal 
 	if prDetails != "" {
 		fmt.Fprintf(&b, "## PR #%d Details\n\n", task.PRNumber)
 		b.WriteString(prDetails)
+		b.WriteString("\n\n")
+	}
+
+	if prComments != "" {
+		fmt.Fprintf(&b, "## PR #%d Comments\n\n", task.PRNumber)
+		b.WriteString(prComments)
 		b.WriteString("\n\n")
 	}
 

--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -268,9 +268,15 @@ func (s *Supervisor) ReviewSession(ctx context.Context, taskID int64) (*ReviewSe
 		}
 	}
 
+	// Ensure the reviewer agent definition exists so --agent reviewer works.
+	if _, err := ensureAgentDefByName(task.WorktreePath, AgentReviewer); err != nil {
+		return nil, fmt.Errorf("resolve reviewer agent def: %w", err)
+	}
+
 	// Pre-fetch all context so the agent starts ready for conversation.
 	issueComments := s.fetchIssueComments(ctx, task.IssueNumber, task.WorktreePath)
 	prDetails := s.fetchPRDetails(ctx, task.PRNumber, task.WorktreePath)
+	prComments := s.fetchPRComments(ctx, task.PRNumber, task.WorktreePath)
 	prDiff := s.fetchPRDiff(ctx, task.PRNumber, task.WorktreePath)
 	claudeMD := s.readClaudeMD(task.WorktreePath)
 
@@ -285,10 +291,11 @@ func (s *Supervisor) ReviewSession(ctx context.Context, taskID int64) (*ReviewSe
 		rw.siblingTasks = tasks
 	}
 
-	prompt := renderReviewSessionPrompt(task, s.owner, s.repo, s.project.GoalDescription, rw, issueComments, prDetails, prDiff, claudeMD)
+	prompt := renderReviewSessionPrompt(task, s.owner, s.repo, s.project.GoalDescription, rw, issueComments, prDetails, prComments, prDiff, claudeMD)
 
 	allowedTools := resolveAllowedTools(s.repoDir)
 	args := []string{
+		"--agent", "reviewer",
 		"-p",
 		"--output-format", "stream-json",
 		"--verbose",
@@ -648,6 +655,21 @@ func (s *Supervisor) fetchPRDiff(ctx context.Context, prNumber int, workDir stri
 	out, err := cmd.Output()
 	if err != nil {
 		debugLog("review-session: fetch PR diff", "error", err, "pr", prNumber)
+		return ""
+	}
+	return string(out)
+}
+
+// fetchPRComments shells out to gh to get PR comments (both review comments and conversation).
+// Returns empty string on any error — the review session still works, just with less context.
+func (s *Supervisor) fetchPRComments(ctx context.Context, prNumber int, workDir string) string {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", strconv.Itoa(prNumber),
+		"--comments", "-R", s.owner+"/"+s.repo)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+s.ghToken)
+	out, err := cmd.Output()
+	if err != nil {
+		debugLog("review-session: fetch PR comments", "error", err, "pr", prNumber)
 		return ""
 	}
 	return string(out)


### PR DESCRIPTION
The r (review session) command now launches Claude with --agent reviewer and includes PR comments in the initial prompt. Fixes #348