### PR TITLE
Add watch filter settings, fix empty carousel and poll interval

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -929,11 +929,21 @@ func (s *Supervisor) Prepare(ctx context.Context, guidance string) (*PrepareResu
 		return nil, fmt.Errorf("get existing tasks: %w", err)
 	}
 
-	if len(existingTasks) > 0 {
+	// Only consider non-terminal tasks as "existing" — done/removed/skipped
+	// are effectively cleared and shouldn't trigger the reprepare flow.
+	hasNonTerminal := false
+	for _, t := range existingTasks {
+		if t.Status != "done" && t.Status != "removed" && t.Status != "skipped" {
+			hasNonTerminal = true
+			break
+		}
+	}
+
+	if hasNonTerminal {
 		return s.prepareWithExisting(ctx, existingTasks, agentDef)
 	}
 
-	// No existing tasks — fresh prepare.
+	// No active tasks — fresh prepare.
 	return s.prepareFresh(ctx, guidance, agentDef)
 }
 
@@ -1013,6 +1023,20 @@ func (s *Supervisor) prepareFresh(ctx context.Context, guidance string, agentDef
 			return nil, fmt.Errorf("convert tracked items: %w", err)
 		}
 		tasks = converted
+	}
+
+	// If still no tasks and a watch filter is configured, poll now to discover issues.
+	if len(tasks) == 0 && s.project.AutopilotFilterType != "" && s.project.AutopilotFilterValue != "" {
+		discovered := s.watchPoll(ctx)
+		if discovered > 0 {
+			freshTasks, _ := s.store.GetAutopilotTasks(s.project.ID)
+			tasks = make([]*db.AutopilotTask, 0, len(freshTasks))
+			for i := range freshTasks {
+				if freshTasks[i].Status != "removed" {
+					tasks = append(tasks, &freshTasks[i])
+				}
+			}
+		}
 	}
 
 	if len(tasks) == 0 {
@@ -1704,11 +1728,7 @@ func (s *Supervisor) Launch(ctx context.Context) {
 		defer reviewCheckTicker.Stop()
 
 		// Watch ticker: polls GitHub for new issues matching the project's filter.
-		// Uses the project's refresh interval (default 2 min) as the watch poll interval.
-		watchInterval := s.project.RefreshInterval()
-		if watchInterval < 60*time.Second {
-			watchInterval = 60 * time.Second
-		}
+		watchInterval := 2 * time.Minute
 		watchTicker := time.NewTicker(watchInterval)
 		defer watchTicker.Stop()
 		// Do an initial watch poll right away if a filter is configured.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -993,6 +993,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case filterWatchSetMsg:
+		if msg.err != nil {
+			m.filterStatus = fmt.Sprintf("Error setting watch: %v", msg.err)
+		} else {
+			m.filterStatus = fmt.Sprintf("Watching %s: %s", msg.filterType, msg.filterValue)
+		}
+		return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return clearFilterStatusMsg{}
+		})
+
 	case filterSearchResultMsg:
 		if m.filterState != nil {
 			if msg.err != nil {
@@ -1033,6 +1043,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case clearFilterStatusMsg:
 		m.filterStatus = ""
+		return m, nil
+
+	case settingsWatchChoicesMsg:
+		if m.settingsState != nil {
+			if msg.err != nil {
+				m.settingsState.err = fmt.Sprintf("Fetch failed: %v", msg.err)
+				m.settingsState.step = settingsStepWatchType
+			} else if len(msg.choices) == 0 {
+				m.settingsState.err = "No choices found"
+				m.settingsState.step = settingsStepWatchType
+			} else {
+				m.settingsState.watchChoices = msg.choices
+				m.settingsState.watchIdx = 0
+				m.settingsState.step = settingsStepWatchChoice
+			}
+		}
 		return m, nil
 
 	case settingsSavedMsg:

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2132,8 +2132,8 @@ func TestNewSettingsState_DefaultFields(t *testing.T) {
 	if ss.fieldIdx != 0 {
 		t.Errorf("fieldIdx = %d, want 0", ss.fieldIdx)
 	}
-	if len(ss.fields) != 10 {
-		t.Errorf("fields count = %d, want 10", len(ss.fields))
+	if len(ss.fields) != 11 {
+		t.Errorf("fields count = %d, want 11", len(ss.fields))
 	}
 	// Check first field.
 	if ss.fields[0].label != "Sync interval" {

--- a/internal/tui/filter.go
+++ b/internal/tui/filter.go
@@ -19,6 +19,7 @@ const (
 	filterStepSelectType
 	filterStepFetchingChoices
 	filterStepSelectChoice
+	filterStepWatchOrAdd // choose between setting watch filter vs one-shot add
 	filterStepInputValue
 	filterStepFetching
 	filterStepPreview
@@ -61,8 +62,10 @@ type filterState struct {
 	results      *ghpkg.SearchResult
 	choices      []ghpkg.RepoChoice // available choices for the selected filter type
 	choiceIdx    int                // currently highlighted choice
+	selectedID   int                // ID of the selected choice (for milestone API)
 	typeIdx      int                // currently highlighted filter type (0=label, 1=milestone, 2=project, 3=assignee)
 	conflictIdx  int                // currently highlighted conflict option (0=update, 1=append, 2=clear)
+	watchAddIdx  int                // 0=watch, 1=add issues
 	input        textinput.Model
 	err          error
 	hasExisting  bool // true if project already has tracked items
@@ -107,6 +110,8 @@ func (m Model) updateFilter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.updateFilterSelectType(msg)
 	case filterStepSelectChoice:
 		return m.updateFilterSelectChoice(msg)
+	case filterStepWatchOrAdd:
+		return m.updateFilterWatchOrAdd(msg)
 	case filterStepInputValue:
 		return m.updateFilterInputValue(msg)
 	case filterStepPreview:
@@ -226,31 +231,21 @@ func (m Model) updateFilterSelectChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		return m, nil
 	case "enter":
 		if fs.choiceIdx < len(fs.choices) {
-			// Selected an existing choice — use it directly.
+			// Selected an existing choice — stash it.
 			choice := fs.choices[fs.choiceIdx]
 			fs.filterValue = choice.Value
-			fs.step = filterStepFetching
+			fs.selectedID = choice.ID
 			fs.err = nil
 
-			p := m.poller
-			owner := fs.selectedRepo.Owner
-			repo := fs.selectedRepo.Repo
-			ft := fs.filterType
-			fv := fs.filterValue
-			choiceID := choice.ID
-
-			return m, func() tea.Msg {
-				var result *ghpkg.SearchResult
-				var err error
-				if ft == ghpkg.FilterMilestone && choiceID > 0 {
-					// Use Issues API with milestone number to avoid search query
-					// syntax issues with special characters in milestone titles.
-					result, err = p.SearchIssuesByMilestone(context.Background(), owner, repo, choiceID)
-				} else {
-					result, err = p.SearchGitHubIssues(context.Background(), owner, repo, ft, fv)
-				}
-				return filterSearchResultMsg{results: result, err: err}
+			// For label/milestone, offer watch vs one-shot add.
+			if fs.filterType == ghpkg.FilterLabel || fs.filterType == ghpkg.FilterMilestone {
+				fs.step = filterStepWatchOrAdd
+				fs.watchAddIdx = 0
+				return m, nil
 			}
+
+			// Other types (project, assignee): go straight to fetch.
+			return m.filterDoFetch()
 		}
 		// "Type custom value" option selected — go to text input.
 		fs.step = filterStepInputValue
@@ -264,6 +259,75 @@ func (m Model) updateFilterSelectChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		}
 		cmd := fs.input.Focus()
 		return m, cmd
+	}
+	return m, nil
+}
+
+// filterWatchSetMsg is sent when a watch filter is saved from the filter flow.
+type filterWatchSetMsg struct {
+	filterType  string
+	filterValue string
+	err         error
+}
+
+// filterDoFetch starts the async issue search for the selected filter.
+func (m Model) filterDoFetch() (tea.Model, tea.Cmd) {
+	fs := m.filterState
+	fs.step = filterStepFetching
+	fs.err = nil
+
+	p := m.poller
+	owner := fs.selectedRepo.Owner
+	repo := fs.selectedRepo.Repo
+	ft := fs.filterType
+	fv := fs.filterValue
+	choiceID := fs.selectedID
+
+	return m, func() tea.Msg {
+		var result *ghpkg.SearchResult
+		var err error
+		if ft == ghpkg.FilterMilestone && choiceID > 0 {
+			result, err = p.SearchIssuesByMilestone(context.Background(), owner, repo, choiceID)
+		} else {
+			result, err = p.SearchGitHubIssues(context.Background(), owner, repo, ft, fv)
+		}
+		return filterSearchResultMsg{results: result, err: err}
+	}
+}
+
+func (m Model) updateFilterWatchOrAdd(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	fs := m.filterState
+	switch msg.String() {
+	case "esc":
+		fs.step = filterStepSelectChoice
+		return m, nil
+	case "up", "k":
+		if fs.watchAddIdx > 0 {
+			fs.watchAddIdx--
+		}
+		return m, nil
+	case "down", "j":
+		if fs.watchAddIdx < 1 {
+			fs.watchAddIdx++
+		}
+		return m, nil
+	case "enter":
+		if fs.watchAddIdx == 0 {
+			// Watch: save as project watch filter and exit.
+			filterType := string(fs.filterType)
+			filterValue := fs.filterValue
+			m.project.AutopilotFilterType = filterType
+			m.project.AutopilotFilterValue = filterValue
+			m.mode = "normal"
+			m.filterState = nil
+			m.resizeViewports()
+			return m, func() tea.Msg {
+				err := m.store.UpdateProject(m.project)
+				return filterWatchSetMsg{filterType: filterType, filterValue: filterValue, err: err}
+			}
+		}
+		// Add issues: proceed with the normal fetch flow.
+		return m.filterDoFetch()
 	}
 	return m, nil
 }
@@ -500,6 +564,27 @@ func (m Model) renderFilterView() string {
 			b.WriteString(mutedStyle().Render(customEntry))
 		}
 		b.WriteString("\n")
+
+	case filterStepWatchOrAdd:
+		b.WriteString(textStyle().Render(fmt.Sprintf("  %s: %s", fs.filterType, fs.filterValue)))
+		b.WriteString("\n\n")
+		watchOrAddOptions := []string{
+			"Watch — auto-discover new issues matching this filter",
+			"Add issues — one-time bulk add of current matches",
+		}
+		for i, opt := range watchOrAddOptions {
+			prefix := "    "
+			if i == fs.watchAddIdx {
+				prefix = "  > "
+			}
+			entry := prefix + opt
+			if i == fs.watchAddIdx {
+				b.WriteString(headerStyle().Render(entry))
+			} else {
+				b.WriteString(textStyle().Render(entry))
+			}
+			b.WriteString("\n")
+		}
 
 	case filterStepInputValue:
 		b.WriteString(textStyle().Render(fmt.Sprintf("  Repo: %s/%s  Filter: %s", fs.selectedRepo.Owner, fs.selectedRepo.Repo, fs.filterType)))

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/dustinlange/agent-minder/internal/db"
 	gitpkg "github.com/dustinlange/agent-minder/internal/git"
+	ghpkg "github.com/dustinlange/agent-minder/internal/github"
 	"github.com/dustinlange/agent-minder/internal/poller"
 )
 
@@ -20,6 +22,9 @@ const (
 	settingsStepSelectField settingsStep = iota
 	settingsStepEditValue
 	settingsStepEditTextarea
+	settingsStepWatchType   // selecting none/label/milestone
+	settingsStepWatchFetch  // fetching choices from GitHub
+	settingsStepWatchChoice // selecting a specific label/milestone
 )
 
 // settingsField represents a configurable project setting.
@@ -64,6 +69,24 @@ type settingsState struct {
 	input    textinput.Model
 	textarea textarea.Model
 	err      string
+
+	// Watch filter sub-flow state.
+	watchTypeIdx int                // 0=none, 1=label, 2=milestone
+	watchChoices []ghpkg.RepoChoice // fetched choices for selected type
+	watchIdx     int                // selected choice index
+}
+
+// settingsWatchChoicesMsg is sent when watch filter choices are fetched.
+type settingsWatchChoicesMsg struct {
+	choices []ghpkg.RepoChoice
+	err     error
+}
+
+// Watch type options for the settings sub-flow.
+var watchTypeLabels = []string{"none", "label", "milestone"}
+var watchTypeToFilter = map[string]string{
+	"label":     "label",
+	"milestone": "milestone",
 }
 
 // settingsSavedMsg is sent when settings are persisted.
@@ -160,8 +183,21 @@ func newSettingsState(project *db.Project) *settingsState {
 				value:       boolOnOff(project.AutopilotAutoMerge),
 				toggle:      true,
 			},
+			{
+				label:       "Watch filter",
+				description: "Auto-discover issues by label or milestone",
+				value:       watchFilterDisplay(project.AutopilotFilterType, project.AutopilotFilterValue),
+			},
 		},
 	}
+}
+
+// watchFilterDisplay returns a human-readable display string for the watch filter.
+func watchFilterDisplay(filterType, filterValue string) string {
+	if filterType == "" || filterValue == "" {
+		return "none"
+	}
+	return filterType + ": " + filterValue
 }
 
 // updateSettings handles keypresses for the settings mode.
@@ -179,6 +215,16 @@ func (m Model) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.updateSettingsEditValue(msg)
 	case settingsStepEditTextarea:
 		return m.updateSettingsEditTextarea(msg)
+	case settingsStepWatchType:
+		return m.updateSettingsWatchType(msg)
+	case settingsStepWatchFetch:
+		// Waiting for async fetch — ignore keys except esc.
+		if msg.String() == "esc" {
+			ss.step = settingsStepSelectField
+		}
+		return m, nil
+	case settingsStepWatchChoice:
+		return m.updateSettingsWatchChoice(msg)
 	}
 
 	return m, nil
@@ -206,6 +252,11 @@ func (m Model) updateSettingsSelectField(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 	case "enter":
 		field := ss.fields[ss.fieldIdx]
 		ss.err = ""
+		if field.label == "Watch filter" {
+			ss.step = settingsStepWatchType
+			ss.watchTypeIdx = 0
+			return m, nil
+		}
 		if field.toggle {
 			m.project.AutopilotAutoMerge = !m.project.AutopilotAutoMerge
 			ss.fields[ss.fieldIdx].value = boolOnOff(m.project.AutopilotAutoMerge)
@@ -408,6 +459,99 @@ func (m Model) updateSettingsEditTextarea(msg tea.KeyPressMsg) (tea.Model, tea.C
 	return m, cmd
 }
 
+func (m Model) updateSettingsWatchType(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	ss := m.settingsState
+	switch msg.String() {
+	case "esc":
+		ss.step = settingsStepSelectField
+		return m, nil
+	case "up", "k":
+		if ss.watchTypeIdx > 0 {
+			ss.watchTypeIdx--
+		}
+		return m, nil
+	case "down", "j":
+		if ss.watchTypeIdx < len(watchTypeLabels)-1 {
+			ss.watchTypeIdx++
+		}
+		return m, nil
+	case "enter":
+		selected := watchTypeLabels[ss.watchTypeIdx]
+		if selected == "none" {
+			// Clear the watch filter.
+			m.project.AutopilotFilterType = ""
+			m.project.AutopilotFilterValue = ""
+			ss.fields[ss.fieldIdx].value = "none"
+			ss.step = settingsStepSelectField
+			return m, func() tea.Msg {
+				err := m.store.UpdateProject(m.project)
+				return settingsSavedMsg{field: "Watch filter", err: err}
+			}
+		}
+		// Fetch choices for label/milestone.
+		ss.step = settingsStepWatchFetch
+		ss.watchChoices = nil
+		ss.watchIdx = 0
+		filterType := watchTypeToFilter[selected]
+
+		p := m.poller
+		ghRepos := p.GitHubRepos()
+		if len(ghRepos) == 0 {
+			ss.err = "No GitHub repos enrolled"
+			ss.step = settingsStepSelectField
+			return m, nil
+		}
+		owner := ghRepos[0].Owner
+		repo := ghRepos[0].Repo
+		var ft ghpkg.FilterType
+		if filterType == "label" {
+			ft = ghpkg.FilterLabel
+		} else {
+			ft = ghpkg.FilterMilestone
+		}
+
+		return m, func() tea.Msg {
+			choices, err := p.FetchFilterChoices(context.Background(), owner, repo, ft)
+			return settingsWatchChoicesMsg{choices: choices, err: err}
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateSettingsWatchChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	ss := m.settingsState
+	switch msg.String() {
+	case "esc":
+		ss.step = settingsStepWatchType
+		return m, nil
+	case "up", "k":
+		if ss.watchIdx > 0 {
+			ss.watchIdx--
+		}
+		return m, nil
+	case "down", "j":
+		if ss.watchIdx < len(ss.watchChoices)-1 {
+			ss.watchIdx++
+		}
+		return m, nil
+	case "enter":
+		if ss.watchIdx >= len(ss.watchChoices) {
+			return m, nil
+		}
+		choice := ss.watchChoices[ss.watchIdx]
+		filterType := watchTypeLabels[ss.watchTypeIdx]
+		m.project.AutopilotFilterType = filterType
+		m.project.AutopilotFilterValue = choice.Value
+		ss.fields[ss.fieldIdx].value = watchFilterDisplay(filterType, choice.Value)
+		ss.step = settingsStepSelectField
+		return m, func() tea.Msg {
+			err := m.store.UpdateProject(m.project)
+			return settingsSavedMsg{field: "Watch filter", err: err}
+		}
+	}
+	return m, nil
+}
+
 // saveSettingsField is a common helper for saving a simple text/numeric setting.
 func (m Model) saveSettingsField(ss *settingsState, label, displayValue string) (tea.Model, tea.Cmd) {
 	ss.fields[ss.fieldIdx].value = displayValue
@@ -511,6 +655,50 @@ func (m Model) renderSettingsView() string {
 		if ss.err != "" {
 			b.WriteString("  ")
 			b.WriteString(errorStyle().Render(ss.err))
+			b.WriteString("\n")
+		}
+
+	case settingsStepWatchType:
+		b.WriteString(textStyle().Render("  Select watch filter type:"))
+		b.WriteString("\n")
+		for i, label := range watchTypeLabels {
+			prefix := "    "
+			if i == ss.watchTypeIdx {
+				prefix = "  > "
+			}
+			entry := prefix + label
+			if i == ss.watchTypeIdx {
+				b.WriteString(headerStyle().Render(entry))
+			} else {
+				b.WriteString(textStyle().Render(entry))
+			}
+			b.WriteString("\n")
+		}
+		if ss.err != "" {
+			b.WriteString("  ")
+			b.WriteString(errorStyle().Render(ss.err))
+			b.WriteString("\n")
+		}
+
+	case settingsStepWatchFetch:
+		b.WriteString(textStyle().Render("  Fetching choices..."))
+		b.WriteString("\n")
+
+	case settingsStepWatchChoice:
+		filterType := watchTypeLabels[ss.watchTypeIdx]
+		b.WriteString(textStyle().Render(fmt.Sprintf("  Select %s:", filterType)))
+		b.WriteString("\n")
+		for i, choice := range ss.watchChoices {
+			prefix := "    "
+			if i == ss.watchIdx {
+				prefix = "  > "
+			}
+			entry := prefix + choice.Value
+			if i == ss.watchIdx {
+				b.WriteString(headerStyle().Render(entry))
+			} else {
+				b.WriteString(textStyle().Render(entry))
+			}
 			b.WriteString("\n")
 		}
 	}


### PR DESCRIPTION
## Summary

- **Watch filter in settings (s key):** New "Watch filter" field with multi-step selection — pick type (none/label/milestone) → pick value from fetched GitHub choices → saved to project. Previously only configurable via CLI flags.
- **Watch or add in filter scan (b key):** After selecting a label/milestone, user chooses between "Watch" (continuous auto-discovery) or "Add issues" (one-shot bulk add, existing behavior).
- **Fix empty dep graph carousel:** When all existing tasks were terminal (done/removed/skipped), `Prepare()` was routing to `prepareWithExisting` instead of `prepareFresh`. Now treats terminal-only tasks as fresh. Also runs `watchPoll()` during fresh prepare if a filter is configured.
- **2-minute watch poll interval:** Was tied to project refresh interval (could be 30+ min). Now fixed at 2 minutes for responsive issue discovery.

## Test plan

- [x] `go test ./...` — all tests pass
- [ ] Manual: open settings (s), configure watch filter for a milestone
- [ ] Manual: press b, select a milestone, verify watch-or-add choice appears
- [ ] Manual: start autopilot with only terminal tasks in DB, verify carousel populates from watch filter
- [ ] Manual: add issue to watched milestone, verify it appears within ~2 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)