### PR TITLE
Fix autopilot blocked when using watch filter

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2328,9 +2328,12 @@ func (m Model) startAutopilot() (tea.Model, tea.Cmd) {
 		})
 	}
 
-	// Check prerequisites: need tracked issues or existing tasks.
+	// Check prerequisites: need tracked issues, existing tasks, or a watch filter.
+	// Watch filters (milestone/label) discover issues via watchPoll() after launch,
+	// so skip the tracked-items check when a filter is configured.
+	hasWatchFilter := m.project.AutopilotFilterType != "" && m.project.AutopilotFilterValue != ""
 	existingTasks, _ := m.store.GetAutopilotTasks(m.project.ID)
-	if len(existingTasks) == 0 {
+	if len(existingTasks) == 0 && !hasWatchFilter {
 		trackedItems, _ := m.store.GetTrackedItems(m.project.ID)
 		hasOpenIssue := false
 		for _, item := range trackedItems {


### PR DESCRIPTION
## Summary
- `startAutopilot()` required existing tasks or tracked items with open issues before allowing autopilot to launch
- When using a watch filter (milestone/label), issues are discovered by `watchPoll()` inside `prepareFresh()` — but that code was never reached because the TUI prerequisite check blocked it first
- Fix: skip the tracked-items check when `AutopilotFilterType` + `AutopilotFilterValue` are set

## Test plan
- [ ] Set a milestone watch filter on a project, verify autopilot can start without pre-existing tracked items
- [ ] Verify autopilot still requires tracked items when no watch filter is configured
- [ ] Verify `go test ./internal/tui/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)