### PR TITLE
Fix empty carousel when regenerating dep graph

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -882,12 +882,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 		}
 		m.autopilotTotal = r.Total
-		m.autopilotDepOptions = r.Options
-		m.autopilotDepSelection = 0
 		if len(r.Options) > 0 {
+			m.autopilotDepOptions = r.Options
+			m.autopilotDepSelection = 0
 			m.autopilotUnblocked = r.Options[0].Unblocked
+			m.autopilotMode = "dep-select"
+			m.rebuildAutopilotTaskContent()
+			return m, nil
 		}
-		m.autopilotMode = "dep-select"
+		// No workable tasks after rebuild — go straight to confirm.
+		unblockedTasks, _ := m.store.QueuedUnblockedTasks(m.project.ID)
+		m.autopilotUnblocked = len(unblockedTasks)
+		m.autopilotMode = "confirm"
 		m.rebuildAutopilotTaskContent()
 		return m, nil
 


### PR DESCRIPTION
## Summary
- Fixed bug where selecting "rebuild" during autopilot reprepare with no workable tasks resulted in an empty dep graph carousel
- The `reprepareRebuildResultMsg` handler now gates on `len(Options) > 0` before entering "dep-select" mode, falling through to "confirm" mode otherwise
- Mirrors the existing correct pattern in the `reprepareKeepResultMsg` handler

## Test plan
- [ ] Start autopilot on a project where all issues are done/manual
- [ ] Select rebuild when prompted — should show confirm mode, not empty carousel
- [ ] Start autopilot with workable tasks — dep graph carousel should still render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)