### PR TITLE
Add base branch prompt to init wizard

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dustinlange/agent-minder/internal/db"
 	"github.com/dustinlange/agent-minder/internal/discovery"
+	gitpkg "github.com/dustinlange/agent-minder/internal/git"
 	"github.com/dustinlange/agent-minder/internal/onboarding"
 	"github.com/spf13/cobra"
 )
@@ -191,7 +192,22 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// 8. Write to database.
+	// 8. Base branch for autopilot worktrees and PRs.
+	// Auto-detect from the first repo, but always ask the user to confirm.
+	detectedBranch := "main"
+	if len(repos) > 0 {
+		if detected, err := gitpkg.DefaultBranch(repos[0].Path); err == nil && detected != "" {
+			detectedBranch = detected
+		}
+	}
+	fmt.Printf("\nAutopilot base branch (worktrees and PR targets) [%s]: ", detectedBranch)
+	baseBranchInput := readLine(reader)
+	baseBranch := detectedBranch
+	if baseBranchInput != "" {
+		baseBranch = baseBranchInput
+	}
+
+	// 9. Write to database.
 	project := &db.Project{
 		Name:                projectName,
 		GoalType:            goal.Name,
@@ -202,6 +218,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		AutoEnrollWorktrees: autoEnrollBool,
 		IdlePauseSec:        idlePauseSec,
 		AutopilotSkipLabel:  skipLabel,
+		AutopilotBaseBranch: baseBranch,
 		MinderIdentity:      projectName + "/minder",
 		LLMSummarizerModel:  "haiku",
 		LLMAnalyzerModel:    "opus",

--- a/internal/autopilot/prompt.go
+++ b/internal/autopilot/prompt.go
@@ -606,7 +606,7 @@ func renderTaskContext(task *db.AutopilotTask, baseBranch, owner, repo, testComm
 	fmt.Fprintf(&b, "Rebase before push:\n")
 	fmt.Fprintf(&b, "  git fetch origin %s\n", baseBranch)
 	fmt.Fprintf(&b, "  git rebase origin/%s\n", baseBranch)
-	fmt.Fprintf(&b, "Draft PR target: %s\n", baseBranch)
+	fmt.Fprintf(&b, "Draft PR: gh pr create --draft --base %s -R %s/%s\n", baseBranch, owner, repo)
 	fmt.Fprintf(&b, "Label blocked (if bailing): gh issue edit %d --add-label \"blocked\" -R %s/%s\n", task.IssueNumber, owner, repo)
 	fmt.Fprintf(&b, "Remove in-progress (if bailing): gh issue edit %d --remove-label \"in-progress\" -R %s/%s\n", task.IssueNumber, owner, repo)
 


### PR DESCRIPTION
## Summary

- Adds a base branch prompt to the `init` wizard that auto-detects the repo's default branch and asks the user to confirm or override it. Previously, leaving the base branch blank caused autopilot PRs to silently target `main` even when the repo uses `dev` or another branch.
- Makes the agent task context PR instruction explicit with the full `gh pr create --draft --base <branch> -R owner/repo` command instead of a vague "Draft PR target" hint, reducing the chance of agents targeting the wrong branch.

## Test plan

- [ ] Run `agent-minder init <repo>` on a repo with `dev` as default branch — verify the prompt shows `dev` as default and saves it
- [ ] Run `agent-minder init <repo>` on a repo with `main` as default — verify `main` is shown and pressing Enter accepts it
- [ ] Verify existing tests pass: `go test ./internal/autopilot/... -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)