### PR TITLE
Add R keybinding to refresh done/reviewed autopilot tasks

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -739,6 +739,58 @@ func (s *Supervisor) RestartTask(ctx context.Context, taskID int64) error {
 	return nil
 }
 
+// RefreshTask resets a completed/reviewed task back to queued so it can be re-run.
+// Unlike RestartTask (which handles failed/bailed/stopped), RefreshTask handles
+// tasks that reached a terminal or review state (done, review, reviewing, reviewed).
+func (s *Supervisor) RefreshTask(ctx context.Context, taskID int64) error {
+	tasks, err := s.store.GetAutopilotTasks(s.project.ID)
+	if err != nil {
+		return fmt.Errorf("get tasks: %w", err)
+	}
+
+	var task *db.AutopilotTask
+	for i := range tasks {
+		if tasks[i].ID == taskID {
+			task = &tasks[i]
+			break
+		}
+	}
+	if task == nil {
+		return fmt.Errorf("task %d not found", taskID)
+	}
+	validStatuses := map[string]bool{"done": true, "review": true, "reviewing": true, "reviewed": true}
+	if !validStatuses[task.Status] {
+		return fmt.Errorf("task #%d has status %q — only done, review, reviewing, or reviewed tasks can be refreshed", task.IssueNumber, task.Status)
+	}
+
+	// Clean up worktree and branch from the previous attempt.
+	if task.WorktreePath != "" {
+		if err := gitpkg.WorktreeRemove(s.repoDir, task.WorktreePath); err != nil {
+			if rmErr := os.RemoveAll(task.WorktreePath); rmErr != nil {
+				return fmt.Errorf("failed to clean up worktree at %s (git remove: %v, rm: %v)", task.WorktreePath, err, rmErr)
+			}
+			_ = gitpkg.WorktreePrune(s.repoDir)
+		}
+		if _, statErr := os.Stat(task.WorktreePath); statErr == nil {
+			return fmt.Errorf("worktree directory %s still exists after cleanup — remove it manually and retry", task.WorktreePath)
+		}
+	}
+	if task.Branch != "" {
+		_ = gitpkg.DeleteBranch(s.repoDir, task.Branch)
+	}
+
+	// Reset task fields in DB (clears PR number, review fields, etc.).
+	if err := s.store.ResetAutopilotTask(task.ID); err != nil {
+		return fmt.Errorf("reset task: %w", err)
+	}
+
+	s.emitEvent("started", fmt.Sprintf("Task #%d refreshed — re-queued", task.IssueNumber), task)
+
+	// Try to fill slots with the re-queued task.
+	s.fillSlots(ctx)
+	return nil
+}
+
 // ResumeTask resumes a failed or stopped task in its existing worktree.
 // Unlike RestartTask which nukes the worktree and starts fresh, ResumeTask
 // preserves the prior work and launches the agent with a continuation prompt.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1059,7 +1059,8 @@ func (s *Store) ResetAutopilotTask(id int64) error {
 		UPDATE autopilot_tasks
 		SET status = 'queued', worktree_path = '', branch = '', agent_log = '',
 		    started_at = '', completed_at = '', pr_number = 0,
-		    failure_reason = '', failure_detail = ''
+		    failure_reason = '', failure_detail = '',
+		    review_risk = NULL, review_comment_id = NULL
 		WHERE id = ?
 	`, id)
 	return err

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -237,7 +237,7 @@ type Model struct {
 
 	// Autopilot.
 	autopilotSupervisor       *autopilot.Supervisor
-	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "resume-or-restart-confirm", "review-confirm", "manual-confirm", "design-confirm", "add-slot-confirm", "completed", "reprepare-choice"
+	autopilotMode             string // "", "scan-confirm", "dep-select", "confirm", "running", "stop-confirm", "stop-task-confirm", "restart-confirm", "resume-or-restart-confirm", "refresh-confirm", "review-confirm", "manual-confirm", "design-confirm", "add-slot-confirm", "completed", "reprepare-choice"
 	autopilotModeBeforeReview string // saved mode to restore on review-confirm cancel
 	autopilotPrepareResult    *autopilot.PrepareResult
 	autopilotStatus           string
@@ -1104,7 +1104,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tickEvery()
 
 	case autopilotTickMsg:
-		if m.autopilotMode == "running" || m.autopilotMode == "stop-task-confirm" || m.autopilotMode == "restart-confirm" || m.autopilotMode == "resume-or-restart-confirm" || m.autopilotMode == "review-confirm" || m.autopilotMode == "design-confirm" {
+		if m.autopilotMode == "running" || m.autopilotMode == "stop-task-confirm" || m.autopilotMode == "restart-confirm" || m.autopilotMode == "resume-or-restart-confirm" || m.autopilotMode == "refresh-confirm" || m.autopilotMode == "review-confirm" || m.autopilotMode == "design-confirm" {
 			m.rebuildAutopilotTaskContent()
 			return m, autopilotTick()
 		}
@@ -1279,6 +1279,15 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	}
+	if m.autopilotMode == "refresh-confirm" && m.activeTab == tabAutopilot {
+		switch msg.String() {
+		case "enter":
+			return m.confirmRefreshTask()
+		case "esc":
+			m.autopilotMode = "running"
+			return m, nil
+		}
+	}
 	if m.autopilotMode == "review-confirm" && m.activeTab == tabAutopilot {
 		switch msg.String() {
 		case "enter":
@@ -1417,6 +1426,15 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			p.PollNow(ctx)
 			return nil
 		})
+	case "R":
+		// Refresh: reset a done/review/reviewed task back to queued.
+		if m.activeTab == tabAutopilot && (m.autopilotMode == "running" || m.autopilotMode == "completed") {
+			task := m.selectedAutopilotTask()
+			if task != nil && (task.Status == "done" || task.Status == "review" || task.Status == "reviewing" || task.Status == "reviewed") {
+				m.autopilotMode = "refresh-confirm"
+				return m, nil
+			}
+		}
 	case "g":
 		// Design interview: available on any task during autopilot running/completed.
 		if m.activeTab == tabAutopilot && (m.autopilotMode == "running" || m.autopilotMode == "completed") {
@@ -2602,6 +2620,42 @@ func (m Model) confirmRestartTask() (tea.Model, tea.Cmd) {
 			Time:    time.Now(),
 			Type:    "started",
 			Summary: fmt.Sprintf("Restarted #%d — re-queued", issueNum),
+		})
+	}
+}
+
+// confirmRefreshTask resets a done/review/reviewed task back to queued.
+func (m Model) confirmRefreshTask() (tea.Model, tea.Cmd) {
+	task := m.selectedAutopilotTask()
+	if task == nil || (task.Status != "done" && task.Status != "review" && task.Status != "reviewing" && task.Status != "reviewed") {
+		m.autopilotMode = "running"
+		return m, nil
+	}
+
+	sup := m.autopilotSupervisor
+	if sup == nil {
+		m.autopilotMode = "running"
+		return m, nil
+	}
+
+	taskID := task.ID
+	issueNum := task.IssueNumber
+	m.autopilotMode = "running"
+
+	return m, func() tea.Msg {
+		ctx, cancel := opCtx()
+		defer cancel()
+		if err := sup.RefreshTask(ctx, taskID); err != nil {
+			return autopilotEventMsg(autopilot.Event{
+				Time:    time.Now(),
+				Type:    "error",
+				Summary: fmt.Sprintf("Failed to refresh #%d: %v", issueNum, err),
+			})
+		}
+		return autopilotEventMsg(autopilot.Event{
+			Time:    time.Now(),
+			Type:    "started",
+			Summary: fmt.Sprintf("Refreshed #%d — re-queued", issueNum),
 		})
 	}
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1744,7 +1744,8 @@ func (m Model) computeHeightBudget() (analysisH, eventLogH, autopilotTaskH int) 
 		// Autopilot tab: slot section + task list header + VP + detail panel
 		isRunning := m.autopilotMode == "running" || m.autopilotMode == "stop-confirm" ||
 			m.autopilotMode == "stop-task-confirm" || m.autopilotMode == "restart-confirm" ||
-			m.autopilotMode == "resume-or-restart-confirm" || m.autopilotMode == "review-confirm" ||
+			m.autopilotMode == "resume-or-restart-confirm" || m.autopilotMode == "refresh-confirm" ||
+			m.autopilotMode == "review-confirm" ||
 			m.autopilotMode == "manual-confirm" || m.autopilotMode == "design-confirm" || m.autopilotMode == "completed"
 		if isRunning {
 			// Slot section.
@@ -2110,6 +2111,18 @@ func (m Model) renderBottomBar() string {
 			b.WriteString(helpKeyStyle().Render("esc"))
 			b.WriteString(helpStyle().Render(": cancel"))
 			b.WriteString("\n")
+		} else if m.activeTab == tabAutopilot && m.autopilotMode == "refresh-confirm" {
+			task := m.selectedAutopilotTask()
+			issueNum := 0
+			if task != nil {
+				issueNum = task.IssueNumber
+			}
+			b.WriteString(headerStyle().Render(fmt.Sprintf("  Refresh #%d? Will reset to queued and re-run from scratch. ", issueNum)))
+			b.WriteString(helpKeyStyle().Render("enter"))
+			b.WriteString(helpStyle().Render(": refresh • "))
+			b.WriteString(helpKeyStyle().Render("esc"))
+			b.WriteString(helpStyle().Render(": cancel"))
+			b.WriteString("\n")
 		} else if m.activeTab == tabAutopilot && m.autopilotMode == "restart-confirm" {
 			task := m.selectedAutopilotTask()
 			issueNum := 0
@@ -2283,11 +2296,19 @@ func (m Model) renderHelpBar() string {
 				case "review":
 					condensed = append(condensed,
 						hint{"r", "review"},
+						hint{"R", "refresh"},
+						hint{"l", "log"},
+						hint{"c", "copy path"},
+					)
+				case "reviewing", "reviewed":
+					condensed = append(condensed,
+						hint{"R", "refresh"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
 				case "done":
 					condensed = append(condensed,
+						hint{"R", "refresh"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
@@ -2305,14 +2326,27 @@ func (m Model) renderHelpBar() string {
 			task := m.selectedAutopilotTask()
 			if task != nil {
 				switch task.Status {
-				case "failed", "bailed", "stopped", "done":
+				case "failed", "bailed", "stopped":
 					condensed = append(condensed,
+						hint{"l", "log"},
+						hint{"c", "copy path"},
+					)
+				case "done":
+					condensed = append(condensed,
+						hint{"R", "refresh"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
 				case "review":
 					condensed = append(condensed,
 						hint{"r", "review"},
+						hint{"R", "refresh"},
+						hint{"l", "log"},
+						hint{"c", "copy path"},
+					)
+				case "reviewing", "reviewed":
+					condensed = append(condensed,
+						hint{"R", "refresh"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)


### PR DESCRIPTION
## Summary
- Adds `R` (shift-R) keybinding to reset done/review/reviewing/reviewed autopilot tasks back to queued
- New `RefreshTask()` supervisor method cleans up worktree/branch and re-queues the task
- `ResetAutopilotTask` now also clears `review_risk` and `review_comment_id` fields
- Confirmation prompt and context-sensitive help hints in both running and completed modes

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go test ./internal/db/... ./internal/autopilot/... ./internal/tui/...` all pass
- [x] Pre-commit hooks (fmt, build, lint) pass
- [ ] Manual: start autopilot, wait for a task to complete, press `R` on it, confirm refresh resets to queued and re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)