### PR TITLE
Extend R (refresh) to bailed/failed/stopped autopilot tasks

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1427,10 +1427,10 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return nil
 		})
 	case "R":
-		// Refresh: reset a done/review/reviewed task back to queued.
+		// Refresh: reset a terminal/review task back to queued.
 		if m.activeTab == tabAutopilot && (m.autopilotMode == "running" || m.autopilotMode == "completed") {
 			task := m.selectedAutopilotTask()
-			if task != nil && (task.Status == "done" || task.Status == "review" || task.Status == "reviewing" || task.Status == "reviewed") {
+			if task != nil && (task.Status == "done" || task.Status == "review" || task.Status == "reviewing" || task.Status == "reviewed" || task.Status == "bailed" || task.Status == "failed" || task.Status == "stopped") {
 				m.autopilotMode = "refresh-confirm"
 				return m, nil
 			}

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -2281,6 +2281,7 @@ func (m Model) renderHelpBar() string {
 				case "failed":
 					condensed = append(condensed,
 						hint{"r", "restart"},
+						hint{"R", "refresh"},
 						hint{"i", "detail"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
@@ -2288,6 +2289,7 @@ func (m Model) renderHelpBar() string {
 				case "bailed", "stopped":
 					condensed = append(condensed,
 						hint{"r", "restart"},
+						hint{"R", "refresh"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)
@@ -2328,6 +2330,7 @@ func (m Model) renderHelpBar() string {
 				switch task.Status {
 				case "failed", "bailed", "stopped":
 					condensed = append(condensed,
+						hint{"R", "refresh"},
 						hint{"l", "log"},
 						hint{"c", "copy path"},
 					)


### PR DESCRIPTION
## Summary
- Extends the `R` (refresh) keybinding to also work on `bailed`, `failed`, and `stopped` autopilot tasks, not just `done`/`review`/`reviewing`/`reviewed`
- Adds the `R` hint to the help bar for those statuses in both running and completed modes
- Useful when the underlying issue has been manually resolved or cleaned up and you want to re-queue the task

## Test plan
- [ ] Start autopilot, wait for a task to fail/bail/stop
- [ ] Select the task, verify `R` appears in help bar
- [ ] Press `R`, confirm refresh, verify task resets to queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)