### PR TITLE
Add ETag conditional requests for GitHub API polling

### DIFF
--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -1,0 +1,103 @@
+package github
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"sync"
+)
+
+// etagEntry holds a cached response body and its ETag for conditional requests.
+type etagEntry struct {
+	etag       string
+	body       []byte
+	statusCode int
+	header     http.Header
+}
+
+// etagTransport is an http.RoundTripper that caches GET responses by ETag.
+// When a cached ETag exists for a URL, it sends If-None-Match on repeat requests.
+// On 304 Not Modified, it replays the cached response body — making the response
+// transparent to callers while avoiding GitHub API rate limit charges.
+type etagTransport struct {
+	base  http.RoundTripper
+	mu    sync.Mutex
+	cache map[string]*etagEntry
+}
+
+// newETagTransport wraps a base transport with ETag caching.
+func newETagTransport(base http.RoundTripper) *etagTransport {
+	return &etagTransport{
+		base:  base,
+		cache: make(map[string]*etagEntry),
+	}
+}
+
+func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Only cache GET requests.
+	if req.Method != http.MethodGet {
+		return t.base.RoundTrip(req)
+	}
+
+	key := req.URL.String()
+
+	// If we have a cached ETag for this URL, send If-None-Match.
+	t.mu.Lock()
+	entry, ok := t.cache[key]
+	t.mu.Unlock()
+
+	if ok && entry.etag != "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("If-None-Match", entry.etag)
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	// On 304, replay the cached response.
+	if resp.StatusCode == http.StatusNotModified && ok {
+		_ = resp.Body.Close()
+		resp.StatusCode = entry.statusCode
+		resp.Body = io.NopCloser(bytes.NewReader(entry.body))
+		// Merge cached headers (Content-Type etc.) that 304 responses strip.
+		for k, v := range entry.header {
+			if resp.Header.Get(k) == "" {
+				resp.Header[k] = v
+			}
+		}
+		return resp, nil
+	}
+
+	// Cache the response if it has an ETag.
+	etag := resp.Header.Get("ETag")
+	if etag != "" {
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		// Replace the body so callers can still read it.
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+
+		// Clone relevant headers for replay.
+		hdrs := make(http.Header)
+		for _, k := range []string{"Content-Type", "Content-Length"} {
+			if v := resp.Header.Get(k); v != "" {
+				hdrs.Set(k, v)
+			}
+		}
+
+		t.mu.Lock()
+		t.cache[key] = &etagEntry{
+			etag:       etag,
+			body:       body,
+			statusCode: resp.StatusCode,
+			header:     hdrs,
+		}
+		t.mu.Unlock()
+	}
+
+	return resp, nil
+}

--- a/internal/github/etag_transport_test.go
+++ b/internal/github/etag_transport_test.go
@@ -1,0 +1,145 @@
+package github
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestETagTransport_CachesAndReplays304(t *testing.T) {
+	var hits atomic.Int32
+	body := `{"id":1,"title":"test issue"}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.Header.Get("If-None-Match") == `"abc123"` {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", `"abc123"`)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	transport := newETagTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	// First request — should get full response and cache it.
+	resp, err := client.Get(srv.URL + "/repos/o/r/issues/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if string(got) != body {
+		t.Fatalf("first request body = %q, want %q", got, body)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("first request status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("server hits = %d, want 1", hits.Load())
+	}
+
+	// Second request — should send If-None-Match, get 304, replay cached body.
+	resp2, err := client.Get(srv.URL + "/repos/o/r/issues/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+	if string(got2) != body {
+		t.Fatalf("second request body = %q, want %q", got2, body)
+	}
+	if resp2.StatusCode != 200 {
+		t.Fatalf("second request status = %d, want 200 (replayed)", resp2.StatusCode)
+	}
+	if hits.Load() != 2 {
+		t.Fatalf("server hits = %d, want 2 (conditional request still hits server)", hits.Load())
+	}
+}
+
+func TestETagTransport_SkipsNonGET(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"should-not-cache"`)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer srv.Close()
+
+	transport := newETagTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/repos/o/r/issues", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	// Cache should be empty — POST shouldn't be cached.
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	if len(transport.cache) != 0 {
+		t.Fatalf("cache has %d entries after POST, want 0", len(transport.cache))
+	}
+}
+
+func TestETagTransport_UpdatesCacheOnNewETag(t *testing.T) {
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		// Always return 200 with a new ETag (simulates changed resource).
+		w.Header().Set("ETag", `"v`+string(rune('0'+n))+`"`)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":` + string(rune('0'+n)) + `}`))
+	}))
+	defer srv.Close()
+
+	transport := newETagTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	// First call.
+	resp, _ := client.Get(srv.URL + "/test")
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	// Second call — server returns new data (not 304), cache should update.
+	resp2, _ := client.Get(srv.URL + "/test")
+	got, _ := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+
+	transport.mu.Lock()
+	entry := transport.cache[srv.URL+"/test"]
+	transport.mu.Unlock()
+
+	if entry == nil {
+		t.Fatal("expected cache entry")
+	}
+	if string(got) != string(entry.body) {
+		t.Fatalf("response body %q doesn't match cached body %q", got, entry.body)
+	}
+}
+
+func TestETagTransport_NoETagNoCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`no etag`))
+	}))
+	defer srv.Close()
+
+	transport := newETagTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	resp, _ := client.Get(srv.URL + "/test")
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	if len(transport.cache) != 0 {
+		t.Fatalf("cache has %d entries, want 0 (no ETag in response)", len(transport.cache))
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -54,8 +54,13 @@ type Client struct {
 
 // NewClient creates a GitHub client authenticated with the given PAT.
 // Uses a 30-second HTTP timeout to prevent indefinite hangs on network issues.
+// Wraps the transport with ETag caching so conditional requests (304 Not Modified)
+// don't count against the GitHub API rate limit.
 func NewClient(token string) *Client {
-	httpClient := &http.Client{Timeout: 30 * time.Second}
+	httpClient := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: newETagTransport(http.DefaultTransport),
+	}
 	return &Client{
 		gh: github.NewClient(httpClient).WithAuthToken(token),
 	}


### PR DESCRIPTION
## Summary
- Adds a transparent `etagTransport` (`http.RoundTripper`) that caches GET response bodies alongside their ETags
- On repeat requests, sends `If-None-Match`; on `304 Not Modified`, replays the cached body so callers see a normal 200 response
- Wired into `NewClient` — all existing GitHub API methods benefit automatically with zero code changes
- **Key win:** GitHub conditional requests (304s) don't count against the API rate limit, so the 30-second review/label/manual-task polling and 2-minute watch polls will largely stop consuming quota when nothing has changed

## Test plan
- [x] Unit tests for cache hit (304 replay), cache miss, cache update on new ETag, non-GET bypass, and no-ETag-no-cache
- [ ] Manual: run autopilot with `MINDER_DEBUG=1`, confirm `X-RateLimit-Remaining` stays stable during idle polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)