### PR TITLE
Add watch-and-wait mode for autopilot

### DIFF
--- a/internal/autopilot/supervisor.go
+++ b/internal/autopilot/supervisor.go
@@ -69,6 +69,7 @@ type PrepareResult struct {
 	Existing  int            // count of preserved tasks from previous session
 	NewIssues int            // count of newly discovered issues not yet in task table
 	HasGraph  bool           // true if a stored dep graph was found
+	WatchMode bool           // true if no tasks yet but a watch filter is configured — skip dep graph
 	// Status counts for existing tasks.
 	Done   int
 	Manual int
@@ -123,6 +124,7 @@ type Supervisor struct {
 	slots           []*slotState // len == maxAgents; nil = idle
 	active          bool
 	daemonMode      bool // when true, supervisor stays alive even when all work completes
+	watchMode       bool // when true, skip dep analysis for new tasks — just queue and run
 	paused          bool // when true, fillSlots returns early
 	budgetPaused    bool // when true, budget ceiling was hit — fillSlots returns early
 	budgetWarned    bool // true once the 80% warning has been emitted (avoids repeats)
@@ -971,6 +973,14 @@ func (s *Supervisor) IsPaused() bool {
 	return s.paused
 }
 
+// IsWatchMode returns true if the supervisor is in watch-and-wait mode
+// (no dep graph, tasks queued independently as they arrive).
+func (s *Supervisor) IsWatchMode() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.watchMode
+}
+
 // Prepare fetches tracked issues, creates autopilot tasks, and builds a dependency graph.
 // If existing tasks are found from a previous session, returns PrepareResult with
 // HasGraph=true so the TUI can offer keep/rebuild choice. Otherwise builds fresh.
@@ -1114,6 +1124,14 @@ func (s *Supervisor) prepareFresh(ctx context.Context, guidance string, agentDef
 	}
 
 	if len(tasks) == 0 {
+		// If a watch filter is configured, enter watch mode — sit and wait for
+		// issues to appear without requiring a dep graph up front.
+		if s.project.AutopilotFilterType != "" && s.project.AutopilotFilterValue != "" {
+			s.mu.Lock()
+			s.watchMode = true
+			s.mu.Unlock()
+			return &PrepareResult{AgentDef: agentDef, WatchMode: true}, nil
+		}
 		return &PrepareResult{AgentDef: agentDef}, nil
 	}
 
@@ -1886,8 +1904,9 @@ func (s *Supervisor) Launch(ctx context.Context) {
 				s.mu.Lock()
 				isPaused := s.paused
 				isDaemon := s.daemonMode
+				isWatch := s.watchMode
 				s.mu.Unlock()
-				if isPaused || isDaemon {
+				if isPaused || isDaemon || isWatch {
 					hasWork = true
 				}
 			}
@@ -3941,6 +3960,21 @@ func (s *Supervisor) ingestPendingTasks(ctx context.Context) int {
 	}
 	if len(pending) == 0 {
 		return 0
+	}
+
+	s.mu.Lock()
+	isWatchMode := s.watchMode
+	s.mu.Unlock()
+
+	if isWatchMode {
+		// In watch mode, skip dep analysis — just queue tasks directly.
+		s.emitEvent("discovered", fmt.Sprintf("Discovered %d new task(s) — queuing without dependencies", len(pending)), nil)
+		for _, t := range pending {
+			if t.Status == "pending" {
+				_ = s.store.UpdateAutopilotTaskStatus(t.ID, "queued")
+			}
+		}
+		return len(pending)
 	}
 
 	s.emitEvent("discovered", fmt.Sprintf("Discovered %d new task(s) — analyzing dependencies", len(pending)), nil)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -762,7 +762,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 		}
 		r := msg.result
-		if r.Total == 0 && r.Existing == 0 {
+		if r.Total == 0 && r.Existing == 0 && !r.WatchMode {
 			m.autopilotStatus = "No issues found matching filter"
 			m.autopilotMode = ""
 			m.autopilotSupervisor = nil
@@ -770,6 +770,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
 				return clearAutopilotStatusMsg{}
 			})
+		}
+		// Watch mode: no tasks yet but a watch filter is configured.
+		// Skip dep-select and go straight to confirm (or auto-launch on startup).
+		if r.WatchMode {
+			filterDesc := fmt.Sprintf("%s:%s", m.project.AutopilotFilterType, m.project.AutopilotFilterValue)
+			m.autopilotStatus = fmt.Sprintf("Watch mode — waiting for issues matching %s", filterDesc)
+			m.autopilotTotal = 0
+			if m.autopilotAutoloading {
+				m.autopilotAutoloading = false
+				m.activeTab = tabAutopilot
+				return m.confirmAutopilot()
+			}
+			m.autopilotMode = "confirm"
+			if m.activeTab != tabAutopilot {
+				m.autopilotHasNew = true
+			}
+			return m, nil
 		}
 		// If existing tasks found, offer keep/rebuild choice (or auto-keep on startup).
 		if r.HasGraph || r.Existing > 0 {

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -379,22 +379,35 @@ func (m Model) renderAutopilotTab() string {
 	// Confirm state: issue scan completed, awaiting launch confirmation.
 	if m.autopilotMode == "confirm" {
 		b.WriteString("\n")
-		b.WriteString(headerStyle().Render("  Autopilot — Ready to Launch"))
-		b.WriteString("\n\n")
-		b.WriteString(textStyle().Render(fmt.Sprintf("  %d issues found, %d unblocked",
-			m.autopilotTotal, m.autopilotUnblocked)))
-		b.WriteString("\n")
-		b.WriteString(textStyle().Render(fmt.Sprintf("  Will launch up to %d agents", m.project.AutopilotMaxAgents)))
-		b.WriteString("\n")
-		// Show dep graph at confirm time so user can verify before launching.
-		depGraph := m.renderDepGraph()
-		if depGraph != "" {
+		if m.autopilotTotal == 0 && m.autopilotSupervisor != nil && m.project.AutopilotFilterType != "" {
+			// Watch mode — no tasks yet, waiting for issues.
+			b.WriteString(headerStyle().Render("  Autopilot — Watch Mode"))
+			b.WriteString("\n\n")
+			b.WriteString(textStyle().Render(fmt.Sprintf("  Watching %s:%s for new issues",
+				m.project.AutopilotFilterType, m.project.AutopilotFilterValue)))
 			b.WriteString("\n")
-			b.WriteString(depGraph)
+			b.WriteString(textStyle().Render(fmt.Sprintf("  Will launch up to %d agents as issues arrive", m.project.AutopilotMaxAgents)))
+			b.WriteString("\n")
+			b.WriteString(textStyle().Render("  No dependency graph — tasks run independently"))
+			b.WriteString("\n")
+		} else {
+			b.WriteString(headerStyle().Render("  Autopilot — Ready to Launch"))
+			b.WriteString("\n\n")
+			b.WriteString(textStyle().Render(fmt.Sprintf("  %d issues found, %d unblocked",
+				m.autopilotTotal, m.autopilotUnblocked)))
+			b.WriteString("\n")
+			b.WriteString(textStyle().Render(fmt.Sprintf("  Will launch up to %d agents", m.project.AutopilotMaxAgents)))
+			b.WriteString("\n")
+			// Show dep graph at confirm time so user can verify before launching.
+			depGraph := m.renderDepGraph()
+			if depGraph != "" {
+				b.WriteString("\n")
+				b.WriteString(depGraph)
+			}
+			b.WriteString("\n")
+			b.WriteString(mutedStyle().Render("  Press G to rebuild dependencies with guidance, s to change settings."))
+			b.WriteString("\n")
 		}
-		b.WriteString("\n")
-		b.WriteString(mutedStyle().Render("  Press G to rebuild dependencies with guidance, s to change settings."))
-		b.WriteString("\n")
 		return b.String()
 	}
 


### PR DESCRIPTION
## Summary
- Allow autopilot to start when a watch filter (label/milestone) is configured but no matching issues exist yet
- In watch mode, skip dependency graph entirely — tasks are queued and run independently as they're discovered
- TUI shows a dedicated "Watch Mode" confirm screen with filter details
- Auto-launches on startup autoload path (same as existing auto-keep behavior)

## Changes
- `PrepareResult.WatchMode` flag signals watch-and-wait to the TUI
- `Supervisor.watchMode` field skips dep analysis in `ingestPendingTasks()` and keeps the launch loop alive
- TUI handles `WatchMode` by skipping dep-select, going straight to confirm/launch
- Layout renders "Autopilot — Watch Mode" screen when no tasks exist with a watch filter

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Build passes with pre-commit hooks (fmt, build, lint)
- [ ] Manual: init project with label filter, no matching issues → press `a` → see watch mode confirm → press Enter → autopilot runs idle → create matching issue → agent picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)