### PR TITLE
Refactor DeriveProjectName to use util.StringOrDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Refactor DeriveProjectName to use StringOrDefault**: Added `internal/util` package with `StringOrDefault` helper and refactored `discovery.DeriveProjectName()` to use it for the fallback case (#188)
+
 ### Added
 - **Deployment guide + service units**: Complete deployment documentation for running agent-minder watch mode on Ubuntu VPS (systemd) and macOS (LaunchAgent). Includes service units, install scripts, environment templates, logrotate config, firewall/Tailscale guidance, and troubleshooting. New `--foreground` flag on `deploy` and `deploy watch` for process-manager-friendly execution (#287)
 - **Remote TUI client**: `agent-minder deploy tui --remote host:port` launches a k9s-like live dashboard for monitoring remote deploy daemons. Features: live-updating task table with color-coded statuses, dependency graph visualization, analysis results viewer, agent log streaming with auto-tail, and action keys for refresh/poll/stop. Configurable poll intervals via `--task-poll` and `--analysis-poll` flags. Auth via `--api-key` flag or `MINDER_API_KEY` env var. New `internal/remotetui` package with bubbletea v2 model. (#282)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -7,6 +7,7 @@ import (
 
 	gitpkg "github.com/dustinlange/agent-minder/internal/git"
 	"github.com/dustinlange/agent-minder/internal/onboarding"
+	"github.com/dustinlange/agent-minder/internal/util"
 )
 
 // LegacyWorktree is kept for backward compat with v1 callers.
@@ -98,10 +99,10 @@ func DeriveProjectName(repos []*RepoInfo) string {
 	// We want to snap back to "agent".
 	prefix = trimToWordBoundary(prefix, names)
 
-	if prefix == "" || len(prefix) < 2 {
-		return repos[0].ShortName
+	if len(prefix) < 2 {
+		prefix = ""
 	}
-	return prefix
+	return util.StringOrDefault(prefix, repos[0].ShortName)
 }
 
 // SuggestTopics generates topic names for a set of repos plus a coord topic.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,9 @@
+package util
+
+// StringOrDefault returns value if non-empty, otherwise fallback.
+func StringOrDefault(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,20 @@
+package util
+
+import "testing"
+
+func TestStringOrDefault(t *testing.T) {
+	tests := []struct {
+		value, fallback, want string
+	}{
+		{"hello", "default", "hello"},
+		{"", "default", "default"},
+		{"", "", ""},
+		{"value", "", "value"},
+	}
+	for _, tt := range tests {
+		got := StringOrDefault(tt.value, tt.fallback)
+		if got != tt.want {
+			t.Errorf("StringOrDefault(%q, %q) = %q, want %q", tt.value, tt.fallback, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Added `internal/util` package with `StringOrDefault(value, fallback string)` helper
- Refactored `discovery.DeriveProjectName()` to use `util.StringOrDefault()` for the fallback case
- Added unit tests for `StringOrDefault`

## Test plan
- [x] `go test ./internal/util/...` — new helper tests pass
- [x] `go test ./internal/discovery/...` — existing tests pass (behavior preserved)
- [x] Pre-commit hooks (gofmt, build, golangci-lint) pass

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)