### PR TITLE
Add unit tests for daemon HTTP API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Daemon API server tests**: httptest-based unit tests for all daemon HTTP API endpoints — status, tasks, dep-graph, lessons, stop, resume, and API key middleware (#379)
 - **Deployment guide + service units**: Complete deployment documentation for running agent-minder watch mode on Ubuntu VPS (systemd) and macOS (LaunchAgent). Includes service units, install scripts, environment templates, logrotate config, firewall/Tailscale guidance, and troubleshooting. New `--foreground` flag on `deploy` and `deploy watch` for process-manager-friendly execution (#287)
 - **Remote TUI client**: `agent-minder deploy tui --remote host:port` launches a k9s-like live dashboard for monitoring remote deploy daemons. Features: live-updating task table with color-coded statuses, dependency graph visualization, analysis results viewer, agent log streaming with auto-tail, and action keys for refresh/poll/stop. Configurable poll intervals via `--task-poll` and `--analysis-poll` flags. Auth via `--api-key` flag or `MINDER_API_KEY` env var. New `internal/remotetui` package with bubbletea v2 model. (#282)
 - **Watch polling for TUI autopilot**: Optional `--watch-milestone` / `--watch-label` flags on the `start` command enable continuous GitHub issue discovery during autopilot sessions. New issues matching the filter are created as `pending` tasks and automatically ingested with incremental dep analysis. TUI shows a "watching" indicator when active. (#337)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,0 +1,343 @@
+package daemon
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aptx-health/agent-minder/internal/db"
+)
+
+func testServer(t *testing.T) (*Server, *db.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	conn, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	store := db.NewStore(conn)
+
+	deploy := &db.Deployment{
+		ID:             "test-deploy",
+		RepoDir:        "/tmp/repo",
+		Owner:          "acme",
+		Repo:           "widgets",
+		Mode:           "issues",
+		MaxAgents:      3,
+		MaxTurns:       50,
+		MaxBudgetUSD:   5.0,
+		AnalyzerModel:  "sonnet",
+		SkipLabel:      "no-agent",
+		TotalBudgetUSD: 25.0,
+		BaseBranch:     "main",
+	}
+	if err := store.CreateDeployment(deploy); err != nil {
+		t.Fatalf("CreateDeployment: %v", err)
+	}
+
+	srv := NewServer(ServerConfig{
+		Store:    store,
+		DeployID: "test-deploy",
+	})
+	return srv, store
+}
+
+func doRequest(t *testing.T, srv *Server, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	rr := httptest.NewRecorder()
+	srv.middleware(srv.mux).ServeHTTP(rr, req)
+	return rr
+}
+
+func TestHandleStatus(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rr := doRequest(t, srv, "GET", "/status")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp StatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.DeployID != "test-deploy" {
+		t.Errorf("deploy_id = %q, want %q", resp.DeployID, "test-deploy")
+	}
+	if resp.TotalBudget != 25.0 {
+		t.Errorf("total_budget = %v, want 25", resp.TotalBudget)
+	}
+	if resp.Config.MaxAgents != 3 {
+		t.Errorf("config.max_agents = %d, want 3", resp.Config.MaxAgents)
+	}
+	if resp.Config.BaseBranch != "main" {
+		t.Errorf("config.base_branch = %q, want %q", resp.Config.BaseBranch, "main")
+	}
+}
+
+func TestHandleTasks(t *testing.T) {
+	srv, store := testServer(t)
+
+	// Empty list initially.
+	rr := doRequest(t, srv, "GET", "/tasks")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var empty []TaskResponse
+	if err := json.NewDecoder(rr.Body).Decode(&empty); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Add a task.
+	task := &db.Task{
+		DeploymentID: "test-deploy",
+		IssueNumber:  42,
+		IssueTitle:   sql.NullString{String: "Fix auth", Valid: true},
+		Owner:        "acme",
+		Repo:         "widgets",
+		Status:       db.StatusQueued,
+	}
+	if err := store.CreateTask(task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	rr = doRequest(t, srv, "GET", "/tasks")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var tasks []TaskResponse
+	if err := json.NewDecoder(rr.Body).Decode(&tasks); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(tasks))
+	}
+	if tasks[0].IssueNumber != 42 {
+		t.Errorf("issue_number = %d, want 42", tasks[0].IssueNumber)
+	}
+	if tasks[0].Status != "queued" {
+		t.Errorf("status = %q, want %q", tasks[0].Status, "queued")
+	}
+	if tasks[0].IssueTitle != "Fix auth" {
+		t.Errorf("issue_title = %q, want %q", tasks[0].IssueTitle, "Fix auth")
+	}
+}
+
+func TestHandleTaskByID(t *testing.T) {
+	srv, store := testServer(t)
+
+	task := &db.Task{
+		DeploymentID: "test-deploy",
+		IssueNumber:  99,
+		IssueTitle:   sql.NullString{String: "Add feature", Valid: true},
+		Owner:        "acme",
+		Repo:         "widgets",
+		Status:       db.StatusQueued,
+	}
+	if err := store.CreateTask(task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	// Valid task.
+	rr := doRequest(t, srv, "GET", "/tasks/1")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp TaskResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.IssueNumber != 99 {
+		t.Errorf("issue_number = %d, want 99", resp.IssueNumber)
+	}
+	if resp.IssueTitle != "Add feature" {
+		t.Errorf("issue_title = %q, want %q", resp.IssueTitle, "Add feature")
+	}
+
+	// Non-existent task → 404.
+	rr = doRequest(t, srv, "GET", "/tasks/9999")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for missing task, got %d", rr.Code)
+	}
+
+	// Invalid ID → 400.
+	rr = doRequest(t, srv, "GET", "/tasks/abc")
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid id, got %d", rr.Code)
+	}
+}
+
+func TestHandleDepGraph(t *testing.T) {
+	srv, store := testServer(t)
+
+	// No dep graph → 404.
+	rr := doRequest(t, srv, "GET", "/dep-graph")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+
+	// Create dep graph.
+	if err := store.SaveDepGraph("test-deploy", `{"1":[],"2":[1]}`, "linear"); err != nil {
+		t.Fatalf("SaveDepGraph: %v", err)
+	}
+
+	rr = doRequest(t, srv, "GET", "/dep-graph")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp DepGraphResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.GraphJSON != `{"1":[],"2":[1]}` {
+		t.Errorf("graph_json = %q, want %q", resp.GraphJSON, `{"1":[],"2":[1]}`)
+	}
+	if resp.OptionName != "linear" {
+		t.Errorf("option_name = %q, want %q", resp.OptionName, "linear")
+	}
+}
+
+func TestHandleLessons(t *testing.T) {
+	srv, store := testServer(t)
+
+	// Create a lesson scoped to acme/widgets.
+	l := &db.Lesson{
+		RepoScope: sql.NullString{String: "acme/widgets", Valid: true},
+		Content:   "Always run go vet",
+		Source:    "review",
+		Active:    true,
+	}
+	if err := store.CreateLesson(l); err != nil {
+		t.Fatalf("CreateLesson: %v", err)
+	}
+
+	rr := doRequest(t, srv, "GET", "/lessons")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var lessons []LessonResponse
+	if err := json.NewDecoder(rr.Body).Decode(&lessons); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(lessons) != 1 {
+		t.Fatalf("got %d lessons, want 1", len(lessons))
+	}
+	if lessons[0].Content != "Always run go vet" {
+		t.Errorf("content = %q, want %q", lessons[0].Content, "Always run go vet")
+	}
+	if lessons[0].Source != "review" {
+		t.Errorf("source = %q, want %q", lessons[0].Source, "review")
+	}
+}
+
+func TestHandleStop(t *testing.T) {
+	srv, _ := testServer(t)
+
+	stopped := false
+	srv.StopDaemon = func() { stopped = true }
+
+	rr := doRequest(t, srv, "POST", "/stop")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "stopping" {
+		t.Errorf("status = %q, want %q", resp["status"], "stopping")
+	}
+	// StopDaemon is called in a goroutine; give it a moment.
+	time.Sleep(10 * time.Millisecond)
+	if !stopped {
+		t.Error("StopDaemon callback was not invoked")
+	}
+}
+
+func TestHandleResume(t *testing.T) {
+	srv, _ := testServer(t)
+
+	resumed := false
+	srv.BudgetResume = func() { resumed = true }
+
+	rr := doRequest(t, srv, "POST", "/resume")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "resumed" {
+		t.Errorf("status = %q, want %q", resp["status"], "resumed")
+	}
+	if !resumed {
+		t.Error("BudgetResume callback was not invoked")
+	}
+}
+
+func TestAPIKeyMiddleware(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	conn, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	store := db.NewStore(conn)
+
+	deploy := &db.Deployment{
+		ID:      "auth-deploy",
+		RepoDir: "/tmp/repo",
+		Owner:   "acme",
+		Repo:    "widgets",
+		Mode:    "issues",
+	}
+	if err := store.CreateDeployment(deploy); err != nil {
+		t.Fatalf("CreateDeployment: %v", err)
+	}
+
+	srv := NewServer(ServerConfig{
+		Store:    store,
+		DeployID: "auth-deploy",
+		APIKey:   "secret-key",
+	})
+
+	// No key → 401.
+	rr := doRequest(t, srv, "GET", "/status")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without key, got %d", rr.Code)
+	}
+
+	// Wrong key → 401.
+	req := httptest.NewRequest("GET", "/status", nil)
+	req.Header.Set("X-API-Key", "wrong-key")
+	rr = httptest.NewRecorder()
+	srv.middleware(srv.mux).ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with wrong key, got %d", rr.Code)
+	}
+
+	// Correct key → 200.
+	req = httptest.NewRequest("GET", "/status", nil)
+	req.Header.Set("X-API-Key", "secret-key")
+	rr = httptest.NewRecorder()
+	srv.middleware(srv.mux).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 with correct key, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds httptest-based unit tests for all daemon HTTP API endpoints in `internal/daemon/server_test.go`
- Covers GET /status, GET /tasks, GET /tasks/{id}, GET /dep-graph, GET /lessons, POST /stop, POST /resume
- Tests API key middleware authentication (401 without key, 401 with wrong key, 200 with correct key)
- 8 test functions, ~300 lines of test code

## Test plan
- [x] `go test ./internal/daemon/... -v` — all 8 tests pass
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` — clean
- [x] Pre-commit hooks (gofmt, go build, golangci-lint) pass

Fixes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)