### PR TITLE
Distinguish task_not_found from log_not_found in handleTaskLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Watch polling for TUI autopilot**: Optional `--watch-milestone` / `--watch-label` flags on the `start` command enable continuous GitHub issue discovery during autopilot sessions. New issues matching the filter are created as `pending` tasks and automatically ingested with incremental dep analysis. TUI shows a "watching" indicator when active. (#337)
 
 ### Fixed
+- **Distinct error codes in task log endpoint**: `handleTaskLog` now returns `"task_not_found"` when the task ID doesn't exist vs `"log_not_found"` when the task exists but has no log file, instead of a single ambiguous 404 (#388)
 - **Daemon heartbeat cleanup on graceful stop**: `StartHeartbeat` stop function now blocks until the heartbeat goroutine fully exits, preventing a race where the heartbeat file could be rewritten after removal during shutdown. Fixes false-positive crash detection on next startup. (#378)
 - **Review session uses reviewer agent def and PR context**: The `r` (review session) command now launches Claude with `--agent reviewer` and includes PR body and comments in the initial prompt, matching the automated review path. Previously the session used no agent definition and omitted PR comments. (#348)
 - **Max turns fallback detection**: When an agent's stream-json result event is missing (nil result), the supervisor now counts assistant events from the log file to detect turn limit exhaustion. Previously these agents were misclassified as "bailed" instead of "failed" with reason "max_turns". (#340)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -180,15 +180,19 @@ func (s *Server) handleTaskLog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	task, err := s.store.GetTask(id)
-	if err != nil || !task.AgentLog.Valid {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task or log not found"})
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task_not_found"})
+		return
+	}
+	if !task.AgentLog.Valid {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "log_not_found"})
 		return
 	}
 
 	// Stream the log file.
 	f, err := os.Open(task.AgentLog.String)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "log file not found"})
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "log_not_found"})
 		return
 	}
 	defer func() { _ = f.Close() }()

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -3,8 +3,10 @@ package daemon
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -239,6 +241,88 @@ func TestHandleLessons(t *testing.T) {
 	}
 	if lessons[0].Source != "review" {
 		t.Errorf("source = %q, want %q", lessons[0].Source, "review")
+	}
+}
+
+func TestHandleTaskLog(t *testing.T) {
+	srv, store := testServer(t)
+
+	// Invalid ID → 400.
+	rr := doRequest(t, srv, "GET", "/tasks/abc/log")
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid id, got %d", rr.Code)
+	}
+
+	// Non-existent task → 404 with task_not_found.
+	rr = doRequest(t, srv, "GET", "/tasks/9999/log")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing task, got %d", rr.Code)
+	}
+	var errResp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if errResp["error"] != "task_not_found" {
+		t.Errorf("error = %q, want %q", errResp["error"], "task_not_found")
+	}
+
+	// Task exists but has no log → 404 with log_not_found.
+	task := &db.Task{
+		DeploymentID: "test-deploy",
+		IssueNumber:  50,
+		Owner:        "acme",
+		Repo:         "widgets",
+		Status:       db.StatusQueued,
+	}
+	if err := store.CreateTask(task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	rr = doRequest(t, srv, "GET", fmt.Sprintf("/tasks/%d/log", task.ID))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing log, got %d", rr.Code)
+	}
+	errResp = nil
+	if err := json.NewDecoder(rr.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if errResp["error"] != "log_not_found" {
+		t.Errorf("error = %q, want %q", errResp["error"], "log_not_found")
+	}
+
+	// Task with a valid log file → 200.
+	logFile := filepath.Join(t.TempDir(), "agent.log")
+	if err := os.WriteFile(logFile, []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := store.DB().Exec("UPDATE tasks SET agent_log = ? WHERE id = ?", logFile, task.ID); err != nil {
+		t.Fatalf("set agent_log: %v", err)
+	}
+
+	rr = doRequest(t, srv, "GET", fmt.Sprintf("/tasks/%d/log", task.ID))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if body != "line1\nline2\n" {
+		t.Errorf("body = %q, want %q", body, "line1\nline2\n")
+	}
+
+	// Task with log path set but file missing → 404 with log_not_found.
+	if _, err := store.DB().Exec("UPDATE tasks SET agent_log = ? WHERE id = ?", "/nonexistent/agent.log", task.ID); err != nil {
+		t.Fatalf("set agent_log: %v", err)
+	}
+
+	rr = doRequest(t, srv, "GET", fmt.Sprintf("/tasks/%d/log", task.ID))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing log file, got %d", rr.Code)
+	}
+	errResp = nil
+	if err := json.NewDecoder(rr.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if errResp["error"] != "log_not_found" {
+		t.Errorf("error = %q, want %q", errResp["error"], "log_not_found")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Split the combined 404 in `handleTaskLog` into distinct error codes: `"task_not_found"` vs `"log_not_found"`
- Invalid task IDs still return 400 (already handled)
- Added comprehensive tests covering all four cases: invalid ID, missing task, missing log field, and missing log file on disk

## Test plan
- [x] `go test ./internal/daemon/... -v -run TestHandleTaskLog` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Pre-commit hooks (gofmt, build, golangci-lint) pass

Fixes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)