### PR TITLE
Dedup engine: stackable skip strategies for agent contracts (#405)

### DIFF
--- a/internal/supervisor/dedup.go
+++ b/internal/supervisor/dedup.go
@@ -1,0 +1,133 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	gitpkg "github.com/aptx-health/agent-minder/internal/git"
+)
+
+// DedupResult holds the outcome of a dedup evaluation.
+type DedupResult struct {
+	Skip   bool   // true if the job should be skipped
+	Reason string // human-readable reason for skipping
+}
+
+// EvaluateDedup checks all dedup strategies for a job.
+// Strategies are stackable — if ANY strategy triggers, the job is skipped.
+func EvaluateDedup(ctx context.Context, sc *SlotContext, strategies []string) DedupResult {
+	for _, strategy := range strategies {
+		result := evaluateStrategy(ctx, sc, strategy)
+		if result.Skip {
+			return result
+		}
+	}
+	return DedupResult{}
+}
+
+func evaluateStrategy(ctx context.Context, sc *SlotContext, strategy string) DedupResult {
+	// Parse strategy: "branch_exists", "open_pr_with_label:<label>", "recent_run:<hours>"
+	switch {
+	case strategy == "branch_exists":
+		return dedupBranchExists(sc)
+	case strings.HasPrefix(strategy, "open_pr_with_label:"):
+		label := strings.TrimPrefix(strategy, "open_pr_with_label:")
+		return dedupOpenPRWithLabel(ctx, sc, label)
+	case strings.HasPrefix(strategy, "recent_run:"):
+		hoursStr := strings.TrimPrefix(strategy, "recent_run:")
+		hours, err := strconv.Atoi(hoursStr)
+		if err != nil || hours < 1 {
+			return DedupResult{} // invalid strategy, don't skip
+		}
+		return dedupRecentRun(sc, hours)
+	default:
+		debugLog("unknown dedup strategy", "strategy", strategy)
+		return DedupResult{} // unknown strategy, don't skip
+	}
+}
+
+// dedupBranchExists skips if the job's branch already exists on the remote.
+func dedupBranchExists(sc *SlotContext) DedupResult {
+	branch := sc.Branch
+	if branch == "" {
+		return DedupResult{}
+	}
+
+	branches, err := gitpkg.Branches(sc.RepoDir)
+	if err != nil {
+		return DedupResult{}
+	}
+
+	for _, b := range branches {
+		if b.IsRemote && (b.Name == "origin/"+branch || b.Name == branch) {
+			return DedupResult{
+				Skip:   true,
+				Reason: fmt.Sprintf("branch %q already exists on remote", branch),
+			}
+		}
+	}
+	return DedupResult{}
+}
+
+// dedupOpenPRWithLabel skips if there's an open PR with the given label.
+func dedupOpenPRWithLabel(ctx context.Context, sc *SlotContext, label string) DedupResult {
+	ghClient := sc.NewGHClient()
+	// Search for open PRs with the label using GitHub search API.
+	// SearchIssues uses "is:issue" so we search PRs by listing with label filter.
+	prs, err := ghClient.ListIssuesByLabel(ctx, sc.Owner, sc.Repo, label)
+	if err != nil {
+		return DedupResult{}
+	}
+
+	for _, item := range prs.Items {
+		if item.ItemType == "pull_request" && item.State == "open" {
+			return DedupResult{
+				Skip:   true,
+				Reason: fmt.Sprintf("open PR #%d already has label %q", item.Number, label),
+			}
+		}
+	}
+	return DedupResult{}
+}
+
+// dedupRecentRun skips if a job with the same agent ran within the last N hours.
+func dedupRecentRun(sc *SlotContext, hours int) DedupResult {
+	cutoff := time.Now().UTC().Add(-time.Duration(hours) * time.Hour)
+
+	// Check completed jobs with the same agent in this deployment.
+	jobs, err := sc.Store.GetJobs(sc.Deploy.ID)
+	if err != nil {
+		return DedupResult{}
+	}
+
+	for _, j := range jobs {
+		if j.Agent != sc.Job.Agent {
+			continue
+		}
+		if j.ID == sc.Job.ID {
+			continue // don't match self
+		}
+		// Check if it completed recently.
+		if j.CompletedAt.Valid && j.CompletedAt.Time.After(cutoff) {
+			return DedupResult{
+				Skip: true,
+				Reason: fmt.Sprintf("agent %q ran %s ago (within %dh window)", j.Agent,
+					time.Since(j.CompletedAt.Time).Truncate(time.Minute), hours),
+			}
+		}
+		// Also check if it started recently (still running).
+		if j.StartedAt.Valid && j.StartedAt.Time.After(cutoff) &&
+			(j.Status == "running" || j.Status == "queued" || j.Status == "reviewing") {
+			return DedupResult{
+				Skip: true,
+				Reason: fmt.Sprintf("agent %q is already active (started %s ago)", j.Agent,
+					time.Since(j.StartedAt.Time).Truncate(time.Minute)),
+			}
+		}
+	}
+
+	return DedupResult{}
+}

--- a/internal/supervisor/dedup_test.go
+++ b/internal/supervisor/dedup_test.go
@@ -1,0 +1,160 @@
+package supervisor
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aptx-health/agent-minder/internal/db"
+)
+
+func testStoreForDedup(t *testing.T) *db.Store {
+	t.Helper()
+	dir := t.TempDir()
+	conn, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return db.NewStore(conn)
+}
+
+func testDeployForDedup(t *testing.T, store *db.Store) *db.Deployment {
+	t.Helper()
+	d := &db.Deployment{
+		ID: "dedup-test", RepoDir: "/tmp", Owner: "acme", Repo: "widgets",
+		Mode: "issues", MaxAgents: 3, MaxTurns: 50, MaxBudgetUSD: 5,
+		AnalyzerModel: "sonnet", SkipLabel: "no-agent", TotalBudgetUSD: 25,
+		BaseBranch: "main", ReviewEnabled: true,
+	}
+	_ = store.CreateDeployment(d)
+	return d
+}
+
+func TestDedupRecentRun(t *testing.T) {
+	store := testStoreForDedup(t)
+	deploy := testDeployForDedup(t, store)
+
+	// Create current job.
+	current := &db.Job{
+		DeploymentID: deploy.ID, Agent: "dep-updater", Name: "test-now",
+		Owner: "acme", Repo: "widgets", Status: db.StatusQueued,
+	}
+	_ = store.CreateJob(current)
+
+	sc := &SlotContext{Store: store, Deploy: deploy, Job: current}
+
+	// No previous runs — should not skip.
+	result := EvaluateDedup(context.Background(), sc, []string{"recent_run:24"})
+	if result.Skip {
+		t.Errorf("should not skip with no previous runs, got: %s", result.Reason)
+	}
+
+	// Add a recently completed job with the same agent.
+	old := &db.Job{
+		DeploymentID: deploy.ID, Agent: "dep-updater", Name: "test-old",
+		Owner: "acme", Repo: "widgets", Status: db.StatusDone,
+	}
+	_ = store.CreateJob(old)
+	// Set completed_at directly (CreateJob doesn't insert it).
+	_, _ = store.DB().Exec("UPDATE jobs SET completed_at = ? WHERE id = ?",
+		time.Now().UTC().Add(-2*time.Hour), old.ID)
+
+	// Within 24h window — should skip.
+	result = EvaluateDedup(context.Background(), sc, []string{"recent_run:24"})
+	if !result.Skip {
+		t.Error("should skip — same agent ran 2h ago within 24h window")
+	}
+
+	// Within 1h window — should not skip (ran 2h ago).
+	result = EvaluateDedup(context.Background(), sc, []string{"recent_run:1"})
+	if result.Skip {
+		t.Error("should not skip — 2h ago is outside 1h window")
+	}
+}
+
+func TestDedupRecentRunActiveJob(t *testing.T) {
+	store := testStoreForDedup(t)
+	deploy := testDeployForDedup(t, store)
+
+	current := &db.Job{
+		DeploymentID: deploy.ID, Agent: "dep-updater", Name: "test-now",
+		Owner: "acme", Repo: "widgets", Status: db.StatusQueued,
+	}
+	_ = store.CreateJob(current)
+
+	// Add a currently running job with the same agent.
+	running := &db.Job{
+		DeploymentID: deploy.ID, Agent: "dep-updater", Name: "test-running",
+		Owner: "acme", Repo: "widgets", Status: db.StatusRunning,
+	}
+	_ = store.CreateJob(running)
+	_, _ = store.DB().Exec("UPDATE jobs SET started_at = ? WHERE id = ?",
+		time.Now().UTC().Add(-10*time.Minute), running.ID)
+
+	sc := &SlotContext{Store: store, Deploy: deploy, Job: current}
+
+	result := EvaluateDedup(context.Background(), sc, []string{"recent_run:24"})
+	if !result.Skip {
+		t.Error("should skip — same agent is currently running")
+	}
+}
+
+func TestDedupStackable(t *testing.T) {
+	store := testStoreForDedup(t)
+	deploy := testDeployForDedup(t, store)
+
+	current := &db.Job{
+		DeploymentID: deploy.ID, Agent: "dep-updater", Name: "test",
+		Owner: "acme", Repo: "widgets", Status: db.StatusQueued,
+	}
+	_ = store.CreateJob(current)
+
+	sc := &SlotContext{Store: store, Deploy: deploy, Job: current}
+
+	// Multiple strategies — all must pass (none skip).
+	result := EvaluateDedup(context.Background(), sc, []string{"recent_run:1", "branch_exists"})
+	if result.Skip {
+		t.Error("should not skip when all strategies pass")
+	}
+}
+
+func TestDedupUnknownStrategy(t *testing.T) {
+	store := testStoreForDedup(t)
+	deploy := testDeployForDedup(t, store)
+
+	current := &db.Job{
+		DeploymentID: deploy.ID, Agent: "test", Name: "test",
+		Owner: "acme", Repo: "widgets", Status: db.StatusQueued,
+	}
+	_ = store.CreateJob(current)
+
+	sc := &SlotContext{Store: store, Deploy: deploy, Job: current}
+
+	// Unknown strategy should not skip.
+	result := EvaluateDedup(context.Background(), sc, []string{"unknown_thing"})
+	if result.Skip {
+		t.Error("unknown strategy should not cause skip")
+	}
+}
+
+func TestDedupBranchExists(t *testing.T) {
+	// Without a real git repo, branch_exists will return not-skip (can't check).
+	store := testStoreForDedup(t)
+	deploy := testDeployForDedup(t, store)
+
+	current := &db.Job{
+		DeploymentID: deploy.ID, Agent: "test", Name: "test",
+		Owner: "acme", Repo: "widgets", Status: db.StatusQueued,
+	}
+	_ = store.CreateJob(current)
+
+	sc := &SlotContext{Store: store, Deploy: deploy, Job: current, Branch: "agent/test"}
+
+	// No git repo at /tmp — should not skip (fails gracefully).
+	result := dedupBranchExists(sc)
+	if result.Skip {
+		t.Error("should not skip when git check fails")
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -510,10 +510,20 @@ func (s *Supervisor) runJobManager(ctx context.Context, job *db.Job) {
 	// Create SlotContext.
 	sc := s.newSlotContext(job.ID, job)
 
-	// Resolve contract.
+	// Resolve contract and check dedup.
 	contract, err := ResolveContract(s.repoDir, job.Agent)
 	if err != nil {
 		contract = DefaultContract(job.Agent)
+	}
+
+	// Check dedup strategies before running.
+	if len(contract.Dedup) > 0 {
+		result := EvaluateDedup(ctx, sc, contract.Dedup)
+		if result.Skip {
+			sc.EmitEvent("info", fmt.Sprintf("Skipped %s: %s", sc.JobLabel(), result.Reason))
+			_ = s.store.UpdateJobStatus(job.ID, "skipped")
+			return
+		}
 	}
 
 	// Create and run JobManager.


### PR DESCRIPTION
## Summary

- **3 dedup strategies**: `branch_exists`, `open_pr_with_label:<label>`, `recent_run:<hours>`
- Strategies are stackable — if ANY triggers, job is marked `skipped`
- Evaluated in `runJobManager()` after contract resolution, before job launch
- Graceful degradation: if a check fails (no git repo, API error), it doesn't skip

Example contract:
```yaml
dedup:
  - branch_exists
  - open_pr_with_label:dependencies
  - recent_run:24
```

Closes #405

## Test plan

- [x] `recent_run` with completed job within/outside window
- [x] `recent_run` with active (running) job
- [x] Stackable strategies (multiple pass)
- [x] Unknown strategy doesn't skip
- [x] `branch_exists` graceful failure without git repo
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)