### PR TITLE
Sort running jobs by ID for stable slot numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Watch polling for TUI autopilot**: Optional `--watch-milestone` / `--watch-label` flags on the `start` command enable continuous GitHub issue discovery during autopilot sessions. New issues matching the filter are created as `pending` tasks and automatically ingested with incremental dep analysis. TUI shows a "watching" indicator when active. (#337)
 
 ### Fixed
+- **Stable slot numbering for running jobs**: `RunningJobs()`, `SlotStatus()`, and `StopAgent()` now sort by job ID before assigning slot numbers, preventing nondeterministic ordering from Go map iteration (#384)
 - **Git log date parsing fallback**: `Log()`, `LogSince()`, and `LogGrep()` now use `time.Now()` as fallback when commit dates fail RFC3339 parsing, instead of silently producing zero-valued timestamps. Extracted shared `parseLogOutput()` helper to deduplicate parsing logic across all three functions. (#392)
 - **Replace custom lastIndex with strings.LastIndex**: Removed custom `lastIndex()` in review.go that reimplemented `strings.LastIndex()` and had a potential panic on short strings (#383)
 - **Daemon client HTTP status range check**: Accept all 2xx status codes (not just 200) in `getJSON()` and `post()` methods, so 201/204 responses are no longer treated as errors (#386)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -182,13 +183,25 @@ func (s *Supervisor) Resume() {
 	s.mu.Unlock()
 }
 
+// sortedRunningKeys returns the keys of s.running sorted by job ID.
+// Must be called with s.mu held.
+func (s *Supervisor) sortedRunningKeys() []int64 {
+	keys := make([]int64, 0, len(s.running))
+	for id := range s.running {
+		keys = append(keys, id)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
 // RunningJobs returns info about all currently running jobs.
 func (s *Supervisor) RunningJobs() []RunInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	var infos []RunInfo
-	for _, rs := range s.running {
+	for _, id := range s.sortedRunningKeys() {
+		rs := s.running[id]
 		infos = append(infos, RunInfo{
 			JobID:       rs.job.ID,
 			Agent:       rs.job.Agent,
@@ -212,8 +225,9 @@ func (s *Supervisor) SlotStatus() []SlotInfo {
 	defer s.mu.Unlock()
 
 	var infos []SlotInfo
-	i := 0
-	for _, rs := range s.running {
+	keys := s.sortedRunningKeys()
+	for i, id := range keys {
+		rs := s.running[id]
 		infos = append(infos, SlotInfo{
 			SlotNum:     i,
 			IssueNumber: rs.job.IssueNumber,
@@ -226,12 +240,10 @@ func (s *Supervisor) SlotStatus() []SlotInfo {
 			ToolInput:   rs.liveStatus.ToolInput,
 			StepCount:   rs.liveStatus.StepCount,
 		})
-		i++
 	}
 	// Pad with idle slots up to maxAgents.
-	for i < s.maxAgents {
+	for i := len(keys); i < s.maxAgents; i++ {
 		infos = append(infos, SlotInfo{SlotNum: i, Status: "idle", Paused: s.paused || s.budgetPaused})
-		i++
 	}
 	return infos
 }
@@ -269,16 +281,14 @@ func (s *Supervisor) StopJob(jobID int64) {
 func (s *Supervisor) StopAgent(slotIdx int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	i := 0
-	for _, rs := range s.running {
-		if i == slotIdx {
-			rs.stoppedByUser = true
-			if rs.cancelFunc != nil {
-				rs.cancelFunc()
-			}
-			return
-		}
-		i++
+	keys := s.sortedRunningKeys()
+	if slotIdx < 0 || slotIdx >= len(keys) {
+		return
+	}
+	rs := s.running[keys[slotIdx]]
+	rs.stoppedByUser = true
+	if rs.cancelFunc != nil {
+		rs.cancelFunc()
 	}
 }
 

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,0 +1,114 @@
+package supervisor
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/aptx-health/agent-minder/internal/db"
+)
+
+// newTestSupervisor creates a Supervisor with pre-populated running jobs for testing.
+func newTestSupervisor(t *testing.T, jobIDs []int64) *Supervisor {
+	t.Helper()
+	s := &Supervisor{
+		running:   make(map[int64]*runState),
+		maxAgents: 5,
+	}
+	for _, id := range jobIDs {
+		s.running[id] = &runState{
+			job: &db.Job{
+				ID:          id,
+				IssueNumber: int(id * 10),
+				IssueTitle:  sql.NullString{String: "Issue " + string(rune('A'+id-1)), Valid: true},
+				Branch:      sql.NullString{String: "branch-" + string(rune('a'+id-1)), Valid: true},
+				Status:      db.StatusRunning,
+			},
+			startedAt: time.Now(),
+		}
+	}
+	return s
+}
+
+func TestRunningJobsSortedByID(t *testing.T) {
+	// Insert jobs in non-sorted order to test sorting.
+	s := newTestSupervisor(t, []int64{30, 10, 20})
+
+	infos := s.RunningJobs()
+	if len(infos) != 3 {
+		t.Fatalf("expected 3 running jobs, got %d", len(infos))
+	}
+
+	// Verify jobs are returned sorted by ID.
+	if infos[0].JobID != 10 {
+		t.Errorf("expected first job ID 10, got %d", infos[0].JobID)
+	}
+	if infos[1].JobID != 20 {
+		t.Errorf("expected second job ID 20, got %d", infos[1].JobID)
+	}
+	if infos[2].JobID != 30 {
+		t.Errorf("expected third job ID 30, got %d", infos[2].JobID)
+	}
+}
+
+func TestSlotStatusSortedByID(t *testing.T) {
+	s := newTestSupervisor(t, []int64{30, 10, 20})
+
+	slots := s.SlotStatus()
+	if len(slots) != 5 {
+		t.Fatalf("expected 5 slots (3 running + 2 idle), got %d", len(slots))
+	}
+
+	// Running slots should be sorted by job ID with sequential slot numbers.
+	if slots[0].IssueNumber != 100 || slots[0].SlotNum != 0 {
+		t.Errorf("slot 0: expected issue 100 at slot 0, got issue %d at slot %d", slots[0].IssueNumber, slots[0].SlotNum)
+	}
+	if slots[1].IssueNumber != 200 || slots[1].SlotNum != 1 {
+		t.Errorf("slot 1: expected issue 200 at slot 1, got issue %d at slot %d", slots[1].IssueNumber, slots[1].SlotNum)
+	}
+	if slots[2].IssueNumber != 300 || slots[2].SlotNum != 2 {
+		t.Errorf("slot 2: expected issue 300 at slot 2, got issue %d at slot %d", slots[2].IssueNumber, slots[2].SlotNum)
+	}
+
+	// Remaining slots should be idle.
+	for i := 3; i < 5; i++ {
+		if slots[i].Status != "idle" {
+			t.Errorf("slot %d: expected idle, got %s", i, slots[i].Status)
+		}
+		if slots[i].SlotNum != i {
+			t.Errorf("slot %d: expected SlotNum %d, got %d", i, i, slots[i].SlotNum)
+		}
+	}
+}
+
+func TestStopAgentBySlotIndex(t *testing.T) {
+	s := newTestSupervisor(t, []int64{30, 10, 20})
+
+	// Slot 1 should correspond to job ID 20 (the second by sorted order).
+	s.StopAgent(1)
+
+	rs := s.running[20]
+	if !rs.stoppedByUser {
+		t.Error("expected job 20 (slot 1) to be stopped, but it was not")
+	}
+
+	// Other jobs should not be stopped.
+	if s.running[10].stoppedByUser {
+		t.Error("job 10 (slot 0) should not be stopped")
+	}
+	if s.running[30].stoppedByUser {
+		t.Error("job 30 (slot 2) should not be stopped")
+	}
+}
+
+func TestStopAgentOutOfRange(t *testing.T) {
+	s := newTestSupervisor(t, []int64{10})
+
+	// Should not panic on out-of-range index.
+	s.StopAgent(5)
+	s.StopAgent(-1)
+
+	if s.running[10].stoppedByUser {
+		t.Error("job should not be stopped by out-of-range index")
+	}
+}


### PR DESCRIPTION
## Summary
- Sort `s.running` map keys by job ID before assigning sequential slot numbers in `RunningJobs()`, `SlotStatus()`, and `StopAgent()`
- Extract shared `sortedRunningKeys()` helper method
- Fix `StopAgent()` bounds checking for out-of-range slot indices

## Test plan
- [x] Unit tests for `RunningJobs` sorted order
- [x] Unit tests for `SlotStatus` sorted slot numbering + idle padding
- [x] Unit tests for `StopAgent` by slot index (correct target + out-of-range safety)
- [x] All existing tests pass (`go test ./...`)
- [x] Pre-commit hooks pass (gofmt, go build, golangci-lint)

Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)