### PR TITLE
Fix stale worktree blocking agent launch on re-deploy

### DIFF
--- a/internal/supervisor/jobmanager.go
+++ b/internal/supervisor/jobmanager.go
@@ -76,11 +76,18 @@ func (sc *SlotContext) NewGHClient() *ghpkg.Client {
 }
 
 // SetupWorktree creates a git worktree for this job.
+// Cleans up any stale worktree/branch from a previous run first.
 // Safe to call concurrently — uses the supervisor's gitSetupMu.
 func (sc *SlotContext) SetupWorktree() error {
 	_ = os.MkdirAll(filepath.Dir(sc.WorktreePath), 0755)
 
 	sc.sup.gitSetupMu.Lock()
+	// Remove stale worktree first — git branch -D fails if the branch
+	// is still checked out in an existing worktree.
+	if _, err := os.Stat(sc.WorktreePath); err == nil {
+		_ = gitpkg.WorktreeRemove(sc.RepoDir, sc.WorktreePath)
+	}
+	_ = gitpkg.WorktreePrune(sc.RepoDir)
 	_ = gitpkg.DeleteBranch(sc.RepoDir, sc.Branch)
 	err := gitpkg.WorktreeAdd(sc.RepoDir, sc.WorktreePath, sc.Branch, "origin/"+sc.BaseBranch)
 	sc.sup.gitSetupMu.Unlock()


### PR DESCRIPTION
## Summary
- Force-remove existing worktree and prune stale refs before creating a new worktree in `SetupWorktree()`
- Fixes the "branch already exists" error when re-deploying on the same issue after a crash/bail

## What changed
`SetupWorktree()` now does: `worktree remove --force` → `worktree prune` → `branch -D` → `worktree add`

Previously it only did `branch -D` → `worktree add`, which failed when the branch was still checked out in a stale worktree.

## Test plan
- [x] All existing tests pass
- [ ] Deploy on an issue that has a stale worktree from a previous run

Fixes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)