### PR TITLE
Add minder agents list/show commands

### DIFF
--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aptx-health/agent-minder/internal/supervisor"
+	"github.com/spf13/cobra"
+)
+
+var agentsCmd = &cobra.Command{
+	Use:   "agents",
+	Short: "List and inspect agent definitions",
+}
+
+var agentsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available agent definitions",
+	RunE:  runAgentsList,
+}
+
+var agentsShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Show full agent definition and parsed contract",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAgentsShow,
+}
+
+var flagAgentsRepo string
+
+func init() {
+	rootCmd.AddCommand(agentsCmd)
+	agentsCmd.AddCommand(agentsListCmd)
+	agentsCmd.AddCommand(agentsShowCmd)
+
+	agentsCmd.PersistentFlags().StringVar(&flagAgentsRepo, "repo", ".", "Repository directory")
+}
+
+func runAgentsList(cmd *cobra.Command, args []string) error {
+	repoDir, err := resolveRepoDir(flagAgentsRepo)
+	if err != nil {
+		repoDir = flagAgentsRepo
+	}
+
+	agents := supervisor.DiscoverAgents(repoDir)
+	if len(agents) == 0 {
+		fmt.Println("No agent definitions found.")
+		return nil
+	}
+
+	fmt.Printf("%-20s %-10s %-12s %-8s %s\n", "NAME", "SOURCE", "MODE", "OUTPUT", "DESCRIPTION")
+	fmt.Printf("%-20s %-10s %-12s %-8s %s\n", "----", "------", "----", "------", "-----------")
+	for _, a := range agents {
+		desc := a.Contract.Description
+		if len(desc) > 50 {
+			desc = desc[:47] + "..."
+		}
+		fmt.Printf("%-20s %-10s %-12s %-8s %s\n",
+			a.Name, a.Source, a.Contract.Mode, a.Contract.Output, desc)
+	}
+	return nil
+}
+
+func runAgentsShow(cmd *cobra.Command, args []string) error {
+	repoDir, err := resolveRepoDir(flagAgentsRepo)
+	if err != nil {
+		repoDir = flagAgentsRepo
+	}
+
+	name := args[0]
+	contract, err := supervisor.ResolveContract(repoDir, name)
+	if err != nil {
+		return fmt.Errorf("agent %q: %w", name, err)
+	}
+
+	// Find source info.
+	var source, path string
+	for _, a := range supervisor.DiscoverAgents(repoDir) {
+		if a.Name == name {
+			source = a.Source
+			path = a.Path
+			break
+		}
+	}
+	if source == "" {
+		source = "built-in"
+	}
+
+	fmt.Printf("Agent: %s\n", contract.Name)
+	fmt.Printf("Source: %s\n", source)
+	if path != "" {
+		fmt.Printf("Path: %s\n", path)
+	}
+	if contract.Description != "" {
+		fmt.Printf("Description: %s\n", contract.Description)
+	}
+	fmt.Printf("Mode: %s\n", contract.Mode)
+	fmt.Printf("Output: %s\n", contract.Output)
+
+	if len(contract.Context) > 0 {
+		fmt.Printf("Context: %s\n", strings.Join(contract.Context, ", "))
+	}
+
+	if len(contract.Dedup) > 0 {
+		fmt.Printf("Dedup: %s\n", strings.Join(contract.Dedup, ", "))
+	}
+
+	if contract.Timeout != "" {
+		fmt.Printf("Timeout: %s\n", contract.Timeout)
+	}
+
+	if len(contract.Stages) > 0 {
+		fmt.Println("\nStages:")
+		for i, s := range contract.Stages {
+			fmt.Printf("  %d. %s (agent: %s, on_failure: %s)\n", i+1, s.Name, s.Agent, s.OnFailure)
+		}
+	}
+
+	return nil
+}

--- a/internal/supervisor/contract.go
+++ b/internal/supervisor/contract.go
@@ -225,3 +225,78 @@ func ResolveContract(repoDir string, agentName string) (*AgentContract, error) {
 		return DefaultContract(agentName), nil
 	}
 }
+
+// AgentInfo describes a discovered agent definition.
+type AgentInfo struct {
+	Name     string
+	Source   string // "repo", "user", or "built-in"
+	Path     string // file path (empty for built-in)
+	Contract *AgentContract
+}
+
+// DiscoverAgents finds all available agent definitions across the 3-tier fallback.
+// Returns a deduplicated list where repo overrides user overrides built-in.
+func DiscoverAgents(repoDir string) []AgentInfo {
+	seen := map[string]bool{}
+	var agents []AgentInfo
+
+	// 1. Repo-level agents.
+	repoAgentsDir := filepath.Join(repoDir, ".claude", "agents")
+	if entries, err := os.ReadDir(repoAgentsDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			name := strings.TrimSuffix(e.Name(), ".md")
+			path := filepath.Join(repoAgentsDir, e.Name())
+			contract, err := ParseContract(path)
+			if err != nil {
+				continue
+			}
+			agents = append(agents, AgentInfo{Name: name, Source: "repo", Path: path, Contract: contract})
+			seen[name] = true
+		}
+	}
+
+	// 2. User-level agents.
+	home, _ := os.UserHomeDir()
+	userAgentsDir := filepath.Join(home, ".claude", "agents")
+	if entries, err := os.ReadDir(userAgentsDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			name := strings.TrimSuffix(e.Name(), ".md")
+			if seen[name] {
+				continue
+			}
+			path := filepath.Join(userAgentsDir, e.Name())
+			contract, err := ParseContract(path)
+			if err != nil {
+				continue
+			}
+			agents = append(agents, AgentInfo{Name: name, Source: "user", Path: path, Contract: contract})
+			seen[name] = true
+		}
+	}
+
+	// 3. Built-in agents.
+	for _, def := range []struct {
+		name string
+		raw  string
+	}{
+		{"autopilot", defaultAgentDef},
+		{"reviewer", defaultReviewerDef},
+	} {
+		if seen[def.name] {
+			continue
+		}
+		contract, err := ParseContractFromBytes([]byte(def.raw))
+		if err != nil {
+			continue
+		}
+		agents = append(agents, AgentInfo{Name: def.name, Source: "built-in", Contract: contract})
+	}
+
+	return agents
+}


### PR DESCRIPTION
## Summary
- `minder agents list` — discover all available agents across repo, user, and built-in tiers
- `minder agents show <name>` — display full contract details (mode, output, context, dedup, stages, timeout)
- `DiscoverAgents()` function in supervisor package for programmatic discovery

## Example output
```
$ minder agents list
NAME                 SOURCE     MODE         OUTPUT   DESCRIPTION
----                 ------     ----         ------   -----------
autopilot            repo       reactive     pr       Autonomous agent that implements GitHub issues ...
reviewer             built-in   reactive     pr       Reviews PRs opened by autopilot agents. Checks ...
```

## Test plan
- [x] All tests pass
- [x] Manual test: `minder agents list` and `minder agents show autopilot`

Fixes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)