### PR TITLE
Enroll: agent definition setup and customization

### DIFF
--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/aptx-health/agent-minder/internal/discovery"
 	gitpkg "github.com/aptx-health/agent-minder/internal/git"
 	"github.com/aptx-health/agent-minder/internal/onboarding"
+	"github.com/aptx-health/agent-minder/internal/supervisor"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +17,8 @@ var enrollCmd = &cobra.Command{
 	Use:   "enroll [repo-dir]",
 	Short: "Scan a repo and generate onboarding configuration",
 	Long: `Scans a repository for build/test commands, languages, and CI config,
-then launches an interactive Claude agent to generate .agent-minder/onboarding.yaml.`,
+installs required agent definitions, then launches an interactive Claude agent
+to generate .agent-minder/onboarding.yaml and customize agent instructions.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runEnroll,
 }
@@ -52,6 +55,9 @@ func runEnroll(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Install required agent definitions.
+	agentReport := installAgentDefs(repoDir)
+
 	// Create initial file with inventory.
 	f := onboarding.New(info.Inventory)
 	filePath := onboarding.FilePath(info.Path)
@@ -68,7 +74,7 @@ func runEnroll(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	systemPrompt := buildEnrollSystemPrompt(info, filePath)
+	systemPrompt := buildEnrollSystemPrompt(info, filePath, agentReport)
 	agentCmd := exec.Command(claudePath, "--append-system-prompt", systemPrompt,
 		"Begin the onboarding interview for this repository.")
 	agentCmd.Dir = info.Path
@@ -85,11 +91,66 @@ func runEnroll(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Println("\nOnboarding complete.")
+	// Validate agent definitions after the agent finishes.
+	if errs := supervisor.ValidateAgentDefs(repoDir); len(errs) > 0 {
+		fmt.Println("\nAgent definition validation errors:")
+		for _, e := range errs {
+			fmt.Printf("  - %s\n", e)
+		}
+		fmt.Println("Fix these issues in .claude/agents/ and re-run validation.")
+	} else {
+		fmt.Println("\nAll agent definitions validated successfully.")
+	}
+
+	fmt.Println("Onboarding complete.")
 	return nil
 }
 
-func buildEnrollSystemPrompt(info *discovery.RepoInfo, filePath string) string {
+// installAgentDefs discovers existing agents and installs missing required ones.
+// Returns a report string for the onboarding agent prompt.
+func installAgentDefs(repoDir string) string {
+	existing := supervisor.DiscoverAgents(repoDir)
+	existingNames := map[string]string{} // name → source
+	for _, a := range existing {
+		existingNames[a.Name] = a.Source
+	}
+
+	var installed, skipped []string
+	for _, tmpl := range supervisor.AgentTemplates() {
+		if !tmpl.Required {
+			continue
+		}
+		if source, ok := existingNames[tmpl.Name]; ok {
+			skipped = append(skipped, fmt.Sprintf("%s (already exists at %s level)", tmpl.Name, source))
+			continue
+		}
+		path, err := supervisor.InstallAgentDef(repoDir, tmpl)
+		if err != nil {
+			fmt.Printf("Warning: failed to install %s agent: %v\n", tmpl.Name, err)
+			continue
+		}
+		installed = append(installed, tmpl.Name)
+		fmt.Printf("Installed agent definition: %s\n", path)
+	}
+
+	var report strings.Builder
+	if len(installed) > 0 {
+		fmt.Fprintf(&report, "Installed agent definitions: %s\n", strings.Join(installed, ", "))
+	}
+	if len(skipped) > 0 {
+		fmt.Fprintf(&report, "Existing agent definitions: %s\n", strings.Join(skipped, "; "))
+	}
+	return report.String()
+}
+
+func buildEnrollSystemPrompt(info *discovery.RepoInfo, filePath, agentReport string) string {
+	// Build template reference for the agent.
+	var templateRef strings.Builder
+	for _, tmpl := range supervisor.AgentTemplates() {
+		fmt.Fprintf(&templateRef, "\n### %s.md\nFrontmatter (DO NOT MODIFY):\n```yaml\n---\n%s\n---\n```\n",
+			tmpl.Name, tmpl.Frontmatter)
+	}
+
 	return fmt.Sprintf(`You are an onboarding agent for agent-minder. Your job is to interview the user
 about their repository and fill in the onboarding configuration file.
 
@@ -98,15 +159,38 @@ The repository has been scanned and an initial file created at: %s
 Repository: %s
 Languages: %v
 
-Your goals:
-1. Ask about the test command (verify it works by running it)
-2. Ask about the build command
-3. Ask about any lint commands
-4. Ask about the base branch for PRs (main, dev, develop, etc.) — check git branch output
-5. Ask about special instructions for agents working in this repo
-6. Determine which tools agents need (start with defaults, add as needed)
-7. Update the onboarding file with the gathered information (including base_branch in the context section)
-8. Run validation to ensure the config is correct
+%s
 
-Be concise and efficient. Most repos need minimal configuration.`, filePath, info.Path, info.Inventory.Languages)
+## Your goals
+
+### 1. Onboarding configuration
+- Ask about the test command (verify it works by running it)
+- Ask about the build command
+- Ask about any lint commands
+- Ask about the base branch for PRs (main, dev, develop, etc.) — check git branch output
+- Ask about special instructions for agents working in this repo
+- Determine which tools agents need (start with defaults, add as needed)
+- Update the onboarding file with the gathered information (including base_branch in the context section)
+
+### 2. Customize agent definitions
+Agent definition files are in .claude/agents/*.md. Each file has YAML frontmatter
+between --- markers, followed by instruction text.
+
+CRITICAL RULES for agent definitions:
+- The YAML frontmatter (between the --- markers) must NOT be modified. It contains
+  contract fields that the orchestrator parses. Changing it will break the agent.
+- You may ONLY modify the instruction text BELOW the closing --- marker.
+- Customize the instructions based on what you learn about the repo: coding conventions,
+  test patterns, important directories, review standards, etc.
+- Keep instructions concise and actionable.
+
+Reference frontmatter for each agent type:
+%s
+
+### 3. Validate
+- Run validation to ensure the onboarding config is correct
+- Check that all agent definitions in .claude/agents/ are parseable
+
+Be concise and efficient. Most repos need minimal configuration.`,
+		filePath, info.Path, info.Inventory.Languages, agentReport, templateRef.String())
 }

--- a/internal/supervisor/templates.go
+++ b/internal/supervisor/templates.go
@@ -1,0 +1,126 @@
+package supervisor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// AgentTemplate defines a template for installing agent definitions.
+type AgentTemplate struct {
+	Name        string
+	Required    bool   // required agents are installed automatically
+	Frontmatter string // YAML frontmatter (between --- markers)
+	DefaultBody string // default instruction body
+}
+
+// AgentTemplates returns all known agent templates.
+func AgentTemplates() []AgentTemplate {
+	return []AgentTemplate{
+		{
+			Name:     "autopilot",
+			Required: true,
+			Frontmatter: `name: autopilot
+description: >
+  Autonomous agent that implements GitHub issues in isolated git worktrees.
+tools: Bash, Read, Edit, Write, Glob, Grep
+mode: reactive
+output: pr
+context:
+  - issue
+  - repo_info
+  - lessons
+  - sibling_jobs
+  - dep_graph`,
+			DefaultBody: `You are an autonomous agent working on a GitHub issue in an isolated git worktree.
+Your task context is provided in the user prompt.
+
+## First steps
+1. Label the issue in-progress using the gh command from your task context
+2. Post a starting comment
+3. Read the full issue with comments and any linked issues
+4. Explore the codebase to understand the relevant code
+
+## If you can complete the work
+- Implement the changes
+- Ensure tests pass
+- Commit with "Fixes #<issue>" in the message
+- Rebase onto the base branch before pushing
+- Open a draft PR
+
+## If you cannot proceed
+- Post a comment on the issue explaining what blocks you
+- Add the "blocked" label and remove the "in-progress" label
+
+## Constraints
+- Only modify files within your worktree
+- Do not keep retrying if stuck — bail early with good context
+- Do not over-engineer`,
+		},
+		{
+			Name:     "reviewer",
+			Required: true,
+			Frontmatter: `name: reviewer
+description: >
+  Reviews PRs opened by autopilot agents. Checks for correctness,
+  test coverage, and code quality.
+tools: Bash, Read, Edit, Write, Glob, Grep
+mode: reactive
+output: pr`,
+			DefaultBody: `You are a code reviewer examining a PR opened by an automated agent.
+Review context is provided in the user prompt.
+
+## Review process
+1. Read the PR diff and understand the changes
+2. Check that the implementation matches the issue requirements
+3. Run the test command if provided
+4. Look for bugs, edge cases, and missing error handling
+5. Assess risk level: low-risk, needs-testing, or suspect
+
+## If changes are needed
+- Make the fixes directly in the worktree
+- Run tests to verify
+- Commit and push`,
+		},
+	}
+}
+
+// InstallAgentDef writes an agent definition file to the repo's .claude/agents/ directory.
+// Only writes the frontmatter + default body. Returns the file path.
+func InstallAgentDef(repoDir string, tmpl AgentTemplate) (string, error) {
+	dir := filepath.Join(repoDir, ".claude", "agents")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("create agents dir: %w", err)
+	}
+
+	path := filepath.Join(dir, tmpl.Name+".md")
+	content := fmt.Sprintf("---\n%s\n---\n\n%s\n", tmpl.Frontmatter, tmpl.DefaultBody)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return "", fmt.Errorf("write agent def: %w", err)
+	}
+	return path, nil
+}
+
+// ValidateAgentDefs checks all .md files in .claude/agents/ parse correctly.
+// Returns a list of validation errors (empty if all valid).
+func ValidateAgentDefs(repoDir string) []string {
+	agentsDir := filepath.Join(repoDir, ".claude", "agents")
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		return nil // no agents dir is fine
+	}
+
+	var errors []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		path := filepath.Join(agentsDir, e.Name())
+		_, err := ParseContract(path)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("%s: %v", e.Name(), err))
+		}
+	}
+	return errors
+}

--- a/internal/supervisor/templates_test.go
+++ b/internal/supervisor/templates_test.go
@@ -1,0 +1,128 @@
+package supervisor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentTemplates(t *testing.T) {
+	templates := AgentTemplates()
+	if len(templates) < 2 {
+		t.Fatalf("expected at least 2 templates, got %d", len(templates))
+	}
+
+	// Check required agents exist.
+	names := map[string]bool{}
+	for _, tmpl := range templates {
+		names[tmpl.Name] = true
+	}
+	for _, required := range []string{"autopilot", "reviewer"} {
+		if !names[required] {
+			t.Errorf("missing required template: %s", required)
+		}
+	}
+}
+
+func TestAgentTemplates_FrontmatterParseable(t *testing.T) {
+	for _, tmpl := range AgentTemplates() {
+		t.Run(tmpl.Name, func(t *testing.T) {
+			content := "---\n" + tmpl.Frontmatter + "\n---\n\n" + tmpl.DefaultBody
+			contract, err := ParseContractFromBytes([]byte(content))
+			if err != nil {
+				t.Fatalf("template %s frontmatter not parseable: %v", tmpl.Name, err)
+			}
+			if contract.Name != tmpl.Name {
+				t.Errorf("name mismatch: got %q, want %q", contract.Name, tmpl.Name)
+			}
+		})
+	}
+}
+
+func TestInstallAgentDef(t *testing.T) {
+	dir := t.TempDir()
+	tmpl := AgentTemplates()[0] // autopilot
+
+	path, err := InstallAgentDef(dir, tmpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// File should exist.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("installed file doesn't exist: %v", err)
+	}
+
+	// Should be parseable.
+	contract, err := ParseContract(path)
+	if err != nil {
+		t.Fatalf("installed def not parseable: %v", err)
+	}
+	if contract.Name != tmpl.Name {
+		t.Errorf("name = %q, want %q", contract.Name, tmpl.Name)
+	}
+
+	// File should contain frontmatter and body.
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "---") {
+		t.Error("missing frontmatter markers")
+	}
+	if !strings.Contains(content, tmpl.DefaultBody[:20]) {
+		t.Error("missing default body")
+	}
+}
+
+func TestInstallAgentDef_DoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	tmpl := AgentTemplates()[0]
+
+	// Install once.
+	path, _ := InstallAgentDef(dir, tmpl)
+
+	// Write custom content.
+	custom := "---\nname: autopilot\n---\n\nCustom instructions here."
+	_ = os.WriteFile(path, []byte(custom), 0644)
+
+	// Install again — should overwrite (caller should check existence first).
+	_, _ = InstallAgentDef(dir, tmpl)
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), "Custom instructions") {
+		t.Error("expected overwrite, but custom content persisted")
+	}
+}
+
+func TestValidateAgentDefs_Valid(t *testing.T) {
+	dir := t.TempDir()
+	for _, tmpl := range AgentTemplates() {
+		_, _ = InstallAgentDef(dir, tmpl)
+	}
+
+	errs := ValidateAgentDefs(dir)
+	if len(errs) > 0 {
+		t.Errorf("unexpected validation errors: %v", errs)
+	}
+}
+
+func TestValidateAgentDefs_Invalid(t *testing.T) {
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, ".claude", "agents")
+	_ = os.MkdirAll(agentsDir, 0755)
+
+	// Write a broken agent def.
+	_ = os.WriteFile(filepath.Join(agentsDir, "broken.md"), []byte("no frontmatter here"), 0644)
+
+	errs := ValidateAgentDefs(dir)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 validation error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateAgentDefs_NoDir(t *testing.T) {
+	dir := t.TempDir()
+	errs := ValidateAgentDefs(dir)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for missing dir, got %v", errs)
+	}
+}


### PR DESCRIPTION
## Summary
- `minder enroll` now installs required agent definitions (autopilot, reviewer) if missing
- Onboarding agent receives frontmatter templates with strict instructions: customize body only, never touch frontmatter
- Post-enrollment validation checks all agent defs parse correctly
- `AgentTemplates()` registry makes it easy to add new agent types (dep-updater, security-scanner, etc.)

## Design
Two-step approach for agent customization:
1. Go code handles frontmatter assembly (contract fields are always correct)
2. Onboarding agent customizes only the instruction text based on repo context

## New files
- `internal/supervisor/templates.go` — Template registry, InstallAgentDef, ValidateAgentDefs
- `internal/supervisor/templates_test.go` — 7 tests

## Test plan
- [x] All tests pass (7 new template tests + existing)
- [ ] Run `minder enroll` on a fresh repo to verify full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)