### PR TITLE
Generic stage executor: iterate declared pipeline stages

### DIFF
--- a/internal/supervisor/jobmanager.go
+++ b/internal/supervisor/jobmanager.go
@@ -325,10 +325,16 @@ func (m *DefaultJobManager) Run(ctx context.Context) error {
 	}
 	defer func() { _ = logFile.Close() }()
 
-	// If no stages declared, run as a single-stage job.
+	// If no stages declared, use default pipeline.
+	// Code stage always runs; review stage added if review is enabled.
 	stages := contract.Stages
 	if len(stages) == 0 {
 		stages = []StageContract{{Name: "code", Agent: job.Agent, OnFailure: "bail"}}
+		if sc.Deploy.ReviewEnabled {
+			stages = append(stages, StageContract{
+				Name: "review", Agent: "reviewer", OnFailure: "skip", Retries: 1,
+			})
+		}
 	}
 
 	// --- Stage loop ---


### PR DESCRIPTION
## Summary
- Refactors `DefaultJobManager.Run()` from hardcoded code→review to a generic stage loop
- Stages execute from `contract.Stages` — each stage runs its declared agent
- `on_failure` handling: `bail` (stop), `skip` (next stage), `retry` (re-run previous with feedback)
- Smart retries: only when review finds fixable issues, never on bail or budget exhaustion
- Review feedback formatted as numbered issues list and injected into retry prompt
- Backward-compatible: default autopilot contract declares `[code, review]` stages

## What changed
`jobmanager.go`: +248/-104 lines. The monolithic `Run()` is now a stage loop with extracted `executeCodeStage()`, `executeReviewStage()`, `finalizePipeline()`, `finalizeBail()`, and `formatReviewFeedback()`.

## Test plan
- [x] All existing tests pass
- [ ] Deploy with default autopilot (code→review pipeline should behave identically)
- [ ] Test review retry by deploying on an issue that gets "suspect" review

Fixes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)