### PR TITLE
Fix daemon exiting immediately on scheduler-only deploys

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -433,9 +433,9 @@ func runDaemon(deployID string) error {
 		go func() { _ = srv.ListenAndServe(flagServe) }()
 	}
 
-	// Check if we have jobs to run.
+	// Check if we have jobs to run or schedules to wait for.
 	existingJobs, _ := store.GetJobs(deployID)
-	if len(existingJobs) == 0 && deploy.Mode != "watch" {
+	if len(existingJobs) == 0 && deploy.Mode != "watch" && sched == nil {
 		fmt.Println("No jobs to run. Exiting.")
 		return nil
 	}


### PR DESCRIPTION
## Summary
The daemon child process checked for existing jobs and exited if none found, without considering that the scheduler would create them when cron fires. Now checks for `sched != nil` before exiting.

One-line fix in `cmd/deploy.go`.

## Test plan
- [x] `minder deploy --repo . --serve :7749` stays alive with only jobs.yaml (no issues, no --watch)
- [x] SwiftBar shows daemon status

🤖 Generated with [Claude Code](https://claude.com/claude-code)