### PR TITLE
Bug-fixer agent + trigger routing (label→agent)

### DIFF
--- a/.agent-minder/jobs.yaml
+++ b/.agent-minder/jobs.yaml
@@ -1,4 +1,12 @@
 jobs:
+  # --- Trigger routes (label→agent) ---
+  bug-fix:
+    trigger: "label:bug"
+    agent: bug-fixer
+    description: "Fix bugs automatically"
+    budget: 5.0
+
+  # --- Weekly cron schedules (UTC times) ---
   weekly-deps:
     schedule: "0 15 * * 1"
     agent: dependency-updater

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -402,6 +402,20 @@ func runDaemon(deployID string) error {
 		}
 	}
 
+	// Extract trigger routes from jobs.yaml and register with supervisor.
+	if cfg, err := scheduler.LoadConfig(cfgPath); err == nil {
+		var routes []supervisor.TriggerRoute
+		for _, def := range cfg.Jobs {
+			if label := def.TriggerLabel(); label != "" {
+				routes = append(routes, supervisor.TriggerRoute{Label: label, Agent: def.Agent})
+			}
+		}
+		if len(routes) > 0 {
+			sup.SetTriggerRoutes(routes)
+			fmt.Printf("  Trigger routes: %d label→agent mappings\n", len(routes))
+		}
+	}
+
 	// Daemon mode if watch, or if we have schedules to evaluate.
 	sup.SetDaemonMode(deploy.Mode == "watch" || sched != nil)
 

--- a/internal/scheduler/config.go
+++ b/internal/scheduler/config.go
@@ -36,6 +36,18 @@ func (j *JobDef) IsTrigger() bool {
 	return j.Trigger != ""
 }
 
+// TriggerLabel returns the label name if this is a label trigger, or empty string.
+func (j *JobDef) TriggerLabel() string {
+	if !j.IsTrigger() {
+		return ""
+	}
+	parts := strings.SplitN(j.Trigger, ":", 2)
+	if len(parts) == 2 && parts[0] == "label" {
+		return parts[1]
+	}
+	return ""
+}
+
 // ParsedSchedule returns the parsed cron expression, or nil if not scheduled.
 func (j *JobDef) ParsedSchedule() (*CronExpr, error) {
 	if j.Schedule == "" {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -97,6 +97,7 @@ type Supervisor struct {
 	active             bool
 	daemonMode         bool
 	watchMode          bool
+	triggerRoutes      []TriggerRoute // label→agent routing from jobs.yaml
 	paused             bool
 	budgetPaused       bool
 	budgetWarned       bool

--- a/internal/supervisor/templates.go
+++ b/internal/supervisor/templates.go
@@ -84,6 +84,55 @@ Review context is provided in the user prompt.
 - Commit and push`,
 		},
 		{
+			Name:     "bug-fixer",
+			Required: false,
+			Frontmatter: `name: bug-fixer
+description: >
+  Specialized agent for fixing bugs. Reproduces the issue first,
+  writes a regression test, then implements the fix.
+tools: Bash, Read, Edit, Write, Glob, Grep
+mode: reactive
+output: pr
+context:
+  - issue
+  - repo_info
+  - lessons
+  - sibling_jobs`,
+			DefaultBody: `You are a bug-fixing agent working in an isolated git worktree.
+Your task context is provided in the user prompt.
+
+## Process
+1. **Understand the bug** — read the report, understand expected vs actual behavior
+2. **Investigate the code** — trace the code path, find the root cause
+3. **Assess reproducibility** — can you write an automated test for this?
+   - If yes: write a regression test that fails, then fix it
+   - If no (UI, browser, environment-specific): proceed with the fix based on
+     code analysis alone — note in the PR that manual testing is needed
+4. **Implement the fix** — minimal change to fix the root cause
+5. **Run tests** — full test suite must pass
+6. **Commit and PR** — commit with "Fixes #<issue>", open a draft PR
+
+## Key principles
+- Always attempt the fix if you understand the root cause, even if you can't
+  reproduce it. You're running headless — many bugs involve UI, browsers, or
+  specific environments you don't have access to. Code analysis is sufficient
+  when the bug is clear from reading the code.
+- Write a regression test when possible, but don't bail just because you can't.
+  A fix without a test is better than no fix at all.
+- Minimal changes only — fix the bug, don't refactor surrounding code.
+- If the root cause is architectural, fix the immediate symptom and explain
+  the deeper issue in the PR description.
+
+## When to bail
+- You don't understand what the bug is (ambiguous report, missing context)
+- The fix requires changes across many unrelated systems
+- You're not confident your change actually addresses the root cause
+
+## Labels
+- Add "in-progress" when starting
+- Remove "in-progress" and add "needs-review" when PR is opened`,
+		},
+		{
 			Name:     "dependency-updater",
 			Required: false,
 			Frontmatter: `name: dependency-updater

--- a/internal/supervisor/watch.go
+++ b/internal/supervisor/watch.go
@@ -17,6 +17,21 @@ type WatchFilter struct {
 	Value string
 }
 
+// TriggerRoute maps a label to an agent type.
+// When an issue has the matching label, it's routed to the specified agent
+// instead of the default autopilot.
+type TriggerRoute struct {
+	Label string // GitHub label to match
+	Agent string // agent type to use
+}
+
+// SetTriggerRoutes configures label→agent routing from jobs.yaml triggers.
+func (s *Supervisor) SetTriggerRoutes(routes []TriggerRoute) {
+	s.mu.Lock()
+	s.triggerRoutes = routes
+	s.mu.Unlock()
+}
+
 // ParseWatchFilter parses a filter string like "label:ready" or "milestone:v2.0".
 func ParseWatchFilter(filter string) (*WatchFilter, error) {
 	parts := strings.SplitN(filter, ":", 2)
@@ -34,39 +49,10 @@ func ParseWatchFilter(filter string) (*WatchFilter, error) {
 	return &WatchFilter{Type: typ, Value: value}, nil
 }
 
-// watchPoll queries GitHub for issues matching the watch filter and creates tasks for new ones.
-// Returns the number of newly discovered issues.
+// watchPoll queries GitHub for issues matching the watch filter and trigger routes,
+// and creates jobs for new ones. Returns the number of newly discovered issues.
 func (s *Supervisor) watchPoll(ctx context.Context) int {
-	if !s.deploy.WatchFilter.Valid || s.deploy.WatchFilter.String == "" {
-		return 0
-	}
-
-	filter, err := ParseWatchFilter(s.deploy.WatchFilter.String)
-	if err != nil {
-		s.emitEvent("warning", fmt.Sprintf("Invalid watch filter: %v", err), 0)
-		return 0
-	}
-
 	ghClient := s.newGHClient()
-
-	var searchResult *ghpkg.SearchResult
-	switch filter.Type {
-	case "label":
-		searchResult, err = ghClient.ListIssuesByLabel(ctx, s.owner, s.repo, filter.Value)
-	case "milestone":
-		msNum, msErr := ghClient.FindMilestoneNumber(ctx, s.owner, s.repo, filter.Value)
-		if msErr != nil {
-			s.emitEvent("warning", fmt.Sprintf("Milestone lookup failed: %v", msErr), 0)
-			return 0
-		}
-		searchResult, err = ghClient.ListIssuesByMilestone(ctx, s.owner, s.repo, msNum)
-	}
-	if err != nil {
-		s.emitEvent("warning", fmt.Sprintf("Watch poll failed: %v", err), 0)
-		return 0
-	}
-
-	issues := searchResult.Items
 
 	// Get existing jobs to find new issues.
 	existing, _ := s.store.GetJobs(s.deploy.ID)
@@ -75,49 +61,110 @@ func (s *Supervisor) watchPoll(ctx context.Context) int {
 		knownIssues[j.IssueNumber] = true
 	}
 
-	// Check skip label.
 	skipLabel := s.deploy.SkipLabel
-
 	discovered := 0
-	for _, issue := range issues {
-		if issue.State != "open" {
-			continue
-		}
-		if knownIssues[issue.Number] {
-			continue
-		}
-		if hasLabel(issue.Labels, skipLabel) {
-			continue
-		}
 
-		// Fetch full issue content.
-		content, _ := ghClient.FetchItemContent(ctx, s.owner, s.repo, issue.Number, "issue")
-		body := ""
-		if content != nil {
-			body = content.Body
+	// 1. Poll the --watch filter (routes to default agent).
+	if s.deploy.WatchFilter.Valid && s.deploy.WatchFilter.String != "" {
+		issues := s.pollFilter(ctx, ghClient, s.deploy.WatchFilter.String)
+		for _, issue := range issues {
+			if knownIssues[issue.Number] || issue.State != "open" || hasLabel(issue.Labels, skipLabel) {
+				continue
+			}
+			agent := s.resolveAgentForIssue(issue.Labels)
+			if n := s.createJobForIssue(ctx, ghClient, issue, agent); n > 0 {
+				knownIssues[issue.Number] = true
+				discovered += n
+			}
 		}
+	}
 
-		j := &db.Job{
-			DeploymentID: s.deploy.ID,
-			Agent:        "autopilot",
-			Name:         fmt.Sprintf("issue-%d", issue.Number),
-			IssueNumber:  issue.Number,
-			IssueTitle:   sql.NullString{String: issue.Title, Valid: true},
-			IssueBody:    sql.NullString{String: body, Valid: body != ""},
-			Owner:        s.owner,
-			Repo:         s.repo,
-			Status:       db.StatusQueued,
+	// 2. Poll trigger routes (label→agent mapping from jobs.yaml).
+	s.mu.Lock()
+	routes := s.triggerRoutes
+	s.mu.Unlock()
+
+	for _, route := range routes {
+		issues := s.pollFilter(ctx, ghClient, "label:"+route.Label)
+		for _, issue := range issues {
+			if knownIssues[issue.Number] || issue.State != "open" || hasLabel(issue.Labels, skipLabel) {
+				continue
+			}
+			if n := s.createJobForIssue(ctx, ghClient, issue, route.Agent); n > 0 {
+				knownIssues[issue.Number] = true
+				discovered += n
+			}
 		}
-
-		if err := s.store.CreateJob(j); err != nil {
-			continue
-		}
-
-		discovered++
-		s.emitEvent("info", fmt.Sprintf("Discovered #%d: %s", issue.Number, issue.Title), j.ID)
 	}
 
 	return discovered
+}
+
+// pollFilter queries GitHub for issues matching a filter string.
+func (s *Supervisor) pollFilter(ctx context.Context, ghClient *ghpkg.Client, filterStr string) []ghpkg.ItemStatus {
+	filter, err := ParseWatchFilter(filterStr)
+	if err != nil {
+		return nil
+	}
+
+	var searchResult *ghpkg.SearchResult
+	switch filter.Type {
+	case "label":
+		searchResult, err = ghClient.ListIssuesByLabel(ctx, s.owner, s.repo, filter.Value)
+	case "milestone":
+		msNum, msErr := ghClient.FindMilestoneNumber(ctx, s.owner, s.repo, filter.Value)
+		if msErr != nil {
+			return nil
+		}
+		searchResult, err = ghClient.ListIssuesByMilestone(ctx, s.owner, s.repo, msNum)
+	}
+	if err != nil || searchResult == nil {
+		return nil
+	}
+	return searchResult.Items
+}
+
+// resolveAgentForIssue checks the issue's labels against trigger routes.
+// Returns the matching agent, or "autopilot" as default.
+func (s *Supervisor) resolveAgentForIssue(labels []string) string {
+	s.mu.Lock()
+	routes := s.triggerRoutes
+	s.mu.Unlock()
+
+	for _, route := range routes {
+		if hasLabel(labels, route.Label) {
+			return route.Agent
+		}
+	}
+	return "autopilot"
+}
+
+// createJobForIssue fetches issue content and inserts a job row.
+func (s *Supervisor) createJobForIssue(ctx context.Context, ghClient *ghpkg.Client, issue ghpkg.ItemStatus, agent string) int {
+	content, _ := ghClient.FetchItemContent(ctx, s.owner, s.repo, issue.Number, "issue")
+	body := ""
+	if content != nil {
+		body = content.Body
+	}
+
+	j := &db.Job{
+		DeploymentID: s.deploy.ID,
+		Agent:        agent,
+		Name:         fmt.Sprintf("issue-%d", issue.Number),
+		IssueNumber:  issue.Number,
+		IssueTitle:   sql.NullString{String: issue.Title, Valid: true},
+		IssueBody:    sql.NullString{String: body, Valid: body != ""},
+		Owner:        s.owner,
+		Repo:         s.repo,
+		Status:       db.StatusQueued,
+	}
+
+	if err := s.store.CreateJob(j); err != nil {
+		return 0
+	}
+
+	s.emitEvent("info", fmt.Sprintf("Discovered #%d: %s (agent: %s)", issue.Number, issue.Title, agent), j.ID)
+	return 1
 }
 
 // isValidFilterValue checks that a filter value contains only safe characters:


### PR DESCRIPTION
## Summary
- **Bug-fixer agent template**: specialized for headless bug fixing — attempts fixes based on code analysis even when reproduction isn't possible, writes regression tests when feasible
- **Trigger routing**: jobs.yaml `trigger: "label:bug"` routes matching issues to the bug-fixer agent instead of autopilot
- **Watch mode refactored**: polls both --watch filter and trigger labels, routes to the right agent per issue

## How it works
```yaml
# jobs.yaml
jobs:
  bug-fix:
    trigger: "label:bug"
    agent: bug-fixer
```

When watch mode discovers an issue with the `bug` label, it creates a job with `agent: bug-fixer` instead of `autopilot`. Issues matching --watch but no trigger still go to autopilot.

## Test plan
- [x] All tests pass
- [ ] Label an issue with `bug`, verify it gets picked up by the bug-fixer agent
- [ ] Verify issues with `agent-ready` but not `bug` still route to autopilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)