### PR TITLE
Fix SwiftBar plugin stale status after daemon restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Watch polling for TUI autopilot**: Optional `--watch-milestone` / `--watch-label` flags on the `start` command enable continuous GitHub issue discovery during autopilot sessions. New issues matching the filter are created as `pending` tasks and automatically ingested with incremental dep analysis. TUI shows a "watching" indicator when active. (#337)
 
 ### Fixed
+- **SwiftBar plugin shows stale status after daemon restart**: Updated `scripts/agent-minder.30s.sh` to use v2 schema (`deployments`/`jobs` tables, `v2.db` path) and filter to only active deployments via PID file checks. Also fixed `/jobs` and `/lessons` API endpoints to return `[]` instead of `null` when empty. (#434)
 - **Scheduler SQLite contention and UNIQUE constraint**: Fixed SQLITE_BUSY errors from concurrent scheduler/supervisor DB access; handle UNIQUE constraint violations when reinserting schedules; improved error logging (#431)
 - **Daemon exiting on scheduler-only deploys**: Fixed daemon exiting immediately when running with only scheduled jobs and no issue arguments (#427)
 - **Enroll validation**: Use minder CLI for YAML validation instead of Python/Ruby YAML parsers (#422)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -152,7 +152,7 @@ func (s *Server) handleJobs(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	var resp []JobResponse
+	resp := make([]JobResponse, 0, len(jobs))
 	for _, j := range jobs {
 		resp = append(resp, jobToResponse(j))
 	}
@@ -264,7 +264,7 @@ func (s *Server) handleLessons(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var resp []LessonResponse
+	resp := make([]LessonResponse, 0, len(lessons))
 	for _, l := range lessons {
 		resp = append(resp, LessonResponse{
 			ID:             l.ID,

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -84,6 +84,36 @@ func TestHandleStatus(t *testing.T) {
 	}
 }
 
+func TestHandleJobsEmptyReturnsArray(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// A fresh deploy with no jobs should return [] not null.
+	rr := doRequest(t, srv, "GET", "/jobs")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+	if body != "[]\n" {
+		t.Errorf("empty jobs response = %q, want %q (must be JSON array, not null)", body, "[]\n")
+	}
+}
+
+func TestHandleLessonsEmptyReturnsArray(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// No lessons exist — should return [] not null.
+	rr := doRequest(t, srv, "GET", "/lessons")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+	if body != "[]\n" {
+		t.Errorf("empty lessons response = %q, want %q (must be JSON array, not null)", body, "[]\n")
+	}
+}
+
 func TestHandleTasks(t *testing.T) {
 	srv, store := testServer(t)
 

--- a/scripts/agent-minder.30s.sh
+++ b/scripts/agent-minder.30s.sh
@@ -18,7 +18,7 @@
 # <xbar.title>agent-minder</xbar.title>
 # <xbar.desc>Deploy watch status indicator</xbar.desc>
 # <xbar.author>Dustin Mays</xbar.author>
-# <xbar.version>1.0</xbar.version>
+# <xbar.version>2.0</xbar.version>
 # <xbar.dependencies>agent-minder</xbar.dependencies>
 
 # --- Configuration ---
@@ -27,29 +27,37 @@ export PATH="${BREW_PREFIX}/bin:${HOME}/go/bin:${HOME}/.local/bin:/usr/local/bin
 
 MINDER="${AGENT_MINDER_BIN:-agent-minder}"
 LOGS_DIR="${HOME}/.agent-minder"
+DEPLOYS_DIR="${LOGS_DIR}/deploys"
 LAUNCHD_LOG="${LOGS_DIR}/launchd-daemon.log"
 
 # --- Helpers ---
 icon_for_status() {
     case "$1" in
-        running)  echo "🔄" ;;
-        queued)   echo "⏳" ;;
-        blocked)  echo "🚫" ;;
-        pending)  echo "📋" ;;
-        review)   echo "👀" ;;
+        running)   echo "🔄" ;;
+        queued)    echo "⏳" ;;
+        blocked)   echo "🚫" ;;
+        review)    echo "👀" ;;
         reviewing) echo "🔍" ;;
-        done)     echo "✅" ;;
-        bailed)   echo "❌" ;;
-        failed)   echo "💥" ;;
-        stopped)  echo "⏹" ;;
-        manual)   echo "🔧" ;;
-        skipped)  echo "⏭" ;;
-        *)        echo "·" ;;
+        reviewed)  echo "✅" ;;
+        done)      echo "✅" ;;
+        bailed)    echo "❌" ;;
+        stopped)   echo "⏹" ;;
+        *)         echo "·" ;;
     esac
 }
 
+# Check if a deployment daemon is alive by inspecting its PID file.
+is_deploy_alive() {
+    local deploy_id="$1"
+    local pid_file="${DEPLOYS_DIR}/${deploy_id}.pid"
+    [[ -f "$pid_file" ]] || return 1
+    local pid
+    pid=$(cat "$pid_file" 2>/dev/null)
+    [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
 # --- Gather data ---
-# Get deploy list output. If agent-minder isn't available, show offline.
+# If agent-minder isn't available, show offline.
 if ! command -v "$MINDER" &>/dev/null; then
     echo "🤖 ?"
     echo "---"
@@ -58,9 +66,8 @@ if ! command -v "$MINDER" &>/dev/null; then
     exit 0
 fi
 
-# Parse deploy projects from the database directly via deploy list.
-# We read the DB to get structured data since deploy list is text-only.
-DB="${MINDER_DB:-${HOME}/.agent-minder/minder.db}"
+# Use the v2 database path (matches internal/db.DefaultDBPath).
+DB="${MINDER_DB:-${HOME}/.agent-minder/v2.db}"
 
 if [[ ! -f "$DB" ]]; then
     echo "🤖 —"
@@ -70,29 +77,51 @@ if [[ ! -f "$DB" ]]; then
     exit 0
 fi
 
-# Query deploy projects and their task counts using sqlite3.
-# This avoids parsing CLI text output and is much more reliable.
+# Query deployments and their job counts using sqlite3.
+# Uses the v2 schema: deployments + jobs tables.
+# Order by started_at DESC so the most recent deploy is first.
 DEPLOY_DATA=$(sqlite3 "$DB" "
-    SELECT p.name, p.goal_description,
-        COUNT(CASE WHEN t.status = 'running' THEN 1 END) as running,
-        COUNT(CASE WHEN t.status = 'queued' THEN 1 END) as queued,
-        COUNT(CASE WHEN t.status IN ('pending', 'blocked') THEN 1 END) as waiting,
-        COUNT(CASE WHEN t.status = 'review' THEN 1 END) as review,
-        COUNT(CASE WHEN t.status = 'done' THEN 1 END) as done,
-        COUNT(CASE WHEN t.status IN ('bailed', 'failed', 'stopped') THEN 1 END) as errored,
-        COUNT(*) as total,
-        COALESCE(SUM(t.cost_usd), 0) as cost
-    FROM projects p
-    LEFT JOIN autopilot_tasks t ON t.project_id = p.id
-    WHERE p.is_deploy = 1
-    GROUP BY p.id
-    ORDER BY p.created_at DESC;
+    SELECT d.id, d.owner || '/' || d.repo, d.mode,
+        COUNT(CASE WHEN j.status = 'running' THEN 1 END) as running,
+        COUNT(CASE WHEN j.status = 'queued' THEN 1 END) as queued,
+        COUNT(CASE WHEN j.status = 'blocked' THEN 1 END) as waiting,
+        COUNT(CASE WHEN j.status IN ('review', 'reviewing', 'reviewed') THEN 1 END) as review,
+        COUNT(CASE WHEN j.status = 'done' THEN 1 END) as done,
+        COUNT(CASE WHEN j.status IN ('bailed', 'stopped') THEN 1 END) as errored,
+        COUNT(j.id) as total,
+        COALESCE(SUM(j.cost_usd), 0) as cost,
+        d.total_budget_usd
+    FROM deployments d
+    LEFT JOIN jobs j ON j.deployment_id = d.id
+    GROUP BY d.id
+    ORDER BY d.started_at DESC;
 " 2>/dev/null)
 
 if [[ -z "$DEPLOY_DATA" ]]; then
     echo "🤖 —"
     echo "---"
     echo "No deployments | color=gray"
+    echo "---"
+    echo "Refresh | refresh=true"
+    exit 0
+fi
+
+# Filter to only alive deployments (daemon process still running).
+ALIVE_DATA=""
+while IFS='|' read -r deploy_id fullrepo mode running queued waiting review done errored total cost budget; do
+    [[ -z "$deploy_id" ]] && continue
+    if is_deploy_alive "$deploy_id"; then
+        ALIVE_DATA+="${deploy_id}|${fullrepo}|${mode}|${running}|${queued}|${waiting}|${review}|${done}|${errored}|${total}|${cost}|${budget}"$'\n'
+    fi
+done <<< "$DEPLOY_DATA"
+
+# Remove trailing newline.
+ALIVE_DATA="${ALIVE_DATA%$'\n'}"
+
+if [[ -z "$ALIVE_DATA" ]]; then
+    echo "🤖 —"
+    echo "---"
+    echo "No active deployments | color=gray"
     echo "---"
     echo "Refresh | refresh=true"
     exit 0
@@ -106,7 +135,7 @@ TOTAL_ERRORED=0
 TOTAL_ALL=0
 HAS_ACTIVE=false
 
-while IFS='|' read -r name desc running queued waiting review done errored total cost; do
+while IFS='|' read -r deploy_id fullrepo mode running queued waiting review done errored total cost budget; do
     TOTAL_RUNNING=$((TOTAL_RUNNING + running))
     TOTAL_DONE=$((TOTAL_DONE + done))
     TOTAL_ERRORED=$((TOTAL_ERRORED + errored))
@@ -114,7 +143,7 @@ while IFS='|' read -r name desc running queued waiting review done errored total
     if [[ $running -gt 0 || $queued -gt 0 || $waiting -gt 0 ]]; then
         HAS_ACTIVE=true
     fi
-done <<< "$DEPLOY_DATA"
+done <<< "$ALIVE_DATA"
 
 # Build the menu bar string.
 if [[ "$HAS_ACTIVE" == true ]]; then
@@ -130,36 +159,41 @@ echo "$BAR"
 echo "---"
 
 # --- Dropdown: per-deploy details ---
-while IFS='|' read -r name desc running queued waiting review done errored total cost; do
+while IFS='|' read -r deploy_id fullrepo mode running queued waiting review done errored total cost budget; do
     # Deploy header.
     cost_str=$(printf '$%.2f' "$cost")
-    echo "${name} — ${running} running, ${done} done (${cost_str}) | font=MonospacedSystemFont size=13"
-    echo "${desc} | color=gray size=11"
+    budget_str=$(printf '$%.2f' "$budget")
+    echo "${deploy_id} ${fullrepo} — ${running} running, ${done} done (${cost_str}/${budget_str}) | font=MonospacedSystemFont size=13"
+    echo "${mode} mode | color=gray size=11"
 
-    # Per-task details: query individual tasks for this deploy.
+    # Per-job details for this deployment.
     TASKS=$(sqlite3 "$DB" "
-        SELECT t.issue_number, t.issue_title, t.status, t.pr_number, t.cost_usd
-        FROM autopilot_tasks t
-        JOIN projects p ON p.id = t.project_id
-        WHERE p.name = '${name}'
+        SELECT j.issue_number, j.issue_title, j.name, j.status, j.pr_number, j.cost_usd
+        FROM jobs j
+        WHERE j.deployment_id = '${deploy_id}'
         ORDER BY
-            CASE t.status
+            CASE j.status
                 WHEN 'running' THEN 0
                 WHEN 'queued' THEN 1
-                WHEN 'pending' THEN 2
-                WHEN 'blocked' THEN 3
-                WHEN 'review' THEN 4
-                WHEN 'reviewing' THEN 5
+                WHEN 'blocked' THEN 2
+                WHEN 'review' THEN 3
+                WHEN 'reviewing' THEN 4
+                WHEN 'reviewed' THEN 5
                 WHEN 'done' THEN 6
                 ELSE 7
             END,
-            t.issue_number;
+            j.id;
     " 2>/dev/null)
 
-    while IFS='|' read -r num title status pr_num task_cost; do
-        [[ -z "$num" ]] && continue
+    while IFS='|' read -r num title name status pr_num task_cost; do
+        [[ -z "$status" ]] && continue
         icon=$(icon_for_status "$status")
-        title_short="${title:0:40}"
+        # Use issue number if available, otherwise use job name.
+        if [[ -n "$num" && "$num" != "0" ]]; then
+            label="#${num} ${title:0:40}"
+        else
+            label="${name:0:40}"
+        fi
         pr_info=""
         if [[ -n "$pr_num" && "$pr_num" != "0" ]]; then
             pr_info=" (PR #${pr_num})"
@@ -168,23 +202,21 @@ while IFS='|' read -r name desc running queued waiting review done errored total
         if [[ -n "$task_cost" ]] && (( $(echo "$task_cost > 0" | bc -l 2>/dev/null || echo 0) )); then
             cost_info=$(printf ' $%.2f' "$task_cost")
         fi
-        echo "--${icon} #${num} ${title_short} — ${status}${pr_info}${cost_info} | font=MonospacedSystemFont size=12"
+        echo "--${icon} ${label} — ${status}${pr_info}${cost_info} | font=MonospacedSystemFont size=12"
     done <<< "$TASKS"
 
     echo "-----"
-done <<< "$DEPLOY_DATA"
+done <<< "$ALIVE_DATA"
 
 # --- Actions ---
 echo "---"
-echo "Deploy List | bash='${MINDER}' param1=deploy param2=list terminal=true"
-echo "---"
 
 # Per-deploy actions.
-while IFS='|' read -r name desc running queued waiting review done errored total cost; do
-    echo "${name}"
-    echo "--Status | bash='${MINDER}' param1=deploy param2=status param3='${name}' terminal=true"
-    echo "--Stop | bash='${MINDER}' param1=deploy param2=stop param3='${name}' terminal=true refresh=true"
-done <<< "$DEPLOY_DATA"
+while IFS='|' read -r deploy_id fullrepo mode running queued waiting review done errored total cost budget; do
+    echo "${deploy_id} (${fullrepo})"
+    echo "--Status | bash='${MINDER}' param1=status param2='${deploy_id}' terminal=true"
+    echo "--Stop | bash='${MINDER}' param1=stop param2='${deploy_id}' terminal=true refresh=true"
+done <<< "$ALIVE_DATA"
 
 echo "---"
 echo "Open Logs | bash=open param1='${LOGS_DIR}' terminal=false"


### PR DESCRIPTION
## Summary
- **Updated `scripts/agent-minder.30s.sh`** to use the v2 database schema (`deployments`/`jobs` tables at `~/.agent-minder/v2.db`) instead of the stale v1 schema (`projects`/`autopilot_tasks` at `minder.db`). Now filters to only active deployments by checking PID files, so restarted daemons show current data immediately.
- **Fixed `/jobs` and `/lessons` API endpoints** to return `[]` instead of `null` when empty. Go nil slices marshal to JSON `null`, which confused xbar/SwiftBar script consumers and other JSON clients.
- **Added regression tests** (`TestHandleJobsEmptyReturnsArray`, `TestHandleLessonsEmptyReturnsArray`) to prevent future regressions.

## Root cause
The 30s xbar plugin (`scripts/agent-minder.30s.sh`) was reading from the wrong database (`minder.db`) with old table names (`projects`, `autopilot_tasks`). After the v2 rewrite, the correct path is `v2.db` with `deployments` and `jobs` tables. Additionally, the plugin showed ALL deployments without filtering for alive daemons, so stale data from previous deploys persisted after restart.

The HTTP API also contributed: `/jobs` returned JSON `null` (not `[]`) for new deploys with no jobs yet, since Go nil slices marshal differently than empty slices.

## Test plan
- [x] `go test ./internal/daemon/... -v` — all pass including new regression tests
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` — clean
- [ ] Manual: start daemon with `--serve :7749`, stop, restart, verify SwiftBar shows new deploy ID immediately

Fixes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)