### PR TITLE
Fix review stage stuck at 'reviewing' when extraction call hangs

### DIFF
--- a/internal/supervisor/review.go
+++ b/internal/supervisor/review.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aptx-health/agent-minder/internal/claudecli"
 	"github.com/aptx-health/agent-minder/internal/db"
@@ -74,8 +75,14 @@ Review agent log:
 
 Produce your assessment as JSON.`, job.PRNumber.Int64, job.IssueNumber, content)
 
+	// Use a 2-minute timeout for the Haiku extraction call.
+	// Without this, a hung claude -p (e.g., from a usage limit) blocks the
+	// entire review stage goroutine indefinitely — the job never completes.
+	extractCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
 	completer := claudecli.NewCLICompleter()
-	resp, err := completer.Complete(ctx, &claudecli.Request{
+	resp, err := completer.Complete(extractCtx, &claudecli.Request{
 		SystemPrompt: "You extract structured review assessments from agent logs. Be concise and actionable.",
 		Prompt:       prompt,
 		Model:        "haiku",


### PR DESCRIPTION
## Summary
The review assessment extraction (`extractReviewAssessment`) makes a `claude -p --model haiku` call to parse the reviewer's log into structured JSON. This call had **no timeout** — if the `claude -p` process hung (e.g., from hitting a usage limit during concurrent reviews), the entire review stage goroutine blocked indefinitely. The job stayed stuck at "reviewing" forever.

**Root cause:** #351 and #352 reviews ran ~12 min each. After both agents completed successfully (verified in logs), their Haiku extraction calls likely hit a usage limit since #353's extraction had just consumed the same tokens window. Without a timeout, the goroutines blocked silently.

**Fix:** Add a 2-minute `context.WithTimeout` to the extraction call. On timeout, it falls back to `"needs-testing"` — the review agent already completed and posted its findings on the PR, so the structured extraction is best-effort.

## Test plan
- [x] `go test ./internal/supervisor/...` passes
- [ ] Run 3+ concurrent reviews and verify all complete even if Haiku extraction is slow

🤖 Generated with [Claude Code](https://claude.com/claude-code)