### PR TITLE
Add spike agent, minder agents add command, and README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ Each agent runs in an isolated git worktree with its own branch. The supervisor 
 # Install
 go install github.com/aptx-health/agent-minder/cmd/minder@latest
 
-# Set up
+# Authenticate (stores token in OS keychain)
+minder auth login
+
+# Or set env var
 export GITHUB_TOKEN=ghp_...
+
+# Enroll a repo (scans, installs agents, configures jobs)
+minder enroll /path/to/repo
 
 # Deploy on issues
 minder deploy 42 --repo /path/to/repo --foreground
@@ -51,6 +57,12 @@ Agents declare their behavior in YAML frontmatter in `.claude/agents/*.md`:
 name: dependency-updater
 mode: proactive              # no issue needed
 output: pr                   # opens a PR
+stages:
+  - name: scan
+  - name: review
+    agent: reviewer
+    on_failure: skip
+    retries: 1
 context:                     # what context to inject
   - repo_info
   - file_list
@@ -66,7 +78,22 @@ timeout: 1h
 You are a dependency update agent...
 ```
 
-Contract fields: `mode` (reactive/proactive), `output` (pr/issue/report/none), `context` (providers), `dedup` (strategies), `stages` (multi-step pipeline), `timeout`.
+Contract fields: `mode` (reactive/proactive), `output` (pr/issue/comment/none), `context` (providers), `dedup` (strategies), `stages` (multi-step pipeline), `timeout`.
+
+### Built-in agent types
+
+| Agent | Mode | Output | Trigger | Description |
+|-------|------|--------|---------|-------------|
+| **autopilot** | reactive | pr | `label:agent-ready` | Implements GitHub issues end-to-end |
+| **reviewer** | reactive | pr | (auto) | Reviews PRs, assesses risk, makes fixes |
+| **bug-fixer** | reactive | pr | `label:bug` | Reproduces bugs, writes regression tests, fixes |
+| **spike** | reactive | issue | `label:spike` | Research and discovery — investigates questions, posts findings |
+| **dependency-updater** | proactive | pr | cron | Scans and updates outdated dependencies |
+| **security-scanner** | proactive | issue | cron | Runs security audits, reports findings |
+| **doc-updater** | proactive | pr | cron | Syncs documentation with code changes |
+
+### Agent-specific stage names
+Each agent type declares meaningful pipeline stage names: autopilot→implement, bug-fixer→fix, dependency-updater→scan, security-scanner→audit, doc-updater→update, spike→research. The default fallback for agents without explicit stages is "run".
 
 ### Context providers
 Agents get context assembled from declared providers:
@@ -74,7 +101,7 @@ Agents get context assembled from declared providers:
 | Provider | Description |
 |----------|-------------|
 | `issue` | Issue title, body, and comments from GitHub |
-| `repo_info` | Languages, test command, base branch, worktree path |
+| `repo_info` | Languages, test/build commands with timeout wrappers, base branch, worktree path |
 | `file_list` | Repository file tree (depth 3) |
 | `recent_commits:<days>` | Git log from last N days |
 | `lessons` | Relevant lessons from the learning system |
@@ -87,7 +114,7 @@ After an agent opens a PR, a review agent assesses it:
 - **needs-testing**: Looks correct but needs human verification.
 - **suspect**: Has issues requiring human review.
 
-Review produces structured JSON with risk level, summary, lessons, and specific issues found.
+Review produces structured JSON with risk level, summary, lessons, and specific issues found. The extraction call has a 2-minute timeout to prevent hanging on concurrent reviews.
 
 ### Learning system
 Minder learns from agent outcomes:
@@ -104,7 +131,7 @@ minder lesson groom --dry-run             # preview consolidation
 ```
 
 ### Job scheduler
-Define recurring jobs in `.agent-minder/jobs.yaml`:
+Define recurring jobs and label triggers in `.agent-minder/jobs.yaml`:
 
 ```yaml
 jobs:
@@ -115,8 +142,14 @@ jobs:
     budget: 3.0
 
   bug-triage:
-    trigger: "label:bug"           # event trigger
-    agent: autopilot
+    trigger: "label:bug"           # label trigger → agent
+    agent: bug-fixer
+
+  spike:
+    trigger: "label:spike"
+    agent: spike
+    description: "Research and discovery"
+    budget: 5.0
 ```
 
 ```bash
@@ -126,9 +159,25 @@ minder jobs run weekly-deps        # manual trigger
 
 ### Dedup engine
 Stackable strategies prevent duplicate work:
-- `branch_exists` — skip if branch already exists
+- `open_pr` — skip if open PR exists for branch (default for reactive PR agents)
+- `branch_exists` — skip if branch already exists on remote
 - `open_pr_with_label:<label>` — skip if matching PR is open
 - `recent_run:<hours>` — skip if same agent ran recently
+
+Reactive PR agents automatically get `open_pr` dedup to prevent re-running issues across daemon restarts. Unlike `branch_exists`, this allows retries when the agent was interrupted (usage limit, crash) before opening a PR.
+
+### Usage limit recovery
+When an agent hits a Claude Code session/usage limit, minder automatically:
+1. Detects the limit (via stream events or error text patterns)
+2. Sets job status to `waiting`
+3. Sleeps with backoff (1h, 2h, 3h)
+4. Resumes the session using `--resume <session_id>`
+5. Up to 3 retry attempts before bailing
+
+No human intervention needed.
+
+### Command timeout wrappers
+Test and build commands injected into agent context include `timeout` wrappers (default 5m for tests, 3m for builds). Configurable via `test_timeout` and `build_timeout` in `onboarding.yaml`. Prevents agents from burning turns waiting on hung processes.
 
 ### Watch mode
 Continuously poll GitHub for new issues matching a filter:
@@ -137,6 +186,8 @@ Continuously poll GitHub for new issues matching a filter:
 minder deploy --watch label:agent-ready --serve :7749
 minder deploy --watch milestone:v2.0
 ```
+
+Trigger routes from `jobs.yaml` are polled automatically — `--watch` flag is optional when triggers are configured.
 
 ### Daemon mode + HTTP API
 Run as a background daemon with a REST API:
@@ -150,8 +201,8 @@ minder stop <deploy-id>                  # stop daemon
 
 Endpoints: `/status`, `/jobs`, `/jobs/{id}`, `/jobs/{id}/log`, `/dep-graph`, `/metrics`, `/lessons`, `/stop`, `/resume`.
 
-### xbar menu bar plugin
-macOS menu bar widget shows agent status at a glance. See `xbar/minder.5s.sh`.
+### SwiftBar menu bar plugin
+macOS menu bar widget shows agent status at a glance. Supports all job statuses including `waiting` (usage limit recovery). See `xbar/minder.5s.sh`.
 
 ## Commands
 
@@ -160,9 +211,11 @@ macOS menu bar widget shows agent status at a glance. See `xbar/minder.5s.sh`.
 | `minder deploy [issues...] [flags]` | Launch agents on issues or start daemon |
 | `minder status [deploy-id]` | Show deployment status (`--json` for structured output) |
 | `minder stop [deploy-id]` | Stop a running deployment |
+| `minder tui` | Launch interactive TUI dashboard |
+| `minder auth login\|status\|logout` | Manage GitHub token in OS keychain |
 | `minder lesson add\|list\|edit\|remove\|pin\|groom` | Manage the learning system |
 | `minder jobs list\|run` | View and trigger scheduled jobs |
-| `minder agents list\|show <name>` | List available agents or show definition details |
+| `minder agents list\|show\|add` | List, inspect, or create agent definitions |
 | `minder enroll [repo-dir]` | Scan a repo and generate onboarding config |
 
 ### Deploy flags
@@ -189,34 +242,35 @@ macOS menu bar widget shows agent status at a glance. See `xbar/minder.5s.sh`.
 | **Go 1.25+** | Build from source |
 | **git** | Worktree management, branch operations |
 | **[Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)** | Agent execution (`claude --agent`) |
-| **`GITHUB_TOKEN`** | GitHub API access for issues, PRs, labels |
+| **`GITHUB_TOKEN`** | GitHub API access (via env var or `minder auth login`) |
 | **[gh CLI](https://cli.github.com/)** | Agents use `gh` for PR creation and issue management |
 
 ## Architecture
 
 ```
 cmd/minder/main.go          # Entry point
-cmd/                         # Cobra commands (deploy, status, stop, lesson, jobs, enroll)
+cmd/                         # Cobra commands (deploy, status, stop, lesson, jobs, agents, auth, enroll, tui)
 internal/
-  supervisor/                # Job manager, context providers, contracts, dedup, review
+  supervisor/                # Job manager, context providers, contracts, dedup, review, bail, templates
   scheduler/                 # Cron parser, jobs.yaml, scheduled job firing
   daemon/                    # PID files, heartbeat, HTTP API server + client
-  db/                        # SQLite schema (v3), models, queries
+  db/                        # SQLite schema (v4), models, queries, migrations
   claudecli/                 # Claude Code CLI wrapper
-  github/                    # GitHub API client (go-github)
+  github/                    # GitHub API client (go-github, ETag caching)
   git/                       # Git CLI wrappers
+  auth/                      # OS keyring integration (macOS Keychain, Linux libsecret)
   lesson/                    # Lesson selection, injection, grooming
   onboarding/                # Repo scanning, onboarding YAML
   discovery/                 # Language/framework detection
   agentutil/                 # Agent log parsing
   sqliteutil/                # WAL recovery
-xbar/                        # macOS menu bar plugin
+xbar/                        # macOS SwiftBar menu bar plugin
 .agent-minder/               # Per-repo config (jobs.yaml, onboarding.yaml)
 ```
 
 ### Data storage
 
-SQLite at `~/.agent-minder/v2.db` (WAL mode, foreign keys). Schema v4.
+SQLite at `~/.agent-minder/v2.db` (WAL mode, foreign keys, single-writer via `SetMaxOpenConns(1)`). Schema v4.
 
 | Table | Purpose |
 |-------|---------|
@@ -232,10 +286,11 @@ SQLite at `~/.agent-minder/v2.db` (WAL mode, foreign keys). Schema v4.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GITHUB_TOKEN` | — | GitHub API token (required) |
+| `GITHUB_TOKEN` | — | GitHub API token (or use `minder auth login`) |
 | `MINDER_DB` | `~/.agent-minder/v2.db` | Database path |
 | `MINDER_LOG` | `~/.agent-minder/debug.log` | Debug log path |
 | `MINDER_DEBUG` | — | Enable structured JSON debug logging |
+| `MINDER_API_KEY` | — | API key for remote daemon access |
 
 ## Testing
 

--- a/cmd/agents_add.go
+++ b/cmd/agents_add.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/aptx-health/agent-minder/internal/discovery"
+	gitpkg "github.com/aptx-health/agent-minder/internal/git"
+	"github.com/aptx-health/agent-minder/internal/supervisor"
+	"github.com/spf13/cobra"
+)
+
+var agentsAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Create a new agent definition interactively",
+	Long: `Launches an interactive Claude session that interviews you about the new agent,
+then creates the agent definition (.claude/agents/<name>.md) and updates
+jobs.yaml with the appropriate trigger or schedule.
+
+The session will ask about:
+- What the agent should do
+- Whether it's reactive (triggered by issues) or proactive (runs on a schedule)
+- For reactive: which label triggers it
+- For proactive: what cron schedule to use
+- Budget and turn limits`,
+	RunE: runAgentsAdd,
+}
+
+func init() {
+	agentsCmd.AddCommand(agentsAddCmd)
+}
+
+func runAgentsAdd(cmd *cobra.Command, args []string) error {
+	repoDir, err := resolveRepoDir(flagAgentsRepo)
+	if err != nil {
+		return fmt.Errorf("resolve repo: %w", err)
+	}
+
+	if !gitpkg.IsRepo(repoDir) {
+		return fmt.Errorf("%s is not a git repository", repoDir)
+	}
+
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return fmt.Errorf("claude CLI not found — install from https://claude.ai/code")
+	}
+
+	// Gather context for the prompt.
+	info, err := discovery.ScanRepo(repoDir)
+	if err != nil {
+		return fmt.Errorf("scan repo: %w", err)
+	}
+
+	existing := supervisor.DiscoverAgents(repoDir)
+	var existingList []string
+	for _, a := range existing {
+		existingList = append(existingList, fmt.Sprintf("- %s (%s, %s)", a.Name, a.Contract.Mode, a.Contract.Output))
+	}
+
+	// Build template reference.
+	var templateRef strings.Builder
+	for _, tmpl := range supervisor.AgentTemplates() {
+		fmt.Fprintf(&templateRef, "\n### %s\n```yaml\n---\n%s\n---\n```\n",
+			tmpl.Name, tmpl.Frontmatter)
+	}
+
+	systemPrompt := buildAgentAddPrompt(info, repoDir, existingList, templateRef.String())
+
+	agentCmd := exec.Command(claudePath, "--append-system-prompt", systemPrompt,
+		"I'd like to add a new agent to this repository.")
+	agentCmd.Dir = repoDir
+	agentCmd.Stdin = os.Stdin
+	agentCmd.Stdout = os.Stdout
+	agentCmd.Stderr = os.Stderr
+
+	fmt.Println("Launching agent creation session...")
+	fmt.Println("The agent will interview you and create the agent definition + jobs.yaml entry.")
+
+	if err := agentCmd.Run(); err != nil {
+		fmt.Printf("\nSession exited with error: %v\n", err)
+		return nil
+	}
+
+	// Validate.
+	if errs := supervisor.ValidateAgentDefs(repoDir); len(errs) > 0 {
+		fmt.Println("\nAgent definition validation errors:")
+		for _, e := range errs {
+			fmt.Printf("  - %s\n", e)
+		}
+	} else {
+		fmt.Println("\nAll agent definitions validated successfully.")
+	}
+
+	return nil
+}
+
+func buildAgentAddPrompt(info *discovery.RepoInfo, repoDir string, existing []string, templateRef string) string {
+	return fmt.Sprintf(`You are an agent creation assistant for agent-minder. Your job is to interview
+the user about a new agent they want to add, then create the agent definition file
+and update jobs.yaml.
+
+Repository: %s
+Languages: %v
+
+## Existing agents
+%s
+
+## Interview process
+
+### 1. Understand the agent
+Ask the user:
+- What should this agent do? (one sentence)
+- Give it a name (lowercase, hyphenated — e.g., "api-tester", "changelog-writer")
+
+### 2. Determine mode and output
+Based on the description, determine:
+- **Mode**: Is this reactive (triggered by issues/labels) or proactive (runs on a schedule)?
+  - Reactive: needs an issue to work on, triggered by a label
+  - Proactive: runs periodically, scans the repo, creates output on its own
+- **Output**: What does this agent produce?
+  - "pr" — opens a pull request with changes
+  - "issue" — creates or comments on a GitHub issue
+  - "comment" — posts findings on the triggering issue (like spike)
+  - "none" — no external output (internal tooling)
+
+### 3. Configure trigger or schedule
+- For **reactive** agents: ask which GitHub label triggers it
+- For **proactive** agents: ask what schedule (suggest sensible defaults based on the task)
+
+### 4. Run a research sub-agent
+Before writing the agent definition, run a research agent to analyze the codebase:
+
+  claude -p --model sonnet "Research this codebase for writing an optimized <agent-name> agent definition that <description>. Focus on: relevant code patterns, tools, commands, and conventions. Output ONLY the instruction body markdown — no frontmatter, no preamble."
+
+Read the output and use it as the foundation for the instruction body.
+
+### 5. Create the agent definition
+Write the file to .claude/agents/<name>.md with:
+- YAML frontmatter with the correct contract fields
+- Instruction body based on the research + user's requirements
+
+Use existing agent templates as reference for the frontmatter structure:
+%s
+
+CRITICAL: The YAML frontmatter must follow the exact structure shown above.
+The orchestrator parses it — incorrect fields will break the agent.
+
+Key frontmatter fields:
+- name, description, tools, mode, output
+- stages (with name, agent, on_failure, retries)
+- context (list of providers: issue, repo_info, file_list, recent_commits:<days>, lessons, sibling_jobs, dep_graph)
+- dedup (for proactive: branch_exists, open_pr_with_label:<label>, recent_run:<hours>)
+
+### 6. Update jobs.yaml
+Read the existing .agent-minder/jobs.yaml (if it exists) and add an entry for the new agent.
+
+For reactive agents:
+  <job-name>:
+    trigger: "label:<label>"
+    agent: <agent-name>
+    description: "<description>"
+    budget: 5.0
+
+For proactive agents:
+  <job-name>:
+    schedule: "<cron expression>"
+    agent: <agent-name>
+    description: "<description>"
+    budget: 3.0
+
+### 7. Validate
+- Run: minder agents list --repo .
+- Run: minder jobs list --repo .
+  If minder is not on PATH, use go run ./cmd/minder.
+  Do NOT use Python or Ruby YAML parsers.
+- If validation fails, fix and re-validate.
+
+### 8. Summary
+Print a summary of what was created:
+- Agent definition file path
+- Mode and trigger/schedule
+- jobs.yaml entry
+
+Be concise and efficient.`, repoDir, info.Inventory.Languages, strings.Join(existing, "\n"), templateRef)
+}

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -197,6 +197,9 @@ Required agents (autopilot, reviewer) are always installed. Optional agents:
   Relevant for any repo, especially those with dependencies.
 - **doc-updater**: Reviews recent changes and updates documentation.
   Relevant if the repo has README.md, CHANGELOG.md, or API docs.
+- **spike**: Research and discovery agent. Investigates questions, feasibility analysis,
+  and security impact assessment. Triggered by the "spike" label. Does NOT write code —
+  posts structured findings as a comment. Relevant for any repo.
 
 ### 3. Run research sub-agents (IMPORTANT — do this BEFORE writing agent definitions)
 For EACH agent the user wants installed (including required agents), spawn a research
@@ -225,6 +228,8 @@ Each research agent should focus on what matters for its agent type:
   secrets management, existing security config files.
 - **doc-updater**: Existing docs, documentation style, doc build tools, areas that
   drift when code changes, doc linting tools.
+- **spike**: Key domain areas, common question patterns, where important design
+  decisions are documented, external services/integrations the repo depends on.
 
 After all research agents complete, read each output file.
 
@@ -253,6 +258,7 @@ based on which agents the user installed:
 - For **dependency-updater**: add a weekly cron schedule (e.g., Monday morning)
 - For **security-scanner**: add a weekly cron schedule (e.g., Wednesday morning)
 - For **doc-updater**: add a weekly cron schedule (e.g., Friday morning)
+- For **spike**: add a trigger route: trigger: "label:spike"
 
 Ask the user what cron times work for them. Use UTC times in the cron expressions.
 

--- a/internal/supervisor/templates.go
+++ b/internal/supervisor/templates.go
@@ -305,6 +305,66 @@ dedup:
 - Do not add documentation for internal/private APIs unless it already exists
 - If no updates are needed, bail cleanly — do not create empty PRs`,
 		},
+		{
+			Name:     "spike",
+			Required: false,
+			Frontmatter: `name: spike
+description: >
+  Research and discovery agent for investigating questions, feasibility
+  analysis, and security impact assessment. Outputs findings as a
+  comment on the triggering issue.
+tools: Bash, Read, Edit, Write, Glob, Grep, WebSearch, WebFetch
+mode: reactive
+output: issue
+stages:
+  - name: research
+context:
+  - issue
+  - repo_info
+  - file_list
+  - lessons`,
+			DefaultBody: `You are a research and discovery agent. Your job is to investigate questions
+posted as GitHub issues, then post structured findings as a comment. You do NOT
+write code, open PRs, or modify files.
+
+## Process
+1. Read the issue carefully — understand what is being asked
+2. Search the codebase: grep for relevant code, read files, check dependencies, review schema
+3. Search the web: official docs, security advisories, changelogs, community discussions
+4. Synthesize findings into a structured comment on the issue
+
+## Output format
+Post a single comment on the issue with:
+
+### Verdict
+One-line answer to the question.
+
+### What I found
+Key findings with evidence — code references and external links.
+
+### Relevant code
+Specific file:line references in the repo.
+
+### Recommendation
+What to do next — is this actionable? Should a follow-up issue be created?
+
+### Sources
+Links to external sources consulted.
+
+## Post your findings
+Write your comment to /tmp/spike-findings.md using the Write tool, then post:
+  gh issue comment <number> --body-file /tmp/spike-findings.md -R <owner>/<repo>
+
+After posting, update labels:
+  gh issue edit <number> --remove-label spike --add-label needs-review -R <owner>/<repo>
+
+## Constraints
+- Do NOT modify any files in the repository
+- Do NOT open PRs or create new issues
+- Do NOT make decisions — report findings for human review
+- Keep findings concise and evidence-based
+- If the question is unanswerable with available information, say so clearly`,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

### Spike agent (new built-in)
Research and discovery agent triggered by the `spike` label. Investigates questions by searching codebase and web, posts structured findings as an issue comment. Does NOT write code or open PRs.

Use cases: CVE impact assessment, feasibility analysis, bug investigation, technology comparisons. Fills the gap between "I have a question" and "I'm ready to write a ticket."

- Tools: includes `WebSearch` and `WebFetch` (unique among agents)
- Output: `issue` (comments on existing issue)
- Stage: `research`
- Added to enrollment prompt as optional agent

### `minder agents add` (new command)
Interactive Claude session that creates a new agent definition from scratch:
1. Interviews user about what the agent should do
2. Determines mode (reactive/proactive) and output type
3. Configures trigger (label) or schedule (cron)
4. Runs a research sub-agent to analyze the codebase
5. Creates `.claude/agents/<name>.md` with optimized instructions
6. Updates `.agent-minder/jobs.yaml` with the trigger/schedule entry
7. Validates with `minder agents list` and `minder jobs list`

### README refresh
Comprehensive update covering all v2.1 features:
- Built-in agent type table (7 agents)
- Auth command, spike agent, agents add
- Usage limit recovery, command timeouts
- open_pr dedup, SwiftBar, stage names
- MINDER_API_KEY env var, schema v4, auth package

## Test plan
- [x] `go build ./...` and `go test ./...` pass
- [x] `minder agents --help` shows add subcommand
- [ ] `minder agents add` launches interactive session
- [ ] `minder enroll --force` offers spike as optional agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)