### PR TITLE
Allow any stage to capture lessons via captures_lessons flag

### DIFF
--- a/internal/supervisor/contract.go
+++ b/internal/supervisor/contract.go
@@ -34,11 +34,12 @@ type AgentContract struct {
 
 // StageContract describes one stage in a multi-stage pipeline.
 type StageContract struct {
-	Name      string `yaml:"name"`
-	Agent     string `yaml:"agent"`      // agent name for this stage (default: parent agent)
-	Timeout   string `yaml:"timeout"`    // per-stage timeout
-	OnFailure string `yaml:"on_failure"` // "bail", "skip", "retry" (default: "bail")
-	Retries   int    `yaml:"retries"`    // number of retries if on_failure=retry
+	Name            string `yaml:"name"`
+	Agent           string `yaml:"agent"`            // agent name for this stage (default: parent agent)
+	Timeout         string `yaml:"timeout"`          // per-stage timeout
+	OnFailure       string `yaml:"on_failure"`       // "bail", "skip", "retry" (default: "bail")
+	Retries         int    `yaml:"retries"`          // number of retries if on_failure=retry
+	CapturesLessons bool   `yaml:"captures_lessons"` // extract and save lessons from this stage's output
 }
 
 // DefaultContract returns the default contract for agents that don't specify one.

--- a/internal/supervisor/jobmanager.go
+++ b/internal/supervisor/jobmanager.go
@@ -451,6 +451,19 @@ func (m *DefaultJobManager) Run(ctx context.Context) error {
 			result = m.executeCodeStage(ctx, stage, agentName, logFile, feedbackPrompt)
 		}
 
+		// Capture lessons from non-reviewer stages that declare captures_lessons.
+		// The reviewer path handles this internally via executeReviewStage.
+		if stage.CapturesLessons && agentName != "reviewer" && result.success {
+			assessment := extractReviewAssessmentFromLog(ctx, sc.LogPath, job, sc.sup, sc.Hooks)
+			if len(assessment.Lessons) > 0 {
+				captured := captureLessonsFromAssessment(sc.Store, sc.Owner, sc.Repo, assessment)
+				if len(captured) > 0 {
+					sc.EmitEvent("info", fmt.Sprintf("Captured %d lessons from %s stage on %s",
+						len(captured), stageName, sc.JobLabel()))
+				}
+			}
+		}
+
 		// Check for user stop.
 		if sc.WasStoppedByUser() {
 			_ = sc.Store.UpdateJobStatus(job.ID, db.StatusStopped)

--- a/internal/supervisor/pipeline_test.go
+++ b/internal/supervisor/pipeline_test.go
@@ -839,6 +839,117 @@ func TestPipeline_StageNamedReviewWithNonReviewerAgent(t *testing.T) {
 	}
 }
 
+// TestPipeline_CapturesLessonsFromNonReviewerStage verifies that a stage
+// with captures_lessons: true extracts and saves lessons from its output.
+func TestPipeline_CapturesLessonsFromNonReviewerStage(t *testing.T) {
+	h := newHarness(t, func(d *db.Deployment) {
+		d.ReviewEnabled = false
+	})
+
+	// The extraction hook returns lessons.
+	h.hooks.ExtractReviewAssessmentFn = func(ctx context.Context, logPath string, job *db.Job) ReviewAssessment {
+		return ReviewAssessment{
+			Risk:    "low-risk",
+			Summary: "Quality check found patterns to learn from",
+			Lessons: []string{
+				"Always validate input before database writes",
+				"Use structured logging with slog, not fmt.Println",
+			},
+		}
+	}
+
+	job := testJob(t, h.store, h.deploy, func(j *db.Job) {
+		j.Agent = "quality-check"
+		j.Name = "weekly-quality"
+		j.IssueNumber = 0
+		j.IssueTitle = sql.NullString{String: "Weekly quality review", Valid: true}
+	})
+
+	contract := &AgentContract{
+		Name:   "quality-check",
+		Mode:   "proactive",
+		Output: "none",
+		Stages: []StageContract{
+			{Name: "scan", Agent: "quality-check", OnFailure: "bail", CapturesLessons: true},
+		},
+	}
+	applyContractDefaults(contract)
+
+	err := h.run(context.Background(), job, contract)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	// Verify lessons were captured.
+	scope := h.deploy.Owner + "/" + h.deploy.Repo
+	lessons, err := h.store.GetActiveLessons(scope)
+	if err != nil {
+		t.Fatalf("GetActiveLessons: %v", err)
+	}
+
+	if len(lessons) < 2 {
+		t.Fatalf("expected at least 2 lessons captured, got %d", len(lessons))
+	}
+
+	// Check lesson content.
+	found := map[string]bool{}
+	for _, l := range lessons {
+		found[l.Content] = true
+	}
+	if !found["Always validate input before database writes"] {
+		t.Error("expected lesson about input validation")
+	}
+	if !found["Use structured logging with slog, not fmt.Println"] {
+		t.Error("expected lesson about structured logging")
+	}
+}
+
+// TestPipeline_NoCaptureWithoutFlag verifies that stages without
+// captures_lessons don't extract lessons.
+func TestPipeline_NoCaptureWithoutFlag(t *testing.T) {
+	h := newHarness(t, func(d *db.Deployment) {
+		d.ReviewEnabled = false
+	})
+
+	// Even if the hook returns lessons, they should NOT be captured.
+	h.hooks.ExtractReviewAssessmentFn = func(ctx context.Context, logPath string, job *db.Job) ReviewAssessment {
+		return ReviewAssessment{
+			Risk:    "low-risk",
+			Lessons: []string{"This should not be captured"},
+		}
+	}
+
+	job := testJob(t, h.store, h.deploy, func(j *db.Job) {
+		j.Agent = "quality-check"
+		j.Name = "weekly-quality-2"
+		j.IssueNumber = 0
+	})
+
+	contract := &AgentContract{
+		Name:   "quality-check",
+		Mode:   "proactive",
+		Output: "none",
+		Stages: []StageContract{
+			{Name: "scan", Agent: "quality-check", OnFailure: "bail"},
+			// No CapturesLessons flag.
+		},
+	}
+	applyContractDefaults(contract)
+
+	err := h.run(context.Background(), job, contract)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	scope := h.deploy.Owner + "/" + h.deploy.Repo
+	lessons, _ := h.store.GetActiveLessons(scope)
+	for _, l := range lessons {
+		if l.Content == "This should not be captured" {
+			t.Error("lesson was captured despite no captures_lessons flag")
+		}
+	}
+}
+
 // --- Utilities ---
 
 func truncate(s string, n int) string {


### PR DESCRIPTION
## Summary
New `captures_lessons: true` field on `StageContract`. When set, the stage's output is parsed for lessons after completion — same Haiku extraction as the reviewer. Enables non-reviewer agents to contribute lessons.

```yaml
# In agent frontmatter
stages:
  - name: scan
    agent: quality-check
    captures_lessons: true
  - name: verify
    agent: reviewer
    on_failure: skip
```

The quality-check agent's findings get extracted into lessons automatically.

**How it works:** After a `captures_lessons` stage completes successfully, `extractReviewAssessmentFromLog` runs the same Haiku structured extraction, then `captureLessonsFromAssessment` saves new lessons (with dedup against existing ones).

**What doesn't change:** The reviewer path still handles its own lesson capture internally. This flag only applies to non-reviewer stages.

## Test plan
- [x] `go test ./...` passes
- [x] TestPipeline_CapturesLessonsFromNonReviewerStage — lessons extracted and saved
- [x] TestPipeline_NoCaptureWithoutFlag — no extraction without the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)