### PR TITLE
Fix checkout worktree restoration branch naming mismatch

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -155,49 +155,108 @@ func findMostRecentJobForIssue(store *db.Store, owner, repo string, issueNum int
 }
 
 func checkoutWorktree(repoDir string, job *db.Job) error {
-	branch := job.Branch.String
-	if branch == "" {
-		// Construct branch from job name.
-		branch = fmt.Sprintf("agent/%s", job.Name)
-	}
-
 	worktreePath := job.WorktreePath.String
 
-	// Check if worktree exists on disk.
+	// If worktree is on disk, use the recorded branch (or our best guess) and present it.
 	if worktreePath != "" && dirExistsCheckout(worktreePath) {
+		branch := job.Branch.String
+		if branch == "" {
+			branch = candidateBranchNames(job)[0]
+		}
 		return presentWorktree(worktreePath, branch, job)
 	}
 
-	// Worktree is gone — recreate from the branch.
-	fmt.Printf("Worktree not found, recreating from branch %s...\n", branch)
+	// Worktree is gone — fetch and pick the first branch that actually exists.
+	candidates := candidateBranchNames(job)
+	fmt.Printf("Worktree not found, recreating from branch %s...\n", candidates[0])
 
-	// Fetch latest and prune stale worktree bookkeeping.
 	_ = gitpkg.Fetch(repoDir)
 	_ = gitpkg.WorktreePrune(repoDir)
 
-	// Create worktree path if we don't have one.
+	branch, err := pickExistingBranch(repoDir, candidates)
+	if err != nil {
+		return err
+	}
+
 	if worktreePath == "" {
 		home, _ := os.UserHomeDir()
 		worktreePath = filepath.Join(home, ".agent-minder", "worktrees", "checkout", job.Name)
 	}
-
 	_ = os.MkdirAll(filepath.Dir(worktreePath), 0755)
 
-	// Try strategies in order:
-	// 1. Check out existing local branch into worktree.
-	// 2. If branch only exists on remote, create from origin/<branch>.
-	err := gitpkg.WorktreeAddExisting(repoDir, worktreePath, branch)
-	if err != nil {
-		// Local branch might exist but worktree add failed for other reasons.
-		// Delete the local branch and recreate from remote.
-		_ = gitpkg.DeleteBranch(repoDir, branch)
-		err = gitpkg.WorktreeAdd(repoDir, worktreePath, branch, "origin/"+branch)
-		if err != nil {
-			return fmt.Errorf("could not create worktree from branch %s: %w", branch, err)
+	if err := createWorktreeFromBranch(repoDir, worktreePath, branch); err != nil {
+		return err
+	}
+	return presentWorktree(worktreePath, branch, job)
+}
+
+// candidateBranchNames returns branch names to try in priority order, mirroring
+// the conventions in supervisor.newSlotContext. Issue-bound jobs use
+// `agent/issue-<N>` regardless of the agent name; proactive jobs use
+// `agent/<job.Name>`.
+func candidateBranchNames(job *db.Job) []string {
+	var names []string
+	seen := map[string]bool{}
+	add := func(b string) {
+		if b == "" || seen[b] {
+			return
+		}
+		seen[b] = true
+		names = append(names, b)
+	}
+	add(job.Branch.String)
+	if job.IssueNumber > 0 {
+		add(fmt.Sprintf("agent/issue-%d", job.IssueNumber))
+	}
+	if job.Name != "" {
+		add(fmt.Sprintf("agent/%s", job.Name))
+	}
+	return names
+}
+
+// pickExistingBranch returns the first candidate that exists locally or on origin.
+func pickExistingBranch(repoDir string, candidates []string) (string, error) {
+	for _, b := range candidates {
+		if gitpkg.BranchExists(repoDir, b) {
+			return b, nil
 		}
 	}
+	return "", fmt.Errorf("no matching branch found locally or on origin (tried: %s)", strings.Join(candidates, ", "))
+}
 
-	return presentWorktree(worktreePath, branch, job)
+// candidateBranchNamesRemote is the JobResponse equivalent of candidateBranchNames.
+func candidateBranchNamesRemote(j *daemon.JobResponse) []string {
+	var names []string
+	seen := map[string]bool{}
+	add := func(b string) {
+		if b == "" || seen[b] {
+			return
+		}
+		seen[b] = true
+		names = append(names, b)
+	}
+	add(j.Branch)
+	if j.IssueNumber > 0 {
+		add(fmt.Sprintf("agent/issue-%d", j.IssueNumber))
+	}
+	if j.Name != "" {
+		add(fmt.Sprintf("agent/%s", j.Name))
+	}
+	return names
+}
+
+// createWorktreeFromBranch creates a worktree at worktreePath for the given branch,
+// preferring an existing local branch and falling back to origin/<branch>.
+func createWorktreeFromBranch(repoDir, worktreePath, branch string) error {
+	if err := gitpkg.WorktreeAddExisting(repoDir, worktreePath, branch); err == nil {
+		return nil
+	}
+	// Local branch may be missing or in a bad state; recreate from remote.
+	_ = gitpkg.DeleteBranch(repoDir, branch)
+	if err := gitpkg.WorktreeAdd(repoDir, worktreePath, branch, "origin/"+branch); err != nil {
+		return fmt.Errorf("could not create worktree from branch %s: %w", branch, err)
+	}
+	return nil
 }
 
 func presentWorktree(path, branch string, job *db.Job) error {
@@ -317,15 +376,19 @@ func runCheckoutRemote(args []string) error {
 		fmt.Printf("\nWarning: this job is currently %s — the agent is actively working.\n\n", selected.Status)
 	}
 
-	branch := selected.Branch
-	if branch == "" {
-		return fmt.Errorf("job has no branch — cannot create worktree")
+	candidates := candidateBranchNamesRemote(selected)
+	if len(candidates) == 0 {
+		return fmt.Errorf("job has no branch and no issue/name to derive one from — cannot create worktree")
 	}
 
-	// Fetch the branch from remote and create a local worktree.
-	fmt.Printf("Fetching branch %s from remote...\n", branch)
+	fmt.Printf("Fetching branch %s from remote...\n", candidates[0])
 	_ = gitpkg.Fetch(repoDir)
 	_ = gitpkg.WorktreePrune(repoDir)
+
+	branch, err := pickExistingBranch(repoDir, candidates)
+	if err != nil {
+		return err
+	}
 
 	home, _ := os.UserHomeDir()
 	worktreePath := filepath.Join(home, ".agent-minder", "worktrees", "checkout", selected.Name)
@@ -338,8 +401,7 @@ func runCheckoutRemote(args []string) error {
 
 	// Delete local branch if it exists, recreate from origin.
 	_ = gitpkg.DeleteBranch(repoDir, branch)
-	err = gitpkg.WorktreeAdd(repoDir, worktreePath, branch, "origin/"+branch)
-	if err != nil {
+	if err := gitpkg.WorktreeAdd(repoDir, worktreePath, branch, "origin/"+branch); err != nil {
 		return fmt.Errorf("could not create worktree from branch %s: %w", branch, err)
 	}
 

--- a/cmd/checkout_test.go
+++ b/cmd/checkout_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	"github.com/aptx-health/agent-minder/internal/daemon"
+	"github.com/aptx-health/agent-minder/internal/db"
+)
+
+func TestCandidateBranchNames(t *testing.T) {
+	tests := []struct {
+		name string
+		job  *db.Job
+		want []string
+	}{
+		{
+			name: "issue job with recorded branch",
+			job: &db.Job{
+				Name:        "bug-fixer-issue-480",
+				IssueNumber: 480,
+				Branch:      sql.NullString{String: "agent/bug-fixer-issue-480", Valid: true},
+			},
+			// Recorded branch first, then supervisor convention for issues, then agent/<name>.
+			want: []string{"agent/bug-fixer-issue-480", "agent/issue-480"},
+		},
+		{
+			name: "issue job with no recorded branch",
+			job: &db.Job{
+				Name:        "bug-fixer-issue-480",
+				IssueNumber: 480,
+			},
+			// Should prefer supervisor's actual convention (agent/issue-N), then fall back.
+			want: []string{"agent/issue-480", "agent/bug-fixer-issue-480"},
+		},
+		{
+			name: "proactive job with no issue number",
+			job: &db.Job{
+				Name: "weekly-deps-2026-04-01",
+			},
+			want: []string{"agent/weekly-deps-2026-04-01"},
+		},
+		{
+			name: "recorded branch matches issue convention — no duplicates",
+			job: &db.Job{
+				Name:        "issue-42",
+				IssueNumber: 42,
+				Branch:      sql.NullString{String: "agent/issue-42", Valid: true},
+			},
+			want: []string{"agent/issue-42"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := candidateBranchNames(tt.job)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("candidateBranchNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCandidateBranchNamesRemote(t *testing.T) {
+	tests := []struct {
+		name string
+		job  *daemon.JobResponse
+		want []string
+	}{
+		{
+			name: "issue job with recorded branch",
+			job: &daemon.JobResponse{
+				Name:        "bug-fixer-issue-480",
+				IssueNumber: 480,
+				Branch:      "agent/bug-fixer-issue-480",
+			},
+			want: []string{"agent/bug-fixer-issue-480", "agent/issue-480"},
+		},
+		{
+			name: "issue job with no recorded branch",
+			job: &daemon.JobResponse{
+				Name:        "bug-fixer-issue-480",
+				IssueNumber: 480,
+			},
+			want: []string{"agent/issue-480", "agent/bug-fixer-issue-480"},
+		},
+		{
+			name: "no info at all",
+			job:  &daemon.JobResponse{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := candidateBranchNamesRemote(tt.job)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("candidateBranchNamesRemote() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- When restoring a worktree, `minder checkout` constructed the fallback branch as `agent/<job.Name>` (e.g. `agent/bug-fixer-issue-480`), but the supervisor creates branches as `agent/issue-<N>` for issue-bound jobs — causing "not a valid object name" errors
- Checkout now builds an ordered candidate list mirroring supervisor conventions (recorded branch → `agent/issue-<N>` → `agent/<name>`) and picks the first that exists locally or on origin
- Same fix applied to remote checkout path (`runCheckoutRemote`)

## Test plan
- [x] Unit tests for `candidateBranchNames` and `candidateBranchNamesRemote` covering: issue jobs with/without recorded branch, proactive jobs, dedup
- [x] Full `go test ./...` passes
- [ ] Manual: `minder checkout` on a job whose worktree was cleaned up (issue-bound, agent name differs from issue number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)