### PR TITLE
Add multi-label AND support to watch filters and trigger routes

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -298,8 +298,8 @@ func runForeground(deployID string) error {
 			fmt.Printf("Warning: sync schedules: %v\n", err)
 		}
 		for _, def := range cfg.Jobs {
-			if label := def.TriggerLabel(); label != "" {
-				routes = append(routes, supervisor.TriggerRoute{Label: label, Agent: def.Agent})
+			if labels := def.TriggerLabels(); len(labels) > 0 {
+				routes = append(routes, supervisor.TriggerRoute{Labels: labels, Agent: def.Agent})
 			}
 		}
 		if len(routes) > 0 {
@@ -418,8 +418,8 @@ func runDaemon(deployID string) error {
 
 		// Extract trigger routes and cron schedules for display.
 		for _, def := range cfg.Jobs {
-			if label := def.TriggerLabel(); label != "" {
-				routes = append(routes, supervisor.TriggerRoute{Label: label, Agent: def.Agent})
+			if labels := def.TriggerLabels(); len(labels) > 0 {
+				routes = append(routes, supervisor.TriggerRoute{Labels: labels, Agent: def.Agent})
 			}
 		}
 		if len(routes) > 0 {
@@ -518,7 +518,7 @@ func printStartupSummary(deploy *db.Deployment, routes []supervisor.TriggerRoute
 		fmt.Printf("  Watch: %s → autopilot\n", deploy.WatchFilter.String)
 	}
 	for _, r := range routes {
-		fmt.Printf("  Trigger: label:%s → %s\n", r.Label, r.Agent)
+		fmt.Printf("  Trigger: label:%s → %s\n", strings.Join(r.Labels, ","), r.Agent)
 	}
 	schedules, _ := store.GetEnabledSchedules(deployID)
 	for _, s := range schedules {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -445,9 +445,15 @@ func (c *Client) ListIssuesByMilestone(ctx context.Context, owner, repo string, 
 // Uses the Issues list API instead of the Search API to avoid permission issues
 // with tokens that lack search scope.
 func (c *Client) ListIssuesByLabel(ctx context.Context, owner, repo, label string) (*SearchResult, error) {
+	return c.ListIssuesByLabels(ctx, owner, repo, []string{label})
+}
+
+// ListIssuesByLabels returns open issues that have ALL the given labels (AND logic).
+// GitHub's Issues list API natively applies AND when multiple labels are specified.
+func (c *Client) ListIssuesByLabels(ctx context.Context, owner, repo string, labels []string) (*SearchResult, error) {
 	var allItems []ItemStatus
 	opts := &github.IssueListByRepoOptions{
-		Labels:    []string{label},
+		Labels:    labels,
 		State:     "open",
 		Sort:      "created",
 		Direction: "desc",

--- a/internal/scheduler/config.go
+++ b/internal/scheduler/config.go
@@ -36,16 +36,17 @@ func (j *JobDef) IsTrigger() bool {
 	return j.Trigger != ""
 }
 
-// TriggerLabel returns the label name if this is a label trigger, or empty string.
-func (j *JobDef) TriggerLabel() string {
+// TriggerLabels returns the label names if this is a label trigger (comma-separated = AND logic).
+// Returns nil for non-label triggers.
+func (j *JobDef) TriggerLabels() []string {
 	if !j.IsTrigger() {
-		return ""
+		return nil
 	}
 	parts := strings.SplitN(j.Trigger, ":", 2)
 	if len(parts) == 2 && parts[0] == "label" {
-		return parts[1]
+		return strings.Split(parts[1], ",")
 	}
-	return ""
+	return nil
 }
 
 // ParsedSchedule returns the parsed cron expression, or nil if not scheduled.

--- a/internal/supervisor/jobmanager.go
+++ b/internal/supervisor/jobmanager.go
@@ -315,17 +315,17 @@ func (sc *SlotContext) ClearUsageLimitFlag() {
 	}
 }
 
-// TriggerLabel returns the label that triggered this job, if any.
+// TriggerLabels returns the labels that triggered this job, if any.
 // Looks up the job's agent in the supervisor's trigger routes.
-func (sc *SlotContext) TriggerLabel() string {
+func (sc *SlotContext) TriggerLabels() []string {
 	sc.sup.mu.Lock()
 	defer sc.sup.mu.Unlock()
 	for _, route := range sc.sup.triggerRoutes {
 		if route.Agent == sc.Job.Agent {
-			return route.Label
+			return route.Labels
 		}
 	}
-	return ""
+	return nil
 }
 
 // ParseCost extracts cost from the agent log.
@@ -814,8 +814,8 @@ func (m *DefaultJobManager) finalizePipeline(ctx context.Context, reviewRisk str
 	if job.IssueNumber > 0 {
 		ghClient.RemoveLabel(ctx, sc.Owner, sc.Repo, job.IssueNumber, "in-progress")
 
-		// Remove the trigger label that started this job (e.g., "bug", "spike", "agent-ready").
-		if triggerLabel := sc.TriggerLabel(); triggerLabel != "" {
+		// Remove the trigger labels that started this job (e.g., "bug", "agent-ready,ux").
+		for _, triggerLabel := range sc.TriggerLabels() {
 			ghClient.RemoveLabel(ctx, sc.Owner, sc.Repo, job.IssueNumber, triggerLabel)
 		}
 	}

--- a/internal/supervisor/multi_agent_test.go
+++ b/internal/supervisor/multi_agent_test.go
@@ -150,16 +150,16 @@ func TestWatchPollDedupByAgentAndIssue(t *testing.T) {
 	}
 }
 
-func TestTriggerLabelLookup(t *testing.T) {
-	// Verify TriggerLabel() finds the right label for an agent.
+func TestTriggerLabelsLookup(t *testing.T) {
+	// Verify TriggerLabels() finds the right labels for an agent.
 	store := testStoreForMultiAgent(t)
 	deploy := testDeployForMultiAgent(t, store)
 
 	sup := NewTestSupervisor(store, deploy, "/tmp/repo")
 	sup.SetTriggerRoutes([]TriggerRoute{
-		{Label: "spike", Agent: "spike"},
-		{Label: "bug", Agent: "bug-fixer"},
-		{Label: "agent-ready", Agent: "autopilot"},
+		{Labels: []string{"spike"}, Agent: "spike"},
+		{Labels: []string{"bug"}, Agent: "bug-fixer"},
+		{Labels: []string{"agent-ready"}, Agent: "autopilot"},
 	})
 
 	spikeJob := &db.Job{
@@ -179,8 +179,8 @@ func TestTriggerLabelLookup(t *testing.T) {
 		Owner: "acme", Repo: "widgets", sup: sup,
 	}
 
-	if label := sc.TriggerLabel(); label != "spike" {
-		t.Errorf("TriggerLabel() = %q, want %q", label, "spike")
+	if labels := sc.TriggerLabels(); len(labels) != 1 || labels[0] != "spike" {
+		t.Errorf("TriggerLabels() = %v, want [spike]", labels)
 	}
 
 	// Test with autopilot.
@@ -200,8 +200,8 @@ func TestTriggerLabelLookup(t *testing.T) {
 		Owner: "acme", Repo: "widgets", sup: sup,
 	}
 
-	if label := sc2.TriggerLabel(); label != "agent-ready" {
-		t.Errorf("TriggerLabel() = %q, want %q", label, "agent-ready")
+	if labels := sc2.TriggerLabels(); len(labels) != 1 || labels[0] != "agent-ready" {
+		t.Errorf("TriggerLabels() = %v, want [agent-ready]", labels)
 	}
 
 	// Agent with no trigger route should return empty.
@@ -220,7 +220,7 @@ func TestTriggerLabelLookup(t *testing.T) {
 		Owner: "acme", Repo: "widgets", sup: sup,
 	}
 
-	if label := sc3.TriggerLabel(); label != "" {
-		t.Errorf("TriggerLabel() for reviewer = %q, want empty", label)
+	if labels := sc3.TriggerLabels(); len(labels) != 0 {
+		t.Errorf("TriggerLabels() for reviewer = %v, want nil", labels)
 	}
 }

--- a/internal/supervisor/watch.go
+++ b/internal/supervisor/watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -13,26 +14,34 @@ import (
 
 // WatchFilter represents a parsed watch filter.
 type WatchFilter struct {
-	Type  string // "label" or "milestone"
-	Value string
+	Type   string   // "label" or "milestone"
+	Values []string // label names (AND logic) or single milestone name
 }
 
-// TriggerRoute maps a label to an agent type.
-// When an issue has the matching label, it's routed to the specified agent
-// instead of the default autopilot.
+// TriggerRoute maps one or more labels to an agent type.
+// When an issue has ALL matching labels (AND logic), it's routed to the
+// specified agent instead of the default autopilot.
 type TriggerRoute struct {
-	Label string // GitHub label to match
-	Agent string // agent type to use
+	Labels []string // GitHub labels to match (AND logic)
+	Agent  string   // agent type to use
 }
 
 // SetTriggerRoutes configures label→agent routing from jobs.yaml triggers.
+// Routes with more labels (more specific) are sorted first so they match
+// before less specific routes.
 func (s *Supervisor) SetTriggerRoutes(routes []TriggerRoute) {
+	sorted := make([]TriggerRoute, len(routes))
+	copy(sorted, routes)
+	sort.Slice(sorted, func(i, j int) bool {
+		return len(sorted[i].Labels) > len(sorted[j].Labels)
+	})
 	s.mu.Lock()
-	s.triggerRoutes = routes
+	s.triggerRoutes = sorted
 	s.mu.Unlock()
 }
 
-// ParseWatchFilter parses a filter string like "label:ready" or "milestone:v2.0".
+// ParseWatchFilter parses a filter string like "label:ready", "label:agent-ready,ux",
+// or "milestone:v2.0". Multiple comma-separated labels use AND logic.
 func ParseWatchFilter(filter string) (*WatchFilter, error) {
 	parts := strings.SplitN(filter, ":", 2)
 	if len(parts) != 2 || parts[1] == "" {
@@ -42,11 +51,26 @@ func ParseWatchFilter(filter string) (*WatchFilter, error) {
 	if typ != "label" && typ != "milestone" {
 		return nil, fmt.Errorf("unsupported filter type %q (expected label or milestone)", typ)
 	}
-	value := parts[1]
-	if !isValidFilterValue(value) {
-		return nil, fmt.Errorf("invalid watch filter value %q (must contain only alphanumeric, hyphen, underscore, dot, or space characters)", value)
+
+	values := splitFilterValues(typ, parts[1])
+	for _, v := range values {
+		if v == "" {
+			return nil, fmt.Errorf("invalid watch filter %q: empty label in comma-separated list", filter)
+		}
+		if !isValidFilterValue(v) {
+			return nil, fmt.Errorf("invalid watch filter value %q (must contain only alphanumeric, hyphen, underscore, dot, or space characters)", v)
+		}
 	}
-	return &WatchFilter{Type: typ, Value: value}, nil
+	return &WatchFilter{Type: typ, Values: values}, nil
+}
+
+// splitFilterValues splits on comma for labels (AND logic) but keeps
+// milestone values intact (commas not meaningful for milestones).
+func splitFilterValues(typ, raw string) []string {
+	if typ == "label" && strings.Contains(raw, ",") {
+		return strings.Split(raw, ",")
+	}
+	return []string{raw}
 }
 
 // watchPoll queries GitHub for issues matching the watch filter and trigger routes,
@@ -91,7 +115,7 @@ func (s *Supervisor) watchPoll(ctx context.Context) int {
 	s.mu.Unlock()
 
 	for _, route := range routes {
-		issues := s.pollFilter(ctx, ghClient, "label:"+route.Label)
+		issues := s.pollFilter(ctx, ghClient, "label:"+strings.Join(route.Labels, ","))
 		for _, issue := range issues {
 			if knownJobs[issueAgent{issue.Number, route.Agent}] || issue.State != "open" || hasLabel(issue.Labels, skipLabel) {
 				continue
@@ -116,9 +140,9 @@ func (s *Supervisor) pollFilter(ctx context.Context, ghClient *ghpkg.Client, fil
 	var searchResult *ghpkg.SearchResult
 	switch filter.Type {
 	case "label":
-		searchResult, err = ghClient.ListIssuesByLabel(ctx, s.owner, s.repo, filter.Value)
+		searchResult, err = ghClient.ListIssuesByLabels(ctx, s.owner, s.repo, filter.Values)
 	case "milestone":
-		msNum, msErr := ghClient.FindMilestoneNumber(ctx, s.owner, s.repo, filter.Value)
+		msNum, msErr := ghClient.FindMilestoneNumber(ctx, s.owner, s.repo, filter.Values[0])
 		if msErr != nil {
 			return nil
 		}
@@ -132,17 +156,28 @@ func (s *Supervisor) pollFilter(ctx context.Context, ghClient *ghpkg.Client, fil
 
 // resolveAgentForIssue checks the issue's labels against trigger routes.
 // Returns the matching agent, or "autopilot" as default.
+// Routes with more labels are checked first so specific routes take priority.
 func (s *Supervisor) resolveAgentForIssue(labels []string) string {
 	s.mu.Lock()
 	routes := s.triggerRoutes
 	s.mu.Unlock()
 
 	for _, route := range routes {
-		if hasLabel(labels, route.Label) {
+		if hasAllLabels(labels, route.Labels) {
 			return route.Agent
 		}
 	}
 	return "autopilot"
+}
+
+// hasAllLabels returns true if issueLabels contains every label in required (case-insensitive).
+func hasAllLabels(issueLabels []string, required []string) bool {
+	for _, req := range required {
+		if !hasLabel(issueLabels, req) {
+			return false
+		}
+	}
+	return len(required) > 0
 }
 
 // createJobForIssue fetches issue content and inserts a job row.

--- a/internal/supervisor/watch_test.go
+++ b/internal/supervisor/watch_test.go
@@ -6,18 +6,21 @@ import (
 
 func TestParseWatchFilter(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		wantErr bool
-		wantTyp string
-		wantVal string
+		name     string
+		input    string
+		wantErr  bool
+		wantTyp  string
+		wantVals []string
 	}{
-		{name: "valid label", input: "label:ready", wantTyp: "label", wantVal: "ready"},
-		{name: "valid milestone", input: "milestone:v2.0", wantTyp: "milestone", wantVal: "v2.0"},
-		{name: "label with spaces", input: "label:needs review", wantTyp: "label", wantVal: "needs review"},
-		{name: "label with hyphens", input: "label:in-progress", wantTyp: "label", wantVal: "in-progress"},
-		{name: "label with underscores", input: "label:no_agent", wantTyp: "label", wantVal: "no_agent"},
-		{name: "uppercase type normalised", input: "LABEL:foo", wantTyp: "label", wantVal: "foo"},
+		{name: "valid label", input: "label:ready", wantTyp: "label", wantVals: []string{"ready"}},
+		{name: "valid milestone", input: "milestone:v2.0", wantTyp: "milestone", wantVals: []string{"v2.0"}},
+		{name: "label with spaces", input: "label:needs review", wantTyp: "label", wantVals: []string{"needs review"}},
+		{name: "label with hyphens", input: "label:in-progress", wantTyp: "label", wantVals: []string{"in-progress"}},
+		{name: "label with underscores", input: "label:no_agent", wantTyp: "label", wantVals: []string{"no_agent"}},
+		{name: "uppercase type normalised", input: "LABEL:foo", wantTyp: "label", wantVals: []string{"foo"}},
+		{name: "multi-label AND", input: "label:agent-ready,ux", wantTyp: "label", wantVals: []string{"agent-ready", "ux"}},
+		{name: "three labels AND", input: "label:a,b,c", wantTyp: "label", wantVals: []string{"a", "b", "c"}},
+		{name: "milestone with comma kept intact", input: "milestone:v2.0", wantTyp: "milestone", wantVals: []string{"v2.0"}},
 		{name: "empty value", input: "label:", wantErr: true},
 		{name: "no colon", input: "labelready", wantErr: true},
 		{name: "unsupported type", input: "author:alice", wantErr: true},
@@ -26,6 +29,8 @@ func TestParseWatchFilter(t *testing.T) {
 		{name: "invalid chars in value", input: "label:foo;bar", wantErr: true},
 		{name: "newline in value", input: "label:foo\nbar", wantErr: true},
 		{name: "tab in value", input: "label:foo\tbar", wantErr: true},
+		{name: "empty label in list", input: "label:foo,,bar", wantErr: true},
+		{name: "trailing comma", input: "label:foo,", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -43,10 +48,63 @@ func TestParseWatchFilter(t *testing.T) {
 			if got.Type != tt.wantTyp {
 				t.Errorf("Type = %q, want %q", got.Type, tt.wantTyp)
 			}
-			if got.Value != tt.wantVal {
-				t.Errorf("Value = %q, want %q", got.Value, tt.wantVal)
+			if len(got.Values) != len(tt.wantVals) {
+				t.Fatalf("Values = %v, want %v", got.Values, tt.wantVals)
+			}
+			for i, v := range got.Values {
+				if v != tt.wantVals[i] {
+					t.Errorf("Values[%d] = %q, want %q", i, v, tt.wantVals[i])
+				}
 			}
 		})
+	}
+}
+
+func TestHasAllLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		issue    []string
+		required []string
+		want     bool
+	}{
+		{"single match", []string{"bug", "ux"}, []string{"ux"}, true},
+		{"AND match", []string{"agent-ready", "ux", "high-priority"}, []string{"agent-ready", "ux"}, true},
+		{"missing one", []string{"agent-ready"}, []string{"agent-ready", "ux"}, false},
+		{"case insensitive", []string{"Agent-Ready", "UX"}, []string{"agent-ready", "ux"}, true},
+		{"empty required", []string{"bug"}, nil, false},
+		{"empty issue labels", nil, []string{"bug"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasAllLabels(tt.issue, tt.required); got != tt.want {
+				t.Errorf("hasAllLabels(%v, %v) = %v, want %v", tt.issue, tt.required, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentSpecificityOrder(t *testing.T) {
+	// More-specific routes (more labels) should match first.
+	store := testStoreForMultiAgent(t)
+	deploy := testDeployForMultiAgent(t, store)
+	sup := NewTestSupervisor(store, deploy, "/tmp/repo")
+
+	sup.SetTriggerRoutes([]TriggerRoute{
+		{Labels: []string{"agent-ready"}, Agent: "autopilot"},
+		{Labels: []string{"agent-ready", "ux"}, Agent: "ux-agent"},
+	})
+
+	// Issue with both labels should route to ux-agent (more specific).
+	agent := sup.resolveAgentForIssue([]string{"agent-ready", "ux"})
+	if agent != "ux-agent" {
+		t.Errorf("resolveAgentForIssue([agent-ready, ux]) = %q, want %q", agent, "ux-agent")
+	}
+
+	// Issue with only agent-ready should route to autopilot.
+	agent = sup.resolveAgentForIssue([]string{"agent-ready"})
+	if agent != "autopilot" {
+		t.Errorf("resolveAgentForIssue([agent-ready]) = %q, want %q", agent, "autopilot")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Watch filters and trigger routes now support comma-separated labels with AND logic: `label:agent-ready,ux` matches issues that have **both** labels
- GitHub's Issues API natively applies AND when multiple labels are passed — no post-filtering needed
- Routes with more labels are sorted first so `label:agent-ready,ux → ux-autopilot` takes priority over `label:agent-ready → autopilot`
- On job completion, all trigger labels are removed from the issue

**Usage examples:**
```bash
minder deploy --watch "label:agent-ready,ux" --agent ux-autopilot
```
```yaml
# jobs.yaml
ux-work:
  trigger: "label:agent-ready,ux"
  agent: ux-autopilot
  description: "Implement UX-focused issues"
```

## Test plan
- [x] `TestParseWatchFilter` — multi-label parsing, empty label rejection, trailing comma
- [x] `TestHasAllLabels` — AND matching, case insensitivity, edge cases
- [x] `TestResolveAgentSpecificityOrder` — more-specific routes match first
- [x] `TestTriggerLabelsLookup` — updated for `[]string` labels
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)