### PR TITLE
Fix duplicate job creation when issue matches multiple trigger routes

### DIFF
--- a/internal/supervisor/watch.go
+++ b/internal/supervisor/watch.go
@@ -117,6 +117,10 @@ func (s *Supervisor) watchPoll(ctx context.Context) int {
 	for _, route := range routes {
 		issues := s.pollFilter(ctx, ghClient, "label:"+strings.Join(route.Labels, ","))
 		for _, issue := range issues {
+			// Skip if a more-specific route should handle this issue.
+			if s.resolveAgentForIssue(issue.Labels) != route.Agent {
+				continue
+			}
 			if knownJobs[issueAgent{issue.Number, route.Agent}] || issue.State != "open" || hasLabel(issue.Labels, skipLabel) {
 				continue
 			}


### PR DESCRIPTION
## Summary
- Fixes #462 follow-up: when an issue has labels matching multiple trigger routes (e.g. `agent-ready` + `ux`), both the broad route (`autopilot`) and specific route (`ux-autopilot`) would create jobs
- In the trigger route loop, now calls `resolveAgentForIssue` to verify the route is the most-specific match before creating a job
- Issue with `[agent-ready, ux]` now only creates a `ux-autopilot` job, not both

## Test plan
- [x] `TestResolveAgentSpecificityOrder` confirms more-specific routes win
- [x] Full `go test ./...` passes
- [ ] Manual: tag an issue with both `agent-ready` and `ux`, verify only `ux-autopilot` job is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)