### PR TITLE
Add --grep filter and interactive /search to checkout and logs

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -29,7 +29,9 @@ If the worktree no longer exists on disk, it is recreated from the remote branch
 Examples:
   minder checkout              # interactive picker
   minder checkout #42          # most recent job for issue 42
-  minder checkout --job 7      # by job ID`,
+  minder checkout --job 7      # by job ID
+  minder checkout -g spike     # filter to spike jobs
+  minder checkout -g 529       # find issue #529 or PR #529`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runCheckout,
 }
@@ -39,6 +41,7 @@ var (
 	flagCheckoutJob    int64
 	flagCheckoutRemote string
 	flagCheckoutKey    string
+	flagCheckoutGrep   string
 )
 
 func init() {
@@ -47,6 +50,7 @@ func init() {
 	checkoutCmd.Flags().Int64Var(&flagCheckoutJob, "job", 0, "Job ID (skip picker)")
 	checkoutCmd.Flags().StringVar(&flagCheckoutRemote, "remote", "", "Remote daemon address (host:port)")
 	checkoutCmd.Flags().StringVar(&flagCheckoutKey, "api-key", "", "API key for remote access")
+	checkoutCmd.Flags().StringVarP(&flagCheckoutGrep, "grep", "g", "", "Filter jobs by substring (matches issue, agent, title, PR, status)")
 }
 
 func runCheckout(cmd *cobra.Command, args []string) error {
@@ -109,8 +113,10 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		candidates = picker.FilterJobs(candidates, flagCheckoutGrep)
+
 		if len(candidates) == 0 {
-			fmt.Println("No completed jobs found for this repository.")
+			fmt.Println("No matching jobs found for this repository.")
 			return nil
 		}
 
@@ -362,8 +368,9 @@ func runCheckoutRemote(args []string) error {
 				candidates = append(candidates, j)
 			}
 		}
+		candidates = picker.FilterRemoteJobs(candidates, flagCheckoutGrep)
 		if len(candidates) == 0 {
-			fmt.Println("No jobs found on remote daemon.")
+			fmt.Println("No matching jobs found on remote daemon.")
 			return nil
 		}
 		selected, err = picker.PickRemoteJob(candidates, "Select a job")

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -31,6 +31,8 @@ Examples:
   minder logs #42              # most recent job for issue 42
   minder logs --job 7          # by job ID
   minder logs --follow         # tail a running job
+  minder logs -g spike         # filter to spike jobs
+  minder logs -g 529           # find issue #529 or PR #529
   minder logs --remote :7749   # stream from remote daemon`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runLogs,
@@ -43,6 +45,7 @@ var (
 	flagLogsRemote string
 	flagLogsKey    string
 	flagLogsRaw    bool
+	flagLogsGrep   string
 )
 
 func init() {
@@ -53,6 +56,7 @@ func init() {
 	logsCmd.Flags().StringVar(&flagLogsRemote, "remote", "", "Remote daemon address (host:port)")
 	logsCmd.Flags().StringVar(&flagLogsKey, "api-key", "", "API key for remote access")
 	logsCmd.Flags().BoolVar(&flagLogsRaw, "raw", false, "Output raw stream-json (no formatting)")
+	logsCmd.Flags().StringVarP(&flagLogsGrep, "grep", "g", "", "Filter jobs by substring (matches issue, agent, title, PR, status)")
 }
 
 func runLogs(cmd *cobra.Command, args []string) error {
@@ -131,8 +135,10 @@ func runLogsLocal(args []string) error {
 			}
 		}
 
+		candidates = picker.FilterJobs(candidates, flagLogsGrep)
+
 		if len(candidates) == 0 {
-			fmt.Println("No jobs with logs found for this repository.")
+			fmt.Println("No matching jobs found for this repository.")
 			return nil
 		}
 
@@ -236,8 +242,9 @@ func runLogsRemote(args []string) error {
 		if err != nil {
 			return fmt.Errorf("fetch jobs: %w", err)
 		}
+		jobs = picker.FilterRemoteJobs(jobs, flagLogsGrep)
 		if len(jobs) == 0 {
-			fmt.Println("No jobs found.")
+			fmt.Println("No matching jobs found.")
 			return nil
 		}
 		selected, err := picker.PickRemoteJob(jobs, "Select a job")

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -3,6 +3,8 @@ package picker
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 
@@ -26,6 +28,7 @@ func PickJob(jobs []*db.Job, title string) (*db.Job, error) {
 	err := huh.NewSelect[*db.Job]().
 		Title(title).
 		Options(options...).
+		Filtering(true).
 		Value(&selected).
 		Run()
 	if err != nil {
@@ -79,6 +82,71 @@ func formatJobLine(j *db.Job) string {
 		label, agent, title, j.Status, pr, cost)
 }
 
+// FilterJobs returns only the jobs whose fields match the filter string
+// (case-insensitive substring match across issue number, agent, title,
+// status, PR number, and cost).
+func FilterJobs(jobs []*db.Job, filter string) []*db.Job {
+	if filter == "" {
+		return jobs
+	}
+	f := strings.ToLower(filter)
+	var out []*db.Job
+	for _, j := range jobs {
+		if strings.Contains(strings.ToLower(jobSearchString(j)), f) {
+			out = append(out, j)
+		}
+	}
+	return out
+}
+
+func jobSearchString(j *db.Job) string {
+	parts := []string{
+		j.Agent, j.Name, j.Status,
+		j.IssueTitle.String,
+	}
+	if j.IssueNumber > 0 {
+		parts = append(parts, strconv.Itoa(j.IssueNumber))
+	}
+	if j.PRNumber.Valid && j.PRNumber.Int64 > 0 {
+		parts = append(parts, strconv.FormatInt(j.PRNumber.Int64, 10))
+	}
+	if j.CostUSD > 0 {
+		parts = append(parts, fmt.Sprintf("%.2f", j.CostUSD))
+	}
+	return strings.Join(parts, " ")
+}
+
+// FilterRemoteJobs returns only the remote jobs whose fields match the filter.
+func FilterRemoteJobs(jobs []daemon.JobResponse, filter string) []daemon.JobResponse {
+	if filter == "" {
+		return jobs
+	}
+	f := strings.ToLower(filter)
+	var out []daemon.JobResponse
+	for _, j := range jobs {
+		if strings.Contains(strings.ToLower(remoteJobSearchString(&j)), f) {
+			out = append(out, j)
+		}
+	}
+	return out
+}
+
+func remoteJobSearchString(j *daemon.JobResponse) string {
+	parts := []string{
+		j.Agent, j.Name, j.Status, j.Title,
+	}
+	if j.IssueNumber > 0 {
+		parts = append(parts, strconv.Itoa(j.IssueNumber))
+	}
+	if j.PRNumber > 0 {
+		parts = append(parts, strconv.Itoa(j.PRNumber))
+	}
+	if j.CostUSD > 0 {
+		parts = append(parts, fmt.Sprintf("%.2f", j.CostUSD))
+	}
+	return strings.Join(parts, " ")
+}
+
 // PickRemoteJob presents an interactive select list of remote API jobs.
 func PickRemoteJob(jobs []daemon.JobResponse, title string) (*daemon.JobResponse, error) {
 	if len(jobs) == 0 {
@@ -94,6 +162,7 @@ func PickRemoteJob(jobs []daemon.JobResponse, title string) (*daemon.JobResponse
 	err := huh.NewSelect[*daemon.JobResponse]().
 		Title(title).
 		Options(options...).
+		Filtering(true).
 		Value(&selected).
 		Run()
 	if err != nil {

--- a/internal/picker/picker_test.go
+++ b/internal/picker/picker_test.go
@@ -1,0 +1,70 @@
+package picker
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/aptx-health/agent-minder/internal/daemon"
+	"github.com/aptx-health/agent-minder/internal/db"
+)
+
+func TestFilterJobs(t *testing.T) {
+	jobs := []*db.Job{
+		{Agent: "spike", Name: "spike-issue-518", IssueNumber: 518, IssueTitle: sql.NullString{String: "[Feature] It'd be great if the...", Valid: true}, Status: "done", CostUSD: 0.88},
+		{Agent: "ux-autopilot", Name: "ux-autopilot-issue-529", IssueNumber: 529, IssueTitle: sql.NullString{String: "Cleanup: remove old tour system", Valid: true}, Status: "reviewed", PRNumber: sql.NullInt64{Int64: 532, Valid: true}, CostUSD: 2.01},
+		{Agent: "bug-fixer", Name: "bug-fixer-issue-521", IssueNumber: 521, IssueTitle: sql.NullString{String: "[Bug] Loading frog icon shows up", Valid: true}, Status: "reviewed", PRNumber: sql.NullInt64{Int64: 523, Valid: true}, CostUSD: 0.44},
+	}
+
+	tests := []struct {
+		name   string
+		filter string
+		want   int
+	}{
+		{"empty filter returns all", "", 3},
+		{"filter by agent name", "spike", 1},
+		{"filter by issue number", "529", 1},
+		{"filter by PR number", "532", 1},
+		{"filter by title substring", "frog", 1},
+		{"filter by status", "done", 1},
+		{"case insensitive", "BUG-FIXER", 1},
+		{"no match", "nonexistent", 0},
+		{"partial agent match", "auto", 1},
+		{"multiple matches", "reviewed", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterJobs(jobs, tt.filter)
+			if len(got) != tt.want {
+				t.Errorf("FilterJobs(%q) returned %d jobs, want %d", tt.filter, len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterRemoteJobs(t *testing.T) {
+	jobs := []daemon.JobResponse{
+		{Agent: "spike", Name: "spike-issue-518", IssueNumber: 518, Title: "[Feature] It'd be great if the...", Status: "done", CostUSD: 0.88},
+		{Agent: "ux-autopilot", Name: "ux-autopilot-issue-529", IssueNumber: 529, Title: "Cleanup: remove old tour system", Status: "reviewed", PRNumber: 532, CostUSD: 2.01},
+	}
+
+	tests := []struct {
+		name   string
+		filter string
+		want   int
+	}{
+		{"empty filter returns all", "", 2},
+		{"filter by agent", "spike", 1},
+		{"filter by PR number", "532", 1},
+		{"no match", "xyz", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterRemoteJobs(jobs, tt.filter)
+			if len(got) != tt.want {
+				t.Errorf("FilterRemoteJobs(%q) returned %d jobs, want %d", tt.filter, len(got), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `--grep` / `-g` flag on `minder checkout` and `minder logs` pre-filters the job list before showing the picker
- Case-insensitive substring match across issue number, agent name, title, status, PR number, and cost
- Enable huh Select's built-in `/` search: press `/` in the picker to interactively filter, ESC to clear filter
- Works in both local and remote modes

**Usage:**
```bash
minder checkout -g spike       # only spike jobs
minder checkout -g 529         # find issue #529 or PR #529
minder logs -g bug-fixer       # only bug-fixer logs
minder logs -g reviewed        # only reviewed jobs
```

In the picker, press `/` to search interactively (vim-style).

## Test plan
- [x] `TestFilterJobs` — 10 cases: agent, issue, PR, title, status, case-insensitive, partial, multi-match, no-match
- [x] `TestFilterRemoteJobs` — 4 cases covering remote job filtering
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)