### PR TITLE
Add action menu to minder checkout: checkout, resume, or logs

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -18,18 +18,19 @@ import (
 
 var checkoutCmd = &cobra.Command{
 	Use:   "checkout [issue-or-job-id]",
-	Short: "Check out an agent's worktree for review",
-	Long: `Opens an agent's worktree so you can review and test its work.
+	Short: "Interact with an agent's work",
+	Long: `Select a job and choose what to do: checkout the worktree, resume with
+Claude, or view logs.
 
 If no argument is given, presents an interactive picker of completed jobs
-for the current repository.
-
-If the worktree no longer exists on disk, it is recreated from the remote branch.
+for the current repository, then an action menu.
 
 Examples:
-  minder checkout              # interactive picker
+  minder checkout              # interactive picker → action menu
   minder checkout #42          # most recent job for issue 42
-  minder checkout --job 7      # by job ID`,
+  minder checkout --job 7      # by job ID
+  minder checkout -g spike     # filter to spike jobs
+  minder checkout -g 529       # find issue #529 or PR #529`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runCheckout,
 }
@@ -125,7 +126,41 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 		fmt.Printf("\n⚠ Warning: this job is currently %s — the agent is actively working.\n\n", job.Status)
 	}
 
-	return checkoutWorktree(repoDir, job)
+	// Action menu.
+	action, err := picker.PickAction(job)
+	if err != nil {
+		return err
+	}
+
+	return executeAction(action, repoDir, job)
+}
+
+func executeAction(action picker.Action, repoDir string, job *db.Job) error {
+	switch action {
+	case picker.ActionCheckout:
+		return checkoutWorktree(repoDir, job)
+
+	case picker.ActionResume:
+		worktreePath, _, err := ensureWorktree(repoDir, job)
+		if err != nil {
+			return err
+		}
+		prompt := buildResumePrompt(job)
+		return launchClaude(worktreePath, prompt)
+
+	case picker.ActionLogs:
+		logPath := resolveLogPath(job)
+		if logPath == "" {
+			return fmt.Errorf("log not found for job %s (deploy %s)", job.Name, job.DeploymentID)
+		}
+		f, err := os.Open(logPath)
+		if err != nil {
+			return fmt.Errorf("open log: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		return streamLog(f, false)
+	}
+	return nil
 }
 
 func findMostRecentJobForIssue(store *db.Store, owner, repo string, issueNum int) (*db.Job, error) {

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/aptx-health/agent-minder/internal/agentutil"
+	"github.com/aptx-health/agent-minder/internal/db"
+	gitpkg "github.com/aptx-health/agent-minder/internal/git"
+)
+
+// ensureWorktree resolves or recreates the worktree for a job and returns
+// the worktree path and branch name.
+func ensureWorktree(repoDir string, job *db.Job) (string, string, error) {
+	worktreePath := job.WorktreePath.String
+	branch := job.Branch.String
+
+	// Worktree exists on disk — use it.
+	if worktreePath != "" && dirExistsCheckout(worktreePath) {
+		if branch == "" {
+			branch = candidateBranchNames(job)[0]
+		}
+		return worktreePath, branch, nil
+	}
+
+	// Recreate from branch.
+	candidates := candidateBranchNames(job)
+	fmt.Printf("Worktree not found, recreating from branch %s...\n", candidates[0])
+
+	_ = gitpkg.Fetch(repoDir)
+	_ = gitpkg.WorktreePrune(repoDir)
+
+	var err error
+	branch, err = pickExistingBranch(repoDir, candidates)
+	if err != nil {
+		return "", "", err
+	}
+
+	if worktreePath == "" {
+		home, _ := os.UserHomeDir()
+		worktreePath = filepath.Join(home, ".agent-minder", "worktrees", "checkout", job.Name)
+	}
+	_ = os.MkdirAll(filepath.Dir(worktreePath), 0755)
+
+	if err := createWorktreeFromBranch(repoDir, worktreePath, branch); err != nil {
+		return "", "", err
+	}
+	return worktreePath, branch, nil
+}
+
+// buildResumePrompt gathers all available context for a job and dumps it
+// into a prompt. No clever filtering — just include everything we have.
+func buildResumePrompt(job *db.Job) string {
+	var b strings.Builder
+
+	b.WriteString("You're picking up work from a previous agent run. Here's everything we know:\n\n")
+
+	// Always include metadata.
+	fmt.Fprintf(&b, "Agent: %s | Status: %s", job.Agent, job.Status)
+	if job.CostUSD > 0 {
+		fmt.Fprintf(&b, " | Cost: $%.2f", job.CostUSD)
+	}
+	b.WriteString("\n")
+
+	if job.IssueNumber > 0 {
+		fmt.Fprintf(&b, "Issue: #%d — %s\n", job.IssueNumber, job.IssueTitle.String)
+	}
+	if job.PRNumber.Valid && job.PRNumber.Int64 > 0 {
+		fmt.Fprintf(&b, "PR: #%d\n", job.PRNumber.Int64)
+	}
+	if job.Branch.Valid && job.Branch.String != "" {
+		fmt.Fprintf(&b, "Branch: %s\n", job.Branch.String)
+	}
+	if job.ReviewRisk.Valid && job.ReviewRisk.String != "" {
+		fmt.Fprintf(&b, "Review risk: %s\n", job.ReviewRisk.String)
+	}
+	if job.FailureReason.Valid && job.FailureReason.String != "" {
+		fmt.Fprintf(&b, "Failure reason: %s\n", job.FailureReason.String)
+	}
+	if job.FailureDetail.Valid && job.FailureDetail.String != "" {
+		detail := job.FailureDetail.String
+		if len(detail) > 1500 {
+			detail = detail[:1500] + "...(truncated)"
+		}
+		fmt.Fprintf(&b, "Failure detail: %s\n", detail)
+	}
+	b.WriteString("\n")
+
+	// Issue body.
+	if job.IssueBody.Valid && job.IssueBody.String != "" {
+		b.WriteString("--- Issue body ---\n")
+		body := job.IssueBody.String
+		if len(body) > 3000 {
+			body = body[:3000] + "\n...(truncated)"
+		}
+		b.WriteString(body)
+		b.WriteString("\n\n")
+	}
+
+	// Result JSON (spike findings, etc).
+	if job.ResultJSON.Valid && job.ResultJSON.String != "" {
+		b.WriteString("--- Agent result ---\n")
+		result := job.ResultJSON.String
+		if len(result) > 3000 {
+			result = result[:3000] + "\n...(truncated)"
+		}
+		b.WriteString(result)
+		b.WriteString("\n\n")
+	}
+
+	// Agent log final output.
+	if logResult := parseAgentLogResult(job); logResult != "" {
+		b.WriteString("--- Agent final output ---\n")
+		b.WriteString(logResult)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("Review the git log, current diff, and any PR comments to get fully oriented. What would you like to do?")
+
+	return b.String()
+}
+
+// parseAgentLogResult extracts the result text from the agent's stream-json log.
+func parseAgentLogResult(job *db.Job) string {
+	logPath := job.AgentLog.String
+	if logPath == "" {
+		// Try convention-based path.
+		home, _ := os.UserHomeDir()
+		base := filepath.Join(home, ".agent-minder", "agents")
+		candidate := filepath.Join(base, fmt.Sprintf("%s-%s.log", job.DeploymentID, job.Name))
+		if fileExists(candidate) {
+			logPath = candidate
+		}
+	}
+	if logPath == "" {
+		return ""
+	}
+
+	result, err := agentutil.ParseAgentLog(logPath)
+	if err != nil || result == nil {
+		return ""
+	}
+
+	text := result.Result
+	if len(text) > 1500 {
+		text = text[:1500] + "\n...(truncated)"
+	}
+	return text
+}
+
+// launchClaude execs claude in the given directory with an initial prompt.
+// This replaces the current process.
+func launchClaude(dir, prompt string) error {
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return fmt.Errorf("claude not found in PATH: %w", err)
+	}
+
+	// Change to worktree directory before exec.
+	if err := os.Chdir(dir); err != nil {
+		return fmt.Errorf("chdir to worktree: %w", err)
+	}
+
+	fmt.Printf("\nLaunching Claude in %s...\n\n", dir)
+
+	// exec replaces this process with claude.
+	return syscall.Exec(claudePath, []string{"claude", prompt}, os.Environ())
+}
+
+// resolveLogPath finds the log file for a job.
+func resolveLogPath(job *db.Job) string {
+	logPath := job.AgentLog.String
+	if logPath != "" && fileExists(logPath) {
+		return logPath
+	}
+
+	home, _ := os.UserHomeDir()
+	base := filepath.Join(home, ".agent-minder", "agents")
+
+	candidates := []string{
+		filepath.Join(base, fmt.Sprintf("%s-%s.log", job.DeploymentID, job.Name)),
+	}
+	if job.IssueNumber > 0 {
+		candidates = append(candidates,
+			filepath.Join(base, fmt.Sprintf("%s-issue-%d.log", job.DeploymentID, job.IssueNumber)),
+		)
+	}
+
+	for _, c := range candidates {
+		if fileExists(c) {
+			return c
+		}
+	}
+	return ""
+}

--- a/cmd/resume_test.go
+++ b/cmd/resume_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/aptx-health/agent-minder/internal/db"
+)
+
+func TestBuildResumePrompt(t *testing.T) {
+	tests := []struct {
+		name     string
+		job      *db.Job
+		contains []string
+	}{
+		{
+			name: "bailed job dumps failure info",
+			job: &db.Job{
+				Agent:         "bug-fixer",
+				IssueNumber:   520,
+				IssueTitle:    sql.NullString{String: "Fix the login bug", Valid: true},
+				IssueBody:     sql.NullString{String: "Users can't log in", Valid: true},
+				Status:        db.StatusBailed,
+				FailureReason: sql.NullString{String: "permission_denied", Valid: true},
+				FailureDetail: sql.NullString{String: "Could not write to file", Valid: true},
+			},
+			contains: []string{
+				"#520", "bug-fixer", "bailed",
+				"permission_denied", "Could not write to file",
+				"Users can't log in",
+			},
+		},
+		{
+			name: "PR job includes all metadata",
+			job: &db.Job{
+				Agent:       "autopilot",
+				IssueNumber: 529,
+				IssueTitle:  sql.NullString{String: "Cleanup old tour", Valid: true},
+				Status:      db.StatusReviewed,
+				PRNumber:    sql.NullInt64{Int64: 532, Valid: true},
+				ReviewRisk:  sql.NullString{String: "needs-testing", Valid: true},
+				Branch:      sql.NullString{String: "agent/issue-529", Valid: true},
+				CostUSD:     2.01,
+			},
+			contains: []string{
+				"#529", "autopilot", "PR: #532",
+				"needs-testing", "$2.01", "agent/issue-529",
+			},
+		},
+		{
+			name: "spike with result JSON",
+			job: &db.Job{
+				Agent:       "spike",
+				IssueNumber: 518,
+				IssueTitle:  sql.NullString{String: "Research caching", Valid: true},
+				Status:      "done",
+				ResultJSON:  sql.NullString{String: `{"recommendation": "use Redis"}`, Valid: true},
+			},
+			contains: []string{
+				"spike", "#518", "use Redis",
+			},
+		},
+		{
+			name: "minimal job still works",
+			job: &db.Job{
+				Agent:  "autopilot",
+				Name:   "weekly-cleanup",
+				Status: "done",
+			},
+			contains: []string{
+				"autopilot", "done",
+				"git log",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prompt := buildResumePrompt(tt.job)
+			for _, s := range tt.contains {
+				if !strings.Contains(prompt, s) {
+					t.Errorf("prompt missing %q\nprompt:\n%s", s, prompt)
+				}
+			}
+		})
+	}
+}

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -10,6 +10,47 @@ import (
 	"github.com/aptx-health/agent-minder/internal/db"
 )
 
+// Action represents what the user wants to do with a selected job.
+type Action string
+
+const (
+	ActionCheckout Action = "checkout"
+	ActionResume   Action = "resume"
+	ActionLogs     Action = "logs"
+)
+
+// PickAction presents an action menu after job selection.
+func PickAction(job *db.Job) (Action, error) {
+	options := []huh.Option[Action]{
+		huh.NewOption("Checkout worktree", ActionCheckout),
+		huh.NewOption("Resume with Claude (gather context, launch claude)", ActionResume),
+		huh.NewOption("View logs", ActionLogs),
+	}
+
+	title := fmt.Sprintf("#%d [%s] %s", job.IssueNumber, job.Agent, truncate(job.IssueTitle.String, 40))
+	if job.IssueNumber == 0 {
+		title = fmt.Sprintf("[%s] %s", job.Agent, truncate(job.Name, 40))
+	}
+
+	var selected Action
+	err := huh.NewSelect[Action]().
+		Title(title).
+		Options(options...).
+		Value(&selected).
+		Run()
+	if err != nil {
+		return "", err
+	}
+	return selected, nil
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}
+
 // PickJob presents an interactive select list of jobs and returns the chosen one.
 // Jobs are displayed with issue number, agent, title, status, PR, and cost.
 func PickJob(jobs []*db.Job, title string) (*db.Job, error) {


### PR DESCRIPTION
## Summary
- `minder checkout` now shows an action menu after picking a job:
  - **Checkout** — existing behavior (worktree path to clipboard)
  - **Resume with Claude** — ensures worktree, dumps all available context into a prompt, `exec`s `claude` in the worktree for instant handoff
  - **View logs** — streams the agent log inline (no need for separate `minder logs`)
- Resume prompt is dumb/thorough: dumps issue body, failure info, result JSON, agent final output, PR number, review risk, branch — whatever is available
- `syscall.Exec` replaces the minder process with claude — no subprocess overhead, user lands in the session immediately
- Picker has built-in `/` search via huh's `Filtering(true)`

## Test plan
- [x] `TestBuildResumePrompt` — 4 scenarios: bailed, PR, spike, minimal
- [x] Full `go test ./...` passes
- [ ] Manual: `minder checkout`, pick a job, select Resume — verify claude launches with context

🤖 Generated with [Claude Code](https://claude.com/claude-code)