### PR TITLE
Fix PR detection for renamed GitHub repos

### DIFF
--- a/internal/supervisor/detect_pr_test.go
+++ b/internal/supervisor/detect_pr_test.go
@@ -1,0 +1,61 @@
+package supervisor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectPRFromLog(t *testing.T) {
+	tests := []struct {
+		name   string
+		owner  string
+		repo   string
+		log    string
+		wantPR int
+	}{
+		{
+			name:  "exact match",
+			owner: "acme", repo: "widgets",
+			log:    `PR created: https://github.com/acme/widgets/pull/42`,
+			wantPR: 42,
+		},
+		{
+			name:  "renamed repo fallback",
+			owner: "acme", repo: "old-name",
+			log:    `PR created: https://github.com/acme/new-name/pull/538`,
+			wantPR: 538,
+		},
+		{
+			name:  "multiple PRs takes last",
+			owner: "acme", repo: "widgets",
+			log:    `https://github.com/acme/widgets/pull/10 then https://github.com/acme/widgets/pull/20`,
+			wantPR: 20,
+		},
+		{
+			name:  "no PR URL",
+			owner: "acme", repo: "widgets",
+			log:    `no pull request here`,
+			wantPR: 0,
+		},
+		{
+			name:  "PR in stream-json",
+			owner: "acme", repo: "old-repo",
+			log:    `{"type":"user","content":"https://github.com/acme/renamed-repo/pull/99"}`,
+			wantPR: 99,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			logPath := filepath.Join(dir, "agent.log")
+			_ = os.WriteFile(logPath, []byte(tt.log), 0o644)
+
+			got := detectPRFromLog(logPath, tt.owner, tt.repo)
+			if got != tt.wantPR {
+				t.Errorf("detectPRFromLog() = %d, want %d", got, tt.wantPR)
+			}
+		})
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -620,15 +620,35 @@ func detectPRFromLog(logPath, owner, repo string) int {
 	if err != nil {
 		return 0
 	}
-	target := fmt.Sprintf("github.com/%s/%s/pull/", owner, repo)
 	content := string(data)
-	idx := strings.LastIndex(content, target)
+
+	// Try exact owner/repo match first.
+	target := fmt.Sprintf("github.com/%s/%s/pull/", owner, repo)
+	if num := lastPRNumberAfter(content, target); num > 0 {
+		return num
+	}
+
+	// Fall back to any "/pull/<number>" in the log. This handles renamed repos
+	// where GitHub redirects the URL (e.g., eternal-fitness → ripit-fitness)
+	// but the deployment record still has the old name.
+	if num := lastPRNumberAfter(content, "/pull/"); num > 0 {
+		return num
+	}
+
+	return 0
+}
+
+func lastPRNumberAfter(content, marker string) int {
+	idx := strings.LastIndex(content, marker)
 	if idx < 0 {
 		return 0
 	}
-	rest := content[idx+len(target):]
+	rest := content[idx+len(marker):]
 	end := strings.IndexFunc(rest, func(r rune) bool { return r < '0' || r > '9' })
-	if end <= 0 {
+	if end < 0 {
+		end = len(rest) // number runs to end of string
+	}
+	if end == 0 {
 		return 0
 	}
 	num, _ := strconv.Atoi(rest[:end])


### PR DESCRIPTION
## Summary
- `detectPRFromLog` now falls back to searching for any `/pull/<number>` when the exact `owner/repo` match fails
- Fixes jobs being marked as "bailed" despite a PR being successfully created, when the GitHub repo has been renamed
- Also fixes off-by-one when PR number is at end of log string

## Root cause
The repo `eternal-fitness` was renamed to `ripit-fitness`. The agent's `gh pr create` worked (GitHub redirects), but `detectPRFromLog` searched for `eternal-fitness/pull/` while the log contained `ripit-fitness/pull/538`. No match → no PR detected → classified as bailed.

## Test plan
- [x] `TestDetectPRFromLog` — exact match, renamed repo fallback, multiple PRs, no PR, stream-json embedded
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)