### PR TITLE
Stop global lessons leaking into unrelated repos

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -255,13 +255,13 @@ func TestLessonCRUD(t *testing.T) {
 	}
 	_ = s.CreateLesson(l2)
 
-	// Get active lessons for repo scope.
+	// Get active lessons for repo scope — only repo-scoped, not global.
 	lessons, err := s.GetActiveLessons("aptx-health/agent-minder")
 	if err != nil {
 		t.Fatalf("GetActiveLessons: %v", err)
 	}
-	if len(lessons) != 2 {
-		t.Errorf("got %d lessons, want 2 (global + repo-scoped)", len(lessons))
+	if len(lessons) != 1 {
+		t.Errorf("got %d lessons, want 1 (repo-scoped only, no global)", len(lessons))
 	}
 
 	// Pinned should come first.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -379,9 +379,12 @@ func (s *Store) GetActiveLessons(repoScope string) ([]*Lesson, error) {
 			"SELECT * FROM lessons WHERE active = 1 AND superseded_by IS NULL "+orderClause)
 		return lessons, err
 	}
+	// Only return lessons scoped to this specific repo. Global (unscoped) lessons
+	// are excluded to prevent cross-repo leakage (e.g., Go lint lessons injected
+	// into JS projects).
 	err := s.db.Select(&lessons,
 		`SELECT * FROM lessons WHERE active = 1 AND superseded_by IS NULL
-		 AND (repo_scope IS NULL OR repo_scope = ?) `+orderClause, repoScope)
+		 AND repo_scope = ? `+orderClause, repoScope)
 	return lessons, err
 }
 
@@ -634,6 +637,18 @@ func (s *Store) RenameRepo(oldOwner, oldRepo, newOwner, newRepo string) (int64, 
 		n, _ := res.RowsAffected()
 		total += n
 	}
+
+	// Also update lesson repo_scope.
+	oldScope := oldOwner + "/" + oldRepo
+	newScope := newOwner + "/" + newRepo
+	res, err := s.db.Exec(
+		"UPDATE lessons SET repo_scope = ? WHERE repo_scope = ?", newScope, oldScope)
+	if err != nil {
+		return total, fmt.Errorf("rename lessons: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	total += n
+
 	return total, nil
 }
 

--- a/internal/lesson/lesson.go
+++ b/internal/lesson/lesson.go
@@ -54,8 +54,9 @@ func DecayScore(l *db.Lesson, now time.Time) float64 {
 }
 
 // SelectLessons returns relevant lessons for a task, respecting the token budget.
-// Selection tiers: pinned first, then repo-scoped, then global.
-// Within each tier, sorted by decay-weighted effectiveness score descending.
+// Selection tiers: pinned first, then repo-scoped by decay score.
+// Only repo-scoped lessons are included — global (unscoped) lessons are excluded
+// to prevent cross-repo leakage (e.g., Go lint lessons injected into JS projects).
 func SelectLessons(store *db.Store, owner, repo string) ([]*db.Lesson, error) {
 	scope := owner + "/" + repo
 	lessons, err := store.GetActiveLessons(scope)
@@ -66,28 +67,21 @@ func SelectLessons(store *db.Store, owner, repo string) ([]*db.Lesson, error) {
 	now := time.Now().UTC()
 
 	// Partition into tiers.
-	var pinned, repoScoped, global []*db.Lesson
+	var pinned, repoScoped []*db.Lesson
 	for _, l := range lessons {
 		switch {
 		case l.Pinned:
 			pinned = append(pinned, l)
-		case l.RepoScope.Valid:
-			repoScoped = append(repoScoped, l)
 		default:
-			global = append(global, l)
+			repoScoped = append(repoScoped, l)
 		}
 	}
 
-	// Sort non-pinned tiers by decay score descending.
-	sortByDecay := func(ls []*db.Lesson) {
-		sort.Slice(ls, func(i, j int) bool {
-			return DecayScore(ls[i], now) > DecayScore(ls[j], now)
-		})
-	}
-	sortByDecay(repoScoped)
-	sortByDecay(global)
+	// Sort by decay score descending.
+	sort.Slice(repoScoped, func(i, j int) bool {
+		return DecayScore(repoScoped[i], now) > DecayScore(repoScoped[j], now)
+	})
 
-	// Budget allocation: pinned ~500 tokens, repo-scoped ~1000, global ~500.
 	var selected []*db.Lesson
 	var totalChars int
 	maxChars := MaxPromptTokens * ApproxTokensPerChar
@@ -104,7 +98,6 @@ func SelectLessons(store *db.Store, owner, repo string) ([]*db.Lesson, error) {
 
 	addFromTier(pinned)
 	addFromTier(repoScoped)
-	addFromTier(global)
 
 	return selected, nil
 }

--- a/internal/lesson/lesson_test.go
+++ b/internal/lesson/lesson_test.go
@@ -22,7 +22,7 @@ func testStore(t *testing.T) *db.Store {
 func TestSelectLessons(t *testing.T) {
 	store := testStore(t)
 
-	// Create a global lesson.
+	// Create a global lesson — should NOT appear in repo-scoped queries.
 	_ = store.CreateLesson(&db.Lesson{Content: "Always run tests", Source: "manual", Active: true})
 
 	// Create a repo-scoped lesson.
@@ -33,8 +33,14 @@ func TestSelectLessons(t *testing.T) {
 		Active:    true,
 	})
 
-	// Create a pinned lesson.
-	_ = store.CreateLesson(&db.Lesson{Content: "Never skip linting", Source: "manual", Active: true, Pinned: true})
+	// Create a pinned repo-scoped lesson.
+	_ = store.CreateLesson(&db.Lesson{
+		RepoScope: sql.NullString{String: "acme/app", Valid: true},
+		Content:   "Never skip linting",
+		Source:    "manual",
+		Active:    true,
+		Pinned:    true,
+	})
 
 	// Create a lesson for a different repo.
 	_ = store.CreateLesson(&db.Lesson{
@@ -49,9 +55,9 @@ func TestSelectLessons(t *testing.T) {
 		t.Fatalf("SelectLessons: %v", err)
 	}
 
-	// Should get pinned + global + repo-scoped (3), not the other/repo lesson.
-	if len(lessons) != 3 {
-		t.Errorf("got %d lessons, want 3", len(lessons))
+	// Should get pinned + repo-scoped (2), not the global or other/repo lessons.
+	if len(lessons) != 2 {
+		t.Errorf("got %d lessons, want 2", len(lessons))
 		for _, l := range lessons {
 			t.Logf("  lesson: %s (pinned=%v scope=%v)", l.Content, l.Pinned, l.RepoScope)
 		}


### PR DESCRIPTION
## Summary
- Global (unscoped) lessons no longer injected into repo-specific agent runs
- Prevents cross-repo leakage (e.g., Go vet lessons in JS/TS projects)
- `RenameRepo` now also migrates `lessons.repo_scope`

## What was happening
Lesson "Always run go vet" had no `repo_scope`, so `GetActiveLessons` included it for every repo via `repo_scope IS NULL OR repo_scope = ?`.

## Fix
`GetActiveLessons` with a scope now uses exact match only (`repo_scope = ?`), excluding unscoped globals.

## Test plan
- [x] Updated `TestLessonCRUD` and `TestSelectLessons`
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)