### PR TITLE
Add Open Issue / Open PR browser links to checkout menu

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -165,8 +166,21 @@ func executeAction(action picker.Action, repoDir string, job *db.Job) error {
 		}
 		defer func() { _ = f.Close() }()
 		return streamLog(f, false)
+
+	case picker.ActionOpenIssue:
+		url := fmt.Sprintf("https://github.com/%s/%s/issues/%d", job.Owner, job.Repo, job.IssueNumber)
+		return openBrowser(url)
+
+	case picker.ActionOpenPR:
+		url := fmt.Sprintf("https://github.com/%s/%s/pull/%d", job.Owner, job.Repo, job.PRNumber.Int64)
+		return openBrowser(url)
 	}
 	return nil
+}
+
+func openBrowser(url string) error {
+	fmt.Println(url)
+	return exec.Command("open", url).Start()
 }
 
 func findMostRecentJobForIssue(store *db.Store, owner, repo string, issueNum int) (*db.Job, error) {

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -19,9 +19,11 @@ import (
 type Action string
 
 const (
-	ActionCheckout Action = "checkout"
-	ActionResume   Action = "resume"
-	ActionLogs     Action = "logs"
+	ActionCheckout  Action = "checkout"
+	ActionResume    Action = "resume"
+	ActionLogs      Action = "logs"
+	ActionOpenIssue Action = "open_issue"
+	ActionOpenPR    Action = "open_pr"
 )
 
 // --- Job items ---
@@ -177,6 +179,16 @@ func PickAction(job *db.Job) (Action, error) {
 		actionItem{"Checkout worktree", ActionCheckout},
 		actionItem{"Resume with Claude", ActionResume},
 		actionItem{"View logs", ActionLogs},
+	}
+	if job.IssueNumber > 0 {
+		items = append(items, actionItem{
+			fmt.Sprintf("Open issue #%d in browser", job.IssueNumber), ActionOpenIssue,
+		})
+	}
+	if job.PRNumber.Valid && job.PRNumber.Int64 > 0 {
+		items = append(items, actionItem{
+			fmt.Sprintf("Open PR #%d in browser", job.PRNumber.Int64), ActionOpenPR,
+		})
 	}
 
 	choice, err := runPicker(newPicker(items, title, false))


### PR DESCRIPTION
## Summary
After selecting a job in `minder checkout`, the action menu now includes:
- **Open issue #N in browser** (when the job has an issue)
- **Open PR #N in browser** (when the job has a PR)

Selecting either opens the GitHub URL in the default browser via `open`.

## Test plan
- [x] `go test ./...` passes
- [ ] Manual: `minder checkout`, pick a job with a PR, select "Open PR" — browser opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)