### PR TITLE
Fix false positive usage limit detection on result text

### DIFF
--- a/internal/supervisor/jobmanager.go
+++ b/internal/supervisor/jobmanager.go
@@ -695,9 +695,15 @@ func isUsageLimitError(result *AgentResult) bool {
 	if result == nil {
 		return false
 	}
+
+	// Only check error results — successful completions that mention "rate limit"
+	// in their content (e.g., an agent fixing rate limiting code) are not errors.
+	if !result.IsError {
+		return false
+	}
+
 	text := strings.ToLower(result.Result)
-	// Match patterns from Claude Code: "hit your limit", "session limit",
-	// "usage limit", "rate limit reached"
+	// Match patterns from Claude Code error messages.
 	for _, pattern := range []string{
 		"hit your limit",
 		"session limit",


### PR DESCRIPTION
## Summary
`isUsageLimitError` now only fires on error results (`IsError=true`), not successful completions.

## What was happening
Agent worked on issue #648 "Fix admin rate limiting". Completed successfully (PR #649, 52 turns, $1.06). But the result summary contained "rate limit" as part of describing the work done, which matched `isUsageLimitError`'\''s keyword search. Minder treated it as a Claude Code usage limit and started a 1-hour wait.

## Fix
Check `result.IsError` first. If the agent completed successfully, its result text is a summary of work — not an error message. Only scan for usage limit keywords in actual error results.

## Test plan
- [x] `go test ./...` passes
- [ ] Manual: deploy on an issue mentioning "rate limit" — should not trigger usage limit wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)