### PR TITLE
ci: upload per-OS minder binary artifact on PR builds (#477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -16,14 +20,22 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build
-        run: go build ./...
+      - name: Build minder binary
+        run: go build -o minder ./cmd/minder
 
       - name: Test
         run: go test ./...
 
       - name: Vet
         run: go vet ./...
+
+      - name: Upload minder binary
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: minder-${{ matrix.os }}
+          path: minder
+          retention-days: 14
 
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **PR build artifacts in CI**: CI workflow now builds the `minder` binary on `ubuntu-latest` and `macos-latest`, uploading per-OS artifacts on pull request builds via `actions/upload-artifact@v4` so reviewers can download a binary without compiling locally. Retention is 14 days. (#477)
 - **Weekly cron schedules for proactive agents**: Built-in agent definitions now include default cron schedules (weekly dependency checks, security scans, doc updates) (#431)
 - **Repo-level agent defs and overnight cron jobs**: Agent definitions can be stored in repos at `.claude/agents/` and discovered at deploy time; overnight cron scheduling for proactive agents (#375)
 - **Built-in agents**: `dependency-updater`, `security-scanner`, and `doc-updater` agents ship as built-in agent definitions alongside `autopilot`, `reviewer`, `designer`, and `onboarding` (#402, #404)


### PR DESCRIPTION
## Summary
- Adds a matrix build (`ubuntu-latest`, `macos-latest`) to the `build-and-test` CI job.
- Replaces the existing `go build ./...` step with `go build -o minder ./cmd/minder` so the same step produces the downloadable binary — no duplicated work.
- Uploads the resulting `minder` binary as a per-OS artifact (`minder-ubuntu-latest`, `minder-macos-latest`) via `actions/upload-artifact@v4`, gated on `github.event_name == 'pull_request'`. Retention: 14 days.
- Test / vet / lint behavior unchanged. Lint job untouched.
- No changes to `release.yml` (goreleaser still owns tagged releases).
- Windows builds intentionally out of scope per the issue.

Fixes #477

## Test plan
- [ ] CI workflow run on this PR succeeds on both `ubuntu-latest` and `macos-latest`.
- [ ] `minder-ubuntu-latest` and `minder-macos-latest` artifacts appear in the run's Artifacts panel.
- [ ] Downloaded binaries execute (`./minder --version` prints `0.2.1-dev`).
- [ ] Existing lint job continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)