### PR TITLE
Polish minder checkout column display (#476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Watch polling for TUI autopilot**: Optional `--watch-milestone` / `--watch-label` flags on the `start` command enable continuous GitHub issue discovery during autopilot sessions. New issues matching the filter are created as `pending` tasks and automatically ingested with incremental dep analysis. TUI shows a "watching" indicator when active. (#337)
 
 ### Fixed
-- **Picker column display**: `minder checkout` job picker now uses fixed-width columns for label/agent/status/PR and right-aligned full-value cost; title column expands to fill the detected terminal width so cost no longer truncates to `$1...` and `PR#XXX` lines up consistently across rows (#476)
+- **Picker column display**: `minder checkout` job picker now uses fixed-width columns for label/agent/status/PR and right-aligned full-value cost; the title column expands to fill the detected terminal width so cost no longer truncates to `$1...` and `PR#XXX` lines up consistently across rows. Agent column caps at 9 chars with ellipsis (so a single long agent name no longer pushes every row wide), and a persistent `ISSUE / AGENT / TITLE / STATUS / PR / COST` header now sits above the list (#476)
 - **Scheduler SQLite contention and UNIQUE constraint**: Fixed SQLITE_BUSY errors from concurrent scheduler/supervisor DB access; handle UNIQUE constraint violations when reinserting schedules; improved error logging (#431)
 - **Daemon exiting on scheduler-only deploys**: Fixed daemon exiting immediately when running with only scheduled jobs and no issue arguments (#427)
 - **Enroll validation**: Use minder CLI for YAML validation instead of Python/Ruby YAML parsers (#422)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Watch polling for TUI autopilot**: Optional `--watch-milestone` / `--watch-label` flags on the `start` command enable continuous GitHub issue discovery during autopilot sessions. New issues matching the filter are created as `pending` tasks and automatically ingested with incremental dep analysis. TUI shows a "watching" indicator when active. (#337)
 
 ### Fixed
+- **Picker column display**: `minder checkout` job picker now uses fixed-width columns for label/agent/status/PR and right-aligned full-value cost; title column expands to fill the detected terminal width so cost no longer truncates to `$1...` and `PR#XXX` lines up consistently across rows (#476)
 - **Scheduler SQLite contention and UNIQUE constraint**: Fixed SQLITE_BUSY errors from concurrent scheduler/supervisor DB access; handle UNIQUE constraint violations when reinserting schedules; improved error logging (#431)
 - **Daemon exiting on scheduler-only deploys**: Fixed daemon exiting immediately when running with only scheduled jobs and no issue arguments (#427)
 - **Enroll validation**: Use minder CLI for YAML validation instead of Python/Ruby YAML parsers (#422)

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -3,6 +3,7 @@ package picker
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
 
 	"github.com/aptx-health/agent-minder/internal/daemon"
 	"github.com/aptx-health/agent-minder/internal/db"
@@ -26,21 +28,56 @@ const (
 	ActionOpenPR    Action = "open_pr"
 )
 
+// Column widths for formatted job rows. Chosen to fit the longest built-in
+// values without truncation:
+//   - labelWidth: "#12345" or short job name
+//   - agentWidth: "dependency-updater" (18 chars, longest built-in agent)
+//   - statusWidth: "reviewing" (9 chars; 10 leaves a buffer)
+//   - prWidth: "PR#1234"
+//   - costWidth: "$1234.45" right-aligned
+const (
+	labelWidth  = 6
+	agentWidth  = 18
+	statusWidth = 10
+	prWidth     = 7
+	costWidth   = 8
+
+	// fixedColumnWidth is the rendered width of everything except the title
+	// column. Layout (with 2-space separators):
+	//   label  [agent]  TITLE  status  pr  cost
+	//   = labelWidth + 2 + 1 + agentWidth + 1 + 2 + 2 + statusWidth + 2 + prWidth + 2 + costWidth
+	fixedColumnWidth = labelWidth + 2 + 1 + agentWidth + 1 + 2 + 2 + statusWidth + 2 + prWidth + 2 + costWidth
+
+	// listChromeWidth reserves space for the bubbles list delegate's left
+	// indicator/indent so our row never gets right-truncated.
+	listChromeWidth = 4
+
+	// minTitleWidth is the smallest title column we'll render at; if the
+	// terminal is too narrow to accommodate it, we still render the title at
+	// this width (the list will truncate visually).
+	minTitleWidth = 20
+
+	// fallbackTermWidth is used when we can't detect terminal size.
+	fallbackTermWidth = 100
+)
+
 // --- Job items ---
 
 type jobItem struct {
-	job *db.Job
+	job  *db.Job
+	line string
 }
 
-func (i jobItem) Title() string       { return formatJobLine(i.job) }
+func (i jobItem) Title() string       { return i.line }
 func (i jobItem) Description() string { return "" }
 func (i jobItem) FilterValue() string { return jobSearchString(i.job) }
 
 type remoteJobItem struct {
-	job *daemon.JobResponse
+	job  *daemon.JobResponse
+	line string
 }
 
-func (i remoteJobItem) Title() string       { return formatRemoteJobLine(i.job) }
+func (i remoteJobItem) Title() string       { return i.line }
 func (i remoteJobItem) Description() string { return "" }
 func (i remoteJobItem) FilterValue() string { return remoteJobSearchString(i.job) }
 
@@ -91,7 +128,7 @@ func (m pickerModel) View() string {
 }
 
 // newPicker creates a picker model from list items.
-func newPicker(items []list.Item, title string, filtering bool) pickerModel {
+func newPicker(items []list.Item, title string, filtering bool, width int) pickerModel {
 	// Single-line delegate (no description).
 	delegate := list.NewDefaultDelegate()
 	delegate.ShowDescription = false
@@ -102,7 +139,11 @@ func newPicker(items []list.Item, title string, filtering bool) pickerModel {
 		height = 30
 	}
 
-	l := list.New(items, delegate, 100, height)
+	if width < fallbackTermWidth {
+		width = fallbackTermWidth
+	}
+
+	l := list.New(items, delegate, width, height)
 	l.Title = title
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(filtering)
@@ -138,12 +179,15 @@ func PickJob(jobs []*db.Job, title string) (*db.Job, error) {
 		return nil, fmt.Errorf("no jobs to select from")
 	}
 
+	termWidth := detectTermWidth()
+	tw := titleWidthFor(termWidth)
+
 	items := make([]list.Item, len(jobs))
 	for i, j := range jobs {
-		items[i] = jobItem{job: j}
+		items[i] = jobItem{job: j, line: formatJobLine(j, tw)}
 	}
 
-	choice, err := runPicker(newPicker(items, title, true))
+	choice, err := runPicker(newPicker(items, title, true, termWidth))
 	if err != nil {
 		return nil, err
 	}
@@ -156,12 +200,15 @@ func PickRemoteJob(jobs []daemon.JobResponse, title string) (*daemon.JobResponse
 		return nil, fmt.Errorf("no jobs to select from")
 	}
 
+	termWidth := detectTermWidth()
+	tw := titleWidthFor(termWidth)
+
 	items := make([]list.Item, len(jobs))
 	for i := range jobs {
-		items[i] = remoteJobItem{job: &jobs[i]}
+		items[i] = remoteJobItem{job: &jobs[i], line: formatRemoteJobLine(&jobs[i], tw)}
 	}
 
-	choice, err := runPicker(newPicker(items, title, true))
+	choice, err := runPicker(newPicker(items, title, true, termWidth))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +238,7 @@ func PickAction(job *db.Job) (Action, error) {
 		})
 	}
 
-	choice, err := runPicker(newPicker(items, title, false))
+	choice, err := runPicker(newPicker(items, title, false, detectTermWidth()))
 	if err != nil {
 		return "", err
 	}
@@ -210,7 +257,7 @@ func PickFromList(labels []string, title string) (string, error) {
 		items[i] = actionItem{label: l, action: Action(l)}
 	}
 
-	choice, err := runPicker(newPicker(items, title, len(labels) > 5))
+	choice, err := runPicker(newPicker(items, title, len(labels) > 5, detectTermWidth()))
 	if err != nil {
 		return "", err
 	}
@@ -256,82 +303,150 @@ func truncate(s string, max int) string {
 	return s[:max-3] + "..."
 }
 
-func formatJobLine(j *db.Job) string {
-	var label string
-	if j.IssueNumber > 0 {
-		label = fmt.Sprintf("#%-4d", j.IssueNumber)
-	} else {
-		name := j.Name
-		if len(name) > 20 {
-			name = name[:17] + "..."
+// padRight returns s padded to width w with spaces on the right, or truncated
+// with a "..." suffix if it exceeds w.
+func padRight(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if len(s) == w {
+		return s
+	}
+	if len(s) > w {
+		if w <= 3 {
+			return s[:w]
 		}
-		label = fmt.Sprintf("%-5s", name)
+		return s[:w-3] + "..."
 	}
-
-	agent := j.Agent
-	if len(agent) > 12 {
-		agent = agent[:12]
-	}
-
-	title := j.IssueTitle.String
-	if title == "" {
-		title = j.Name
-	}
-	if len(title) > 35 {
-		title = title[:32] + "..."
-	}
-
-	pr := "      "
-	if j.PRNumber.Valid && j.PRNumber.Int64 > 0 {
-		pr = fmt.Sprintf("PR#%-3d", j.PRNumber.Int64)
-	}
-
-	cost := ""
-	if j.CostUSD > 0 {
-		cost = fmt.Sprintf("$%.2f", j.CostUSD)
-	}
-
-	return fmt.Sprintf("%s  [%-12s]  %-35s  %-10s  %s  %s",
-		label, agent, title, j.Status, pr, cost)
+	return s + strings.Repeat(" ", w-len(s))
 }
 
-func formatRemoteJobLine(j *daemon.JobResponse) string {
-	var label string
-	if j.IssueNumber > 0 {
-		label = fmt.Sprintf("#%-4d", j.IssueNumber)
-	} else {
-		name := j.Name
-		if len(name) > 20 {
-			name = name[:17] + "..."
+// padLeft returns s padded to width w with spaces on the left
+// (right-aligned), or truncated if it exceeds w.
+func padLeft(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if len(s) == w {
+		return s
+	}
+	if len(s) > w {
+		if w <= 3 {
+			return s[:w]
 		}
-		label = fmt.Sprintf("%-5s", name)
+		return s[:w-3] + "..."
+	}
+	return strings.Repeat(" ", w-len(s)) + s
+}
+
+// detectTermWidth returns the current terminal width via the controlling
+// terminal, falling back to fallbackTermWidth if detection fails or the
+// terminal is unreasonably narrow.
+func detectTermWidth() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w < 40 {
+		return fallbackTermWidth
+	}
+	return w
+}
+
+// titleWidthFor returns the width available for the title column given a
+// terminal width. The result is never less than minTitleWidth.
+func titleWidthFor(termWidth int) int {
+	w := termWidth - fixedColumnWidth - listChromeWidth
+	if w < minTitleWidth {
+		return minTitleWidth
+	}
+	return w
+}
+
+// jobColumns is the column-level data for a single job row, before
+// width-aware padding.
+type jobColumns struct {
+	label  string // "#1234" or short job name
+	agent  string // raw agent name
+	title  string // raw title
+	status string // raw status
+	pr     string // "PR#1234" or ""
+	cost   string // "$1.45" or ""
+}
+
+// renderRow returns the column-aligned string for a job row, using fixed
+// widths for label/agent/status/pr/cost and the supplied titleWidth for the
+// flexible title column.
+func renderRow(c jobColumns, titleWidth int) string {
+	return fmt.Sprintf("%s  [%s]  %s  %s  %s  %s",
+		padRight(c.label, labelWidth),
+		padRight(c.agent, agentWidth),
+		padRight(c.title, titleWidth),
+		padRight(c.status, statusWidth),
+		padRight(c.pr, prWidth),
+		padLeft(c.cost, costWidth),
+	)
+}
+
+func jobToColumns(j *db.Job) jobColumns {
+	c := jobColumns{
+		agent:  j.Agent,
+		status: j.Status,
 	}
 
-	agent := j.Agent
-	if len(agent) > 12 {
-		agent = agent[:12]
+	if j.IssueNumber > 0 {
+		c.label = fmt.Sprintf("#%d", j.IssueNumber)
+	} else {
+		c.label = j.Name
 	}
 
-	title := j.Title
-	if title == "" {
-		title = j.Name
-	}
-	if len(title) > 35 {
-		title = title[:32] + "..."
+	c.title = j.IssueTitle.String
+	if c.title == "" {
+		c.title = j.Name
 	}
 
-	pr := "      "
-	if j.PRNumber > 0 {
-		pr = fmt.Sprintf("PR#%-3d", j.PRNumber)
+	if j.PRNumber.Valid && j.PRNumber.Int64 > 0 {
+		c.pr = fmt.Sprintf("PR#%d", j.PRNumber.Int64)
 	}
 
-	cost := ""
 	if j.CostUSD > 0 {
-		cost = fmt.Sprintf("$%.2f", j.CostUSD)
+		c.cost = fmt.Sprintf("$%.2f", j.CostUSD)
 	}
 
-	return fmt.Sprintf("%s  [%-12s]  %-35s  %-10s  %s  %s",
-		label, agent, title, j.Status, pr, cost)
+	return c
+}
+
+func remoteJobToColumns(j *daemon.JobResponse) jobColumns {
+	c := jobColumns{
+		agent:  j.Agent,
+		status: j.Status,
+	}
+
+	if j.IssueNumber > 0 {
+		c.label = fmt.Sprintf("#%d", j.IssueNumber)
+	} else {
+		c.label = j.Name
+	}
+
+	c.title = j.Title
+	if c.title == "" {
+		c.title = j.Name
+	}
+
+	if j.PRNumber > 0 {
+		c.pr = fmt.Sprintf("PR#%d", j.PRNumber)
+	}
+
+	if j.CostUSD > 0 {
+		c.cost = fmt.Sprintf("$%.2f", j.CostUSD)
+	}
+
+	return c
+}
+
+func formatJobLine(j *db.Job, titleWidth int) string {
+	return renderRow(jobToColumns(j), titleWidth)
+}
+
+func formatRemoteJobLine(j *daemon.JobResponse, titleWidth int) string {
+	return renderRow(remoteJobToColumns(j), titleWidth)
 }
 
 func jobSearchString(j *db.Job) string {

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -28,16 +28,16 @@ const (
 	ActionOpenPR    Action = "open_pr"
 )
 
-// Column widths for formatted job rows. Chosen to fit the longest built-in
-// values without truncation:
+// Column widths for formatted job rows.
 //   - labelWidth: "#12345" or short job name
-//   - agentWidth: "dependency-updater" (18 chars, longest built-in agent)
+//   - agentWidth: fits "autopilot"/"bug-fixer" (9 chars); longer names get
+//     ellipsized so a single overlong agent name can't push every row wide
 //   - statusWidth: "reviewing" (9 chars; 10 leaves a buffer)
 //   - prWidth: "PR#1234"
 //   - costWidth: "$1234.45" right-aligned
 const (
 	labelWidth  = 6
-	agentWidth  = 18
+	agentWidth  = 9
 	statusWidth = 10
 	prWidth     = 7
 	costWidth   = 8
@@ -96,6 +96,7 @@ func (i actionItem) FilterValue() string { return i.label }
 
 type pickerModel struct {
 	list     list.Model
+	header   string // optional column-header line shown above items
 	choice   list.Item
 	quitting bool
 }
@@ -123,8 +124,22 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// headerStyle styles the column-header row. Indented by 2 spaces so it
+// aligns with the list delegate's left padding for item rows.
+var headerStyle = lipgloss.NewStyle().Bold(true).Padding(0, 0, 0, 2)
+
 func (m pickerModel) View() string {
-	return m.list.View()
+	listView := m.list.View()
+	if m.header == "" {
+		return listView
+	}
+	// Inject the header line after the first row of the list view (which
+	// is the title or, in filter mode, the filter input).
+	nl := strings.Index(listView, "\n")
+	if nl < 0 {
+		return listView
+	}
+	return listView[:nl+1] + headerStyle.Render(m.header) + "\n" + listView[nl+1:]
 }
 
 // newPicker creates a picker model from list items.
@@ -187,7 +202,9 @@ func PickJob(jobs []*db.Job, title string) (*db.Job, error) {
 		items[i] = jobItem{job: j, line: formatJobLine(j, tw)}
 	}
 
-	choice, err := runPicker(newPicker(items, title, true, termWidth))
+	m := newPicker(items, title, true, termWidth)
+	m.header = renderHeader(tw)
+	choice, err := runPicker(m)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +225,9 @@ func PickRemoteJob(jobs []daemon.JobResponse, title string) (*daemon.JobResponse
 		items[i] = remoteJobItem{job: &jobs[i], line: formatRemoteJobLine(&jobs[i], tw)}
 	}
 
-	choice, err := runPicker(newPicker(items, title, true, termWidth))
+	m := newPicker(items, title, true, termWidth)
+	m.header = renderHeader(tw)
+	choice, err := runPicker(m)
 	if err != nil {
 		return nil, err
 	}
@@ -382,6 +401,20 @@ func renderRow(c jobColumns, titleWidth int) string {
 		padRight(c.status, statusWidth),
 		padRight(c.pr, prWidth),
 		padLeft(c.cost, costWidth),
+	)
+}
+
+// renderHeader returns the column-header row whose offsets match those
+// produced by renderRow. The bracket positions around the agent column are
+// rendered as spaces so the header lines up with the agent text below.
+func renderHeader(titleWidth int) string {
+	return fmt.Sprintf("%s   %s   %s  %s  %s  %s",
+		padRight("ISSUE", labelWidth),
+		padRight("AGENT", agentWidth),
+		padRight("TITLE", titleWidth),
+		padRight("STATUS", statusWidth),
+		padRight("PR", prWidth),
+		padLeft("COST", costWidth),
 	)
 }
 

--- a/internal/picker/picker_test.go
+++ b/internal/picker/picker_test.go
@@ -203,16 +203,16 @@ func TestFormatJobLineColumns(t *testing.T) {
 		lines[i] = formatJobLine(j, titleWidth)
 	}
 
-	// Expected layout:
-	//   label(6)  [agent(18)]  title(N)  status(10)  pr(7)  cost(8)
-	// → fixed offsets:
-	//   label start  = 0
-	//   agent start  = 6 + 2 + 1 = 9
-	//   title start  = 9 + 18 + 1 + 2 = 30
-	//   status start = 30 + titleWidth + 2 = 30 + 35 + 2 = 67
-	//   pr start     = 67 + 10 + 2 = 79
-	//   cost start   = 79 + 7 + 2 = 88
-	// → total length = 88 + 8 = 96
+	// Layout: label(6)  [agent(9)]  title(N)  status(10)  pr(7)  cost(8)
+	// Derived offsets:
+	agentBracketOff := labelWidth + 2          // 8
+	agentStart := agentBracketOff + 1          // 9
+	agentCloseOff := agentStart + agentWidth   // 18
+	titleStart := agentCloseOff + 1 + 2        // 21
+	statusStart := titleStart + titleWidth + 2 // 58
+	prStart := statusStart + statusWidth + 2   // 70
+	costStart := prStart + prWidth + 2         // 79
+
 	expectedLen := fixedColumnWidth + titleWidth
 	for i, line := range lines {
 		if len(line) != expectedLen {
@@ -220,29 +220,20 @@ func TestFormatJobLineColumns(t *testing.T) {
 		}
 	}
 
-	// Every line must have the same column offsets so PR#XXX, status and
-	// cost columns line up vertically.
-	for i := 1; i < len(lines); i++ {
-		for _, off := range []int{0, 9, 30, 67, 79, 88} {
-			if lines[i][off] == lines[0][off] {
-				continue
-			}
-			// Differing chars at column boundaries are fine; we mainly
-			// care that lengths match (covered above) and that fixed
-			// markers like "[" and "]" sit at the same positions.
+	// Bracket positions must be identical on every row so the agent column
+	// stays vertically aligned.
+	for i := range lines {
+		if lines[i][agentBracketOff] != '[' {
+			t.Errorf("row %d: expected '[' at offset %d, got %q (line=%q)", i, agentBracketOff, lines[i][agentBracketOff], lines[i])
 		}
-		// "[" should always be at position 8 and "]" at position 8 + 1 + 18 = 27.
-		if lines[i][8] != '[' {
-			t.Errorf("row %d: expected '[' at offset 8, got %q (line=%q)", i, lines[i][8], lines[i])
-		}
-		if lines[i][27] != ']' {
-			t.Errorf("row %d: expected ']' at offset 27, got %q (line=%q)", i, lines[i][27], lines[i])
+		if lines[i][agentCloseOff] != ']' {
+			t.Errorf("row %d: expected ']' at offset %d, got %q (line=%q)", i, agentCloseOff, lines[i][agentCloseOff], lines[i])
 		}
 	}
 
 	// Cost column on the $1.45 row must be fully rendered (not "$1...").
 	costLine := lines[2]
-	costField := costLine[88 : 88+costWidth]
+	costField := costLine[costStart : costStart+costWidth]
 	if !strings.Contains(costField, "$1.45") {
 		t.Errorf("expected $1.45 in cost field, got %q (full=%q)", costField, costLine)
 	}
@@ -251,53 +242,100 @@ func TestFormatJobLineColumns(t *testing.T) {
 	}
 
 	// Status column on the "reviewing" row must contain "reviewing" in full.
-	statusField := costLine[67 : 67+statusWidth]
+	statusField := costLine[statusStart : statusStart+statusWidth]
 	if !strings.HasPrefix(statusField, "reviewing") {
-		t.Errorf("expected status 'reviewing' at offset 67, got %q (line=%q)", statusField, costLine)
+		t.Errorf("expected status 'reviewing' at offset %d, got %q (line=%q)", statusStart, statusField, costLine)
 	}
 
 	// PR field for the "reviewing" row must start at the same offset on
 	// every row that has a PR.
-	prField := costLine[79 : 79+prWidth]
+	prField := costLine[prStart : prStart+prWidth]
 	if !strings.HasPrefix(prField, "PR#1240") {
-		t.Errorf("expected PR#1240 at offset 79, got %q (line=%q)", prField, costLine)
+		t.Errorf("expected PR#1240 at offset %d, got %q (line=%q)", prStart, prField, costLine)
 	}
 	// Cheap row with no PR must have a blank PR field at the same offset.
 	noPRRow := lines[0]
-	noPRField := noPRRow[79 : 79+prWidth]
+	noPRField := noPRRow[prStart : prStart+prWidth]
 	if strings.TrimSpace(noPRField) != "" {
 		t.Errorf("expected empty PR field for no-PR row, got %q (line=%q)", noPRField, noPRRow)
 	}
 
 	// Overflow agent must be truncated to fit agentWidth.
 	overflowRow := lines[4]
-	agentField := overflowRow[9 : 9+agentWidth]
+	agentField := overflowRow[agentStart : agentStart+agentWidth]
 	if len(agentField) != agentWidth {
 		t.Errorf("agent field width %d, want %d", len(agentField), agentWidth)
 	}
 	if !strings.HasSuffix(strings.TrimRight(agentField, " "), "...") {
 		t.Errorf("expected overflow agent to be truncated with '...', got %q", agentField)
 	}
-	// Longest built-in agent ("dependency-updater" = 18 chars) must fit
-	// without truncation.
+
+	// dependency-updater (18 chars) exceeds agentWidth and must be
+	// ellipsized, not allowed to push the column wider.
 	builtinRow := lines[3]
-	builtinAgent := builtinRow[9 : 9+agentWidth]
-	if strings.Contains(builtinAgent, "...") {
-		t.Errorf("dependency-updater should fit without truncation, got %q", builtinAgent)
+	builtinAgent := builtinRow[agentStart : agentStart+agentWidth]
+	if !strings.HasSuffix(strings.TrimRight(builtinAgent, " "), "...") {
+		t.Errorf("expected dependency-updater to be truncated with '...', got %q", builtinAgent)
 	}
-	if !strings.Contains(builtinAgent, "dependency-updater") {
-		t.Errorf("expected full 'dependency-updater' in agent field, got %q", builtinAgent)
+
+	// 9-char agent names (autopilot, bug-fixer) must fit without truncation.
+	autopilotRow := lines[2]
+	autopilotAgent := autopilotRow[agentStart : agentStart+agentWidth]
+	if strings.Contains(autopilotAgent, "...") {
+		t.Errorf("autopilot should fit without truncation at width %d, got %q", agentWidth, autopilotAgent)
+	}
+	if strings.TrimSpace(autopilotAgent) != "autopilot" {
+		t.Errorf("expected agent 'autopilot', got %q", autopilotAgent)
 	}
 
 	// Big cost ($12.34) row must render fully right-aligned.
 	bigCostRow := lines[5]
-	bigCostField := bigCostRow[88 : 88+costWidth]
+	bigCostField := bigCostRow[costStart : costStart+costWidth]
 	if !strings.Contains(bigCostField, "$12.34") {
 		t.Errorf("expected $12.34 in cost field, got %q", bigCostField)
 	}
 	// Right-aligned: cost should end with the last char of the number.
 	if bigCostField[costWidth-1] != '4' {
 		t.Errorf("cost field should be right-aligned (last char '4'), got %q", bigCostField)
+	}
+}
+
+func TestRenderHeader(t *testing.T) {
+	titleWidth := 35
+	header := renderHeader(titleWidth)
+	row := renderRow(jobColumns{
+		label: "#123", agent: "autopilot", title: "demo",
+		status: "queued", pr: "PR#1", cost: "$1.00",
+	}, titleWidth)
+
+	if len(header) != len(row) {
+		t.Fatalf("header length %d != row length %d\nheader=%q\nrow   =%q", len(header), len(row), header, row)
+	}
+
+	// Column labels must sit at the same byte offsets as the row's column
+	// content so the header lines up with what's below it.
+	cases := []struct {
+		label string
+		off   int
+	}{
+		{"ISSUE", 0},
+		{"AGENT", labelWidth + 2 + 1}, // 9
+		{"TITLE", labelWidth + 2 + 1 + agentWidth + 1 + 2},                                 // 21
+		{"STATUS", labelWidth + 2 + 1 + agentWidth + 1 + 2 + titleWidth + 2},               // 58
+		{"PR", labelWidth + 2 + 1 + agentWidth + 1 + 2 + titleWidth + 2 + statusWidth + 2}, // 70
+	}
+	for _, c := range cases {
+		got := header[c.off : c.off+len(c.label)]
+		if got != c.label {
+			t.Errorf("header[%d:%d] = %q, want %q (full header=%q)", c.off, c.off+len(c.label), got, c.label, header)
+		}
+	}
+
+	// COST is right-aligned in the cost column.
+	costEnd := len(header)
+	costField := header[costEnd-costWidth : costEnd]
+	if strings.TrimLeft(costField, " ") != "COST" {
+		t.Errorf("expected right-aligned 'COST' in last %d chars, got %q", costWidth, costField)
 	}
 }
 

--- a/internal/picker/picker_test.go
+++ b/internal/picker/picker_test.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/aptx-health/agent-minder/internal/daemon"
@@ -66,5 +67,262 @@ func TestFilterRemoteJobs(t *testing.T) {
 				t.Errorf("FilterRemoteJobs(%q) returned %d jobs, want %d", tt.filter, len(got), tt.want)
 			}
 		})
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	tests := []struct {
+		s    string
+		w    int
+		want string
+	}{
+		{"abc", 6, "abc   "},
+		{"abcdef", 6, "abcdef"},
+		{"abcdefgh", 6, "abc..."},
+		{"a", 2, "a "},
+		{"", 4, "    "},
+		{"abcdef", 3, "abc"},
+		{"abcdef", 0, ""},
+	}
+	for _, tt := range tests {
+		got := padRight(tt.s, tt.w)
+		if got != tt.want {
+			t.Errorf("padRight(%q, %d) = %q, want %q", tt.s, tt.w, got, tt.want)
+		}
+		if tt.w > 0 && len(got) != tt.w {
+			t.Errorf("padRight(%q, %d) length %d, want %d", tt.s, tt.w, len(got), tt.w)
+		}
+	}
+}
+
+func TestPadLeft(t *testing.T) {
+	tests := []struct {
+		s    string
+		w    int
+		want string
+	}{
+		{"$1.45", 8, "   $1.45"},
+		{"$1234.56", 8, "$1234.56"},
+		{"$12345.67", 8, "$1234..."},
+		{"", 4, "    "},
+	}
+	for _, tt := range tests {
+		got := padLeft(tt.s, tt.w)
+		if got != tt.want {
+			t.Errorf("padLeft(%q, %d) = %q, want %q", tt.s, tt.w, got, tt.want)
+		}
+		if tt.w > 0 && len(got) != tt.w {
+			t.Errorf("padLeft(%q, %d) length %d, want %d", tt.s, tt.w, len(got), tt.w)
+		}
+	}
+}
+
+func TestTitleWidthFor(t *testing.T) {
+	tests := []struct {
+		term int
+		want int
+	}{
+		{200, 200 - fixedColumnWidth - listChromeWidth},
+		{120, 120 - fixedColumnWidth - listChromeWidth},
+		{60, minTitleWidth}, // too narrow → clamped
+		{0, minTitleWidth},
+	}
+	for _, tt := range tests {
+		got := titleWidthFor(tt.term)
+		if got != tt.want {
+			t.Errorf("titleWidthFor(%d) = %d, want %d", tt.term, got, tt.want)
+		}
+	}
+}
+
+// TestFormatJobLineColumns is the core acceptance test for the picker
+// column formatting: ensures cost is shown in full, status/pr/cost align
+// across rows, and agent/title use fixed/flexible widths.
+func TestFormatJobLineColumns(t *testing.T) {
+	titleWidth := 35
+	jobs := []*db.Job{
+		// Cheap, no PR, short agent.
+		{
+			Agent:       "spike",
+			Name:        "spike-issue-518",
+			IssueNumber: 518,
+			IssueTitle:  sql.NullString{String: "Investigate weird thing", Valid: true},
+			Status:      "done",
+			CostUSD:     0.88,
+		},
+		// Bigger cost, with PR, mid-length agent.
+		{
+			Agent:       "ux-autopilot",
+			Name:        "ux-autopilot-issue-529",
+			IssueNumber: 529,
+			IssueTitle:  sql.NullString{String: "Cleanup: remove old tour system", Valid: true},
+			Status:      "reviewed",
+			PRNumber:    sql.NullInt64{Int64: 532, Valid: true},
+			CostUSD:     2.01,
+		},
+		// 4-digit issue, dollar value > $1, with PR.
+		{
+			Agent:       "autopilot",
+			Name:        "autopilot-issue-1234",
+			IssueNumber: 1234,
+			IssueTitle:  sql.NullString{String: "Polish minder checkout column display", Valid: true},
+			Status:      "reviewing",
+			PRNumber:    sql.NullInt64{Int64: 1240, Valid: true},
+			CostUSD:     1.45,
+		},
+		// Longest built-in agent.
+		{
+			Agent:       "dependency-updater",
+			Name:        "dependency-updater-issue-300",
+			IssueNumber: 300,
+			IssueTitle:  sql.NullString{String: "Bump go-github", Valid: true},
+			Status:      "queued",
+			CostUSD:     0,
+		},
+		// Overflow agent (scheduled job style) — should be truncated.
+		{
+			Agent:       "monthly-lesson-groomer",
+			Name:        "monthly-groom",
+			IssueNumber: 0,
+			Status:      "queued",
+		},
+		// Big cost, large PR number.
+		{
+			Agent:       "bug-fixer",
+			Name:        "bug-fixer-issue-9999",
+			IssueNumber: 9999,
+			IssueTitle:  sql.NullString{String: "[Bug] something exploded", Valid: true},
+			Status:      "bailed",
+			PRNumber:    sql.NullInt64{Int64: 9876, Valid: true},
+			CostUSD:     12.34,
+		},
+	}
+
+	lines := make([]string, len(jobs))
+	for i, j := range jobs {
+		lines[i] = formatJobLine(j, titleWidth)
+	}
+
+	// Expected layout:
+	//   label(6)  [agent(18)]  title(N)  status(10)  pr(7)  cost(8)
+	// → fixed offsets:
+	//   label start  = 0
+	//   agent start  = 6 + 2 + 1 = 9
+	//   title start  = 9 + 18 + 1 + 2 = 30
+	//   status start = 30 + titleWidth + 2 = 30 + 35 + 2 = 67
+	//   pr start     = 67 + 10 + 2 = 79
+	//   cost start   = 79 + 7 + 2 = 88
+	// → total length = 88 + 8 = 96
+	expectedLen := fixedColumnWidth + titleWidth
+	for i, line := range lines {
+		if len(line) != expectedLen {
+			t.Errorf("row %d: line length %d, want %d (line=%q)", i, len(line), expectedLen, line)
+		}
+	}
+
+	// Every line must have the same column offsets so PR#XXX, status and
+	// cost columns line up vertically.
+	for i := 1; i < len(lines); i++ {
+		for _, off := range []int{0, 9, 30, 67, 79, 88} {
+			if lines[i][off] == lines[0][off] {
+				continue
+			}
+			// Differing chars at column boundaries are fine; we mainly
+			// care that lengths match (covered above) and that fixed
+			// markers like "[" and "]" sit at the same positions.
+		}
+		// "[" should always be at position 8 and "]" at position 8 + 1 + 18 = 27.
+		if lines[i][8] != '[' {
+			t.Errorf("row %d: expected '[' at offset 8, got %q (line=%q)", i, lines[i][8], lines[i])
+		}
+		if lines[i][27] != ']' {
+			t.Errorf("row %d: expected ']' at offset 27, got %q (line=%q)", i, lines[i][27], lines[i])
+		}
+	}
+
+	// Cost column on the $1.45 row must be fully rendered (not "$1...").
+	costLine := lines[2]
+	costField := costLine[88 : 88+costWidth]
+	if !strings.Contains(costField, "$1.45") {
+		t.Errorf("expected $1.45 in cost field, got %q (full=%q)", costField, costLine)
+	}
+	if strings.Contains(costField, "...") {
+		t.Errorf("cost field should not be truncated, got %q", costField)
+	}
+
+	// Status column on the "reviewing" row must contain "reviewing" in full.
+	statusField := costLine[67 : 67+statusWidth]
+	if !strings.HasPrefix(statusField, "reviewing") {
+		t.Errorf("expected status 'reviewing' at offset 67, got %q (line=%q)", statusField, costLine)
+	}
+
+	// PR field for the "reviewing" row must start at the same offset on
+	// every row that has a PR.
+	prField := costLine[79 : 79+prWidth]
+	if !strings.HasPrefix(prField, "PR#1240") {
+		t.Errorf("expected PR#1240 at offset 79, got %q (line=%q)", prField, costLine)
+	}
+	// Cheap row with no PR must have a blank PR field at the same offset.
+	noPRRow := lines[0]
+	noPRField := noPRRow[79 : 79+prWidth]
+	if strings.TrimSpace(noPRField) != "" {
+		t.Errorf("expected empty PR field for no-PR row, got %q (line=%q)", noPRField, noPRRow)
+	}
+
+	// Overflow agent must be truncated to fit agentWidth.
+	overflowRow := lines[4]
+	agentField := overflowRow[9 : 9+agentWidth]
+	if len(agentField) != agentWidth {
+		t.Errorf("agent field width %d, want %d", len(agentField), agentWidth)
+	}
+	if !strings.HasSuffix(strings.TrimRight(agentField, " "), "...") {
+		t.Errorf("expected overflow agent to be truncated with '...', got %q", agentField)
+	}
+	// Longest built-in agent ("dependency-updater" = 18 chars) must fit
+	// without truncation.
+	builtinRow := lines[3]
+	builtinAgent := builtinRow[9 : 9+agentWidth]
+	if strings.Contains(builtinAgent, "...") {
+		t.Errorf("dependency-updater should fit without truncation, got %q", builtinAgent)
+	}
+	if !strings.Contains(builtinAgent, "dependency-updater") {
+		t.Errorf("expected full 'dependency-updater' in agent field, got %q", builtinAgent)
+	}
+
+	// Big cost ($12.34) row must render fully right-aligned.
+	bigCostRow := lines[5]
+	bigCostField := bigCostRow[88 : 88+costWidth]
+	if !strings.Contains(bigCostField, "$12.34") {
+		t.Errorf("expected $12.34 in cost field, got %q", bigCostField)
+	}
+	// Right-aligned: cost should end with the last char of the number.
+	if bigCostField[costWidth-1] != '4' {
+		t.Errorf("cost field should be right-aligned (last char '4'), got %q", bigCostField)
+	}
+}
+
+func TestFormatRemoteJobLineColumns(t *testing.T) {
+	titleWidth := 30
+	jobs := []daemon.JobResponse{
+		{Agent: "spike", Name: "spike-issue-518", IssueNumber: 518, Title: "Investigate", Status: "done", CostUSD: 0.88},
+		{Agent: "autopilot", Name: "autopilot-issue-1234", IssueNumber: 1234, Title: "Polish picker", Status: "reviewing", PRNumber: 1240, CostUSD: 1.45},
+	}
+
+	expectedLen := fixedColumnWidth + titleWidth
+	for i := range jobs {
+		line := formatRemoteJobLine(&jobs[i], titleWidth)
+		if len(line) != expectedLen {
+			t.Errorf("remote row %d: line length %d, want %d (line=%q)", i, len(line), expectedLen, line)
+		}
+		if line[8] != '[' {
+			t.Errorf("remote row %d: expected '[' at offset 8, got %q", i, line[8])
+		}
+	}
+
+	// $1.45 must show in full in the right-aligned cost field.
+	line := formatRemoteJobLine(&jobs[1], titleWidth)
+	costStart := fixedColumnWidth + titleWidth - costWidth
+	if !strings.Contains(line[costStart:], "$1.45") {
+		t.Errorf("expected $1.45 at end of remote line, got %q", line)
 	}
 }


### PR DESCRIPTION
## Summary
- Refactor `internal/picker` so the `minder checkout` job picker uses fixed-width columns for label/agent/status/PR and a flexible, terminal-width-aware title column.
- Right-align the cost column at a width that fits up to `$1234.56`, so values like `$1.45` are no longer truncated to `$1...`.
- Widen the agent column to fit the longest built-in agent name (`dependency-updater`, 18 chars); longer agent/title strings get an `...` ellipsis.
- Detect terminal width via `golang.org/x/term` (already a direct dep) with a 100-column fallback, and set the bubbles list width to match so rows never get right-clipped.
- Extract `padLeft`/`padRight` and a `renderRow`/`jobColumns` indirection to make the formatter unit-testable.

## Test plan
- [x] `go test ./internal/picker/... -v` — all existing filter tests plus new tests for `padLeft`, `padRight`, `titleWidthFor`, `formatJobLine`, and `formatRemoteJobLine` column alignment
- [x] `go test ./... -timeout 5m` — entire suite green
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `gofmt -l .` — no diffs
- [ ] Manual: run `minder checkout` in a real terminal and confirm columns line up with mixed-cost/PR/agent rows

Fixes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)