### PR TITLE
Reap orphan processes left in agent worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ No human intervention needed.
 ### Command timeout wrappers
 Test and build commands injected into agent context include `timeout` wrappers (default 5m for tests, 3m for builds). Configurable via `test_timeout` and `build_timeout` in `onboarding.yaml`. Prevents agents from burning turns waiting on hung processes.
 
+### Orphan process reaper
+Agent runs occasionally leave detached descendants alive in the worktree — `npm start`, `next dev`, `overmind` and similar processes call `setsid` and escape their parent's process group, so they survive the agent that spawned them. The supervisor sweeps every worktree for these orphans and kills them (SIGTERM, then SIGKILL after a 2-second grace) at three points:
+
+- after every agent process exits (scoped to that one worktree)
+- at supervisor startup (across all worktrees whose jobs are not currently running)
+- on a 5-minute ticker while the supervisor is running
+
+Each kill emits one event line in foreground mode (e.g. `[reaper] job#265 issue-699: killed pid=39076 ppid=1 cmd=next-server age=20m sig=KILL`) and a structured `component=reaper` record in `debug.log`. Active agents' processes are never touched — the sweep skips any job in `running` state. For manual cleanup or testing: `minder reaper sweep <worktree-path>`.
+
 ## SwiftBar menu bar plugin
 
 A macOS menu bar widget that shows agent status at a glance. Supports all job statuses including `waiting` (usage limit recovery). See `xbar/minder.5s.sh`.

--- a/cmd/reaper.go
+++ b/cmd/reaper.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/aptx-health/agent-minder/internal/reaper"
+	"github.com/spf13/cobra"
+)
+
+var reaperCmd = &cobra.Command{
+	Use:    "reaper",
+	Short:  "Sweep orphaned processes left in agent worktrees",
+	Hidden: true,
+}
+
+var reaperSweepCmd = &cobra.Command{
+	Use:   "sweep <worktree-path>",
+	Short: "Kill any process whose cwd is inside the given path",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		reaped, err := reaper.Sweep(args[0])
+		if err != nil {
+			return err
+		}
+		if len(reaped) == 0 {
+			fmt.Println("no orphans found")
+			return nil
+		}
+		for _, r := range reaped {
+			fmt.Println(r)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(reaperCmd)
+	reaperCmd.AddCommand(reaperSweepCmd)
+}

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -1,0 +1,192 @@
+// Package reaper finds and kills orphaned processes left behind in agent
+// worktrees by claude agent runs (npm/next/etc. that detach into their own
+// session and survive their parent shell).
+package reaper
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Reaped describes a single process the reaper killed.
+type Reaped struct {
+	PID     int
+	PPID    int
+	Command string
+	Age     time.Duration
+	CPU     float64 // % of one core (top-style)
+	Signal  string  // "TERM" or "KILL"
+}
+
+func (r Reaped) String() string {
+	return fmt.Sprintf("pid=%d ppid=%d cmd=%s age=%s cpu=%.0f%% sig=%s",
+		r.PID, r.PPID, r.Command, r.Age.Truncate(time.Second), r.CPU, r.Signal)
+}
+
+// Sweep finds every process whose current working directory is inside
+// worktreePath and terminates it (SIGTERM, then SIGKILL after grace).
+// Returns the list of processes that were reaped.
+func Sweep(worktreePath string) ([]Reaped, error) {
+	if worktreePath == "" {
+		return nil, nil
+	}
+	pids, err := findPIDsInPath(worktreePath)
+	if err != nil {
+		return nil, err
+	}
+	return killPIDs(pids), nil
+}
+
+// SweepMany runs Sweep across multiple worktree paths and aggregates results.
+func SweepMany(paths []string) []Reaped {
+	var all []Reaped
+	for _, p := range paths {
+		r, err := Sweep(p)
+		if err != nil {
+			continue
+		}
+		all = append(all, r...)
+	}
+	return all
+}
+
+// findPIDsInPath enumerates PIDs whose cwd is inside worktreePath via lsof.
+// Uses `lsof -d cwd -F pn`, which is one process spawn for the whole system.
+func findPIDsInPath(worktreePath string) ([]int, error) {
+	out, err := exec.Command("lsof", "-d", "cwd", "-F", "pn").Output()
+	if err != nil {
+		// lsof returns nonzero when some pids fail to inspect; output is still usable.
+		if _, ok := err.(*exec.ExitError); !ok {
+			return nil, fmt.Errorf("lsof: %w", err)
+		}
+	}
+	// lsof reports resolved (real) paths; resolve our target the same way so
+	// symlinked roots (e.g. /var/folders → /private/var/folders on macOS) match.
+	resolved, rerr := filepath.EvalSymlinks(worktreePath)
+	if rerr != nil {
+		resolved = worktreePath
+	}
+	prefix := strings.TrimRight(resolved, "/") + "/"
+	var pids []int
+	var curPID int
+	for _, line := range strings.Split(string(out), "\n") {
+		if line == "" {
+			continue
+		}
+		switch line[0] {
+		case 'p':
+			n, err := strconv.Atoi(line[1:])
+			if err == nil {
+				curPID = n
+			}
+		case 'n':
+			path := line[1:]
+			if curPID == 0 {
+				continue
+			}
+			if path == resolved || strings.HasPrefix(path, prefix) {
+				pids = append(pids, curPID)
+			}
+		}
+	}
+	return pids, nil
+}
+
+// killPIDs sends SIGTERM, waits a short grace period, then escalates to SIGKILL
+// for any survivors. Returns the list of reaped processes with metadata.
+func killPIDs(pids []int) []Reaped {
+	if len(pids) == 0 {
+		return nil
+	}
+	// Snapshot metadata before killing so we can report on what we hit.
+	meta := snapshotMeta(pids)
+	var reaped []Reaped
+
+	for _, pid := range pids {
+		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+			continue
+		}
+	}
+
+	time.Sleep(2 * time.Second)
+
+	for _, pid := range pids {
+		m := meta[pid]
+		if syscall.Kill(pid, 0) == nil {
+			// Still alive — escalate.
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+			m.Signal = "KILL"
+		} else {
+			m.Signal = "TERM"
+		}
+		m.PID = pid
+		reaped = append(reaped, m)
+	}
+	return reaped
+}
+
+// snapshotMeta collects ppid/command/etime/cpu for a set of PIDs in one ps call.
+func snapshotMeta(pids []int) map[int]Reaped {
+	out := map[int]Reaped{}
+	if len(pids) == 0 {
+		return out
+	}
+	args := []string{"-o", "pid=,ppid=,etime=,%cpu=,comm="}
+	for _, pid := range pids {
+		args = append(args, "-p", strconv.Itoa(pid))
+	}
+	raw, err := exec.Command("ps", args...).Output()
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		ppid, _ := strconv.Atoi(fields[1])
+		cpu, _ := strconv.ParseFloat(fields[3], 64)
+		out[pid] = Reaped{
+			PID:     pid,
+			PPID:    ppid,
+			Age:     parseEtime(fields[2]),
+			CPU:     cpu,
+			Command: strings.Join(fields[4:], " "),
+		}
+	}
+	return out
+}
+
+// parseEtime parses ps etime format: [[DD-]HH:]MM:SS
+func parseEtime(s string) time.Duration {
+	var days, hours, mins, secs int
+	if idx := strings.Index(s, "-"); idx >= 0 {
+		days, _ = strconv.Atoi(s[:idx])
+		s = s[idx+1:]
+	}
+	parts := strings.Split(s, ":")
+	switch len(parts) {
+	case 3:
+		hours, _ = strconv.Atoi(parts[0])
+		mins, _ = strconv.Atoi(parts[1])
+		secs, _ = strconv.Atoi(parts[2])
+	case 2:
+		mins, _ = strconv.Atoi(parts[0])
+		secs, _ = strconv.Atoi(parts[1])
+	case 1:
+		secs, _ = strconv.Atoi(parts[0])
+	}
+	return time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(mins)*time.Minute +
+		time.Duration(secs)*time.Second
+}

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -1,0 +1,149 @@
+package reaper
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestParseEtime(t *testing.T) {
+	cases := map[string]time.Duration{
+		"05":         5 * time.Second,
+		"01:30":      90 * time.Second,
+		"02:00:00":   2 * time.Hour,
+		"1-00:00:00": 24 * time.Hour,
+		"3-04:05:06": 3*24*time.Hour + 4*time.Hour + 5*time.Minute + 6*time.Second,
+	}
+	for in, want := range cases {
+		if got := parseEtime(in); got != want {
+			t.Errorf("parseEtime(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestSweepKillsProcessInWorktree spawns a sleeping child whose cwd lives
+// inside a temp worktree dir, then verifies Sweep finds and kills it.
+func TestSweepKillsProcessInWorktree(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
+	worktree := t.TempDir()
+
+	cmd := exec.Command("sleep", "30")
+	cmd.Dir = worktree
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+
+	// Give the child a moment to settle so lsof sees its cwd.
+	time.Sleep(200 * time.Millisecond)
+
+	reaped, err := Sweep(worktree)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(reaped) == 0 {
+		t.Fatalf("expected to reap at least one process, got 0")
+	}
+	found := false
+	for _, r := range reaped {
+		if r.PID == pid {
+			found = true
+			if r.Signal == "" {
+				t.Errorf("reaped pid %d missing signal", pid)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected pid %d in reaped list, got %+v", pid, reaped)
+	}
+
+	// Verify the process is no longer running (may be a zombie until parent
+	// Waits — zombies are dead but still in the process table, which is fine).
+	state, _ := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "state=").Output()
+	st := string(state)
+	if st != "" && st[0] != 'Z' && st[0] != '\n' {
+		t.Errorf("pid %d state %q after Sweep; expected gone or zombie", pid, st)
+	}
+}
+
+// TestSweepIgnoresProcessOutsideWorktree confirms we don't kill processes
+// whose cwd is a sibling/parent of the worktree.
+func TestSweepIgnoresProcessOutsideWorktree(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
+	parent := t.TempDir()
+	worktree := filepath.Join(parent, "wt")
+	if err := os.Mkdir(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sibling := filepath.Join(parent, "other")
+	if err := os.Mkdir(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sleep", "30")
+	cmd.Dir = sibling
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	reaped, err := Sweep(worktree)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	for _, r := range reaped {
+		if r.PID == pid {
+			t.Errorf("Sweep killed sibling-dir pid %d (worktree=%s): %s", pid, worktree, r)
+		}
+	}
+	// Sanity: sibling pid still alive.
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Errorf("sibling pid %d unexpectedly dead: %v", pid, err)
+	}
+}
+
+// TestSweepEmptyPath returns no error and no reaps.
+func TestSweepEmptyPath(t *testing.T) {
+	r, err := Sweep("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r) != 0 {
+		t.Errorf("expected empty result, got %d", len(r))
+	}
+}
+
+// Smoke: snapshotMeta should populate command + ppid for a known live PID.
+func TestSnapshotMetaSelf(t *testing.T) {
+	pid := os.Getpid()
+	meta := snapshotMeta([]int{pid})
+	m, ok := meta[pid]
+	if !ok {
+		t.Fatalf("no meta for self pid %d", pid)
+	}
+	if m.Command == "" {
+		t.Errorf("empty command for self")
+	}
+	if m.PPID == 0 {
+		t.Errorf("ppid=0 for self pid %d (parent=%d)", pid, os.Getppid())
+	}
+	_ = strconv.Itoa // keep import
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aptx-health/agent-minder/internal/db"
 	gitpkg "github.com/aptx-health/agent-minder/internal/git"
 	ghpkg "github.com/aptx-health/agent-minder/internal/github"
+	"github.com/aptx-health/agent-minder/internal/reaper"
 )
 
 // debugLogger is a structured JSON logger for supervisor tracing.
@@ -311,6 +312,10 @@ func (s *Supervisor) Launch(ctx context.Context) {
 
 	go func() {
 		defer close(s.done)
+
+		// Startup sweep: reap anything left from prior daemon runs.
+		s.sweepAllInactiveWorktrees()
+
 		s.fillCapacity(ctx)
 
 		reviewTicker := time.NewTicker(30 * time.Second)
@@ -321,6 +326,9 @@ func (s *Supervisor) Launch(ctx context.Context) {
 		if s.addWatchTickerToLoop() {
 			s.WatchTick(ctx)
 		}
+
+		reaperTicker := time.NewTicker(5 * time.Minute)
+		defer reaperTicker.Stop()
 
 		for {
 			select {
@@ -341,6 +349,9 @@ func (s *Supervisor) Launch(ctx context.Context) {
 				if s.hasCapacity() {
 					s.fillCapacity(ctx)
 				}
+
+			case <-reaperTicker.C:
+				s.sweepAllInactiveWorktrees()
 
 			default:
 				if s.hasCapacity() {
@@ -527,6 +538,7 @@ func (s *Supervisor) runJobManager(ctx context.Context, job *db.Job) {
 		s.mu.Lock()
 		delete(s.running, job.ID)
 		s.mu.Unlock()
+		s.sweepJobWorktree(job)
 		s.fillCapacity(s.parentCtx)
 	}()
 
@@ -655,4 +667,63 @@ func lastPRNumberAfter(content, marker string) int {
 	}
 	num, _ := strconv.Atoi(rest[:end])
 	return num
+}
+
+// sweepJobWorktree reaps any orphaned processes left in a single job's
+// worktree. Safe to call after the job's agent process has exited.
+func (s *Supervisor) sweepJobWorktree(job *db.Job) {
+	if job == nil || !job.WorktreePath.Valid || job.WorktreePath.String == "" {
+		return
+	}
+	reaped, err := reaper.Sweep(job.WorktreePath.String)
+	if err != nil {
+		debugLog("reaper error", "job", job.ID, "worktree", job.WorktreePath.String, "error", err.Error())
+		return
+	}
+	s.reportReaped(reaped, job.ID, job.IssueNumber)
+}
+
+// sweepAllInactiveWorktrees finds every worktree whose job is NOT currently
+// running and reaps stragglers. Used at startup and on a periodic ticker.
+func (s *Supervisor) sweepAllInactiveWorktrees() {
+	jobs, err := s.store.GetJobs(s.deploy.ID)
+	if err != nil {
+		return
+	}
+
+	s.mu.Lock()
+	running := make(map[int64]bool, len(s.running))
+	for id := range s.running {
+		running[id] = true
+	}
+	s.mu.Unlock()
+
+	for _, j := range jobs {
+		if running[j.ID] {
+			continue // active agent; do not touch
+		}
+		if j.Status == db.StatusRunning {
+			continue // crash-recovery / stale row; skip to be safe
+		}
+		if !j.WorktreePath.Valid || j.WorktreePath.String == "" {
+			continue
+		}
+		reaped, err := reaper.Sweep(j.WorktreePath.String)
+		if err != nil {
+			continue
+		}
+		s.reportReaped(reaped, j.ID, j.IssueNumber)
+	}
+}
+
+// reportReaped emits one event per killed process so the foreground CLI and
+// TUI both surface what the reaper did.
+func (s *Supervisor) reportReaped(reaped []reaper.Reaped, jobID int64, issueNum int) {
+	for _, r := range reaped {
+		msg := fmt.Sprintf("[reaper] job#%d issue-%d: killed %s", jobID, issueNum, r)
+		s.emitEvent("reaped", msg, jobID)
+		debugLog("reaper killed", "job", jobID, "issue", issueNum,
+			"pid", r.PID, "ppid", r.PPID, "command", r.Command,
+			"age_seconds", r.Age.Seconds(), "cpu_percent", r.CPU, "signal", r.Signal)
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `internal/reaper` — uses `lsof -d cwd` to find any process whose cwd is inside a given worktree path, then SIGTERM → 2s grace → SIGKILL.
- Wires sweeps into the supervisor at three points: per-job (after agent exit), at startup, and on a 5-minute ticker.
- Emits a `reaped` event per kill so the foreground CLI surfaces it; same record lands in `debug.log` under `component=reaper`.

## Why
A `next-server` from a smoke-test inside `agent/issue-699` survived its parent agent (npm/next escaped the process group via `setsid`) and pinned a CPU core for 20+ minutes, owned by init, no listener. The agent process exited normally, so nothing in the supervisor was watching for stragglers.

## Safety
Periodic and startup sweeps skip any job whose status is `running` or that appears in the live `running` map, so an active agent's dev server is never killed. The per-job sweep runs only after `cmd.Wait` returns.

## Test plan
- [x] `go test ./internal/reaper/...` — happy path (spawn child in worktree, verify killed), negative path (sibling-dir process untouched), `parseEtime`.
- [x] `go test ./...` — full suite passes.
- [x] Manual: run `minder deploy --foreground`, confirm `[reaper] ...` lines appear in stderr when a stale worktree has live processes.