### PR TITLE
Quiet down git fetch spam during long network outages

### DIFF
--- a/internal/supervisor/network_test.go
+++ b/internal/supervisor/network_test.go
@@ -1,0 +1,173 @@
+package supervisor
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// drainEvents reads all currently-buffered events without blocking.
+func drainEvents(s *Supervisor) []Event {
+	var out []Event
+	for {
+		select {
+		case e := <-s.events:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+// waitForEvent reads up to one event with a short deadline. Returns ok=false if none arrived.
+func waitForEvent(s *Supervisor, d time.Duration) (Event, bool) {
+	select {
+	case e := <-s.events:
+		return e, true
+	case <-time.After(d):
+		return Event{}, false
+	}
+}
+
+func newNetTestSupervisor() *Supervisor {
+	s := &Supervisor{
+		running:   make(map[int64]*runState),
+		maxAgents: 3,
+		events:    make(chan Event, 32),
+	}
+	return s
+}
+
+func TestTryFetchSuccessNoEvents(t *testing.T) {
+	s := newNetTestSupervisor()
+	s.fetchFn = func() error { return nil }
+
+	s.tryFetch()
+	if s.offline {
+		t.Fatal("expected online after successful fetch")
+	}
+	if got := drainEvents(s); len(got) != 0 {
+		t.Fatalf("expected no events on healthy fetch, got %d: %+v", len(got), got)
+	}
+}
+
+func TestTryFetchTransitionsOfflineThenSilent(t *testing.T) {
+	s := newNetTestSupervisor()
+	s.fetchFn = func() error { return errors.New("operation timed out") }
+
+	// First failure: one warning event.
+	s.tryFetch()
+	if !s.offline {
+		t.Fatal("expected offline after network failure")
+	}
+	evt, ok := waitForEvent(s, 200*time.Millisecond)
+	if !ok {
+		t.Fatal("expected an offline warning event")
+	}
+	if evt.Type != "warning" {
+		t.Fatalf("expected warning event, got type=%q summary=%q", evt.Type, evt.Summary)
+	}
+
+	// Subsequent failures while offline must be silent and must not actually
+	// attempt the fetch when nextProbeAt is in the future.
+	calls := 0
+	s.fetchFn = func() error {
+		calls++
+		return errors.New("operation timed out")
+	}
+	for range 5 {
+		s.tryFetch()
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 fetch attempts while in backoff, got %d", calls)
+	}
+	if got := drainEvents(s); len(got) != 0 {
+		t.Fatalf("expected silence while offline, got %d events: %+v", len(got), got)
+	}
+}
+
+func TestTryFetchBackoffAdvancesOnConsecutiveFailures(t *testing.T) {
+	s := newNetTestSupervisor()
+	s.fetchFn = func() error { return errors.New("connection refused") }
+
+	// Force first failure, then jump time forward and fail again.
+	s.tryFetch()
+	if !s.offline || s.offlineBackoffIdx != 0 {
+		t.Fatalf("expected idx=0 after first failure, got offline=%v idx=%d", s.offline, s.offlineBackoffIdx)
+	}
+	_ = drainEvents(s)
+
+	// Simulate clock passing the probe deadline by clearing nextProbeAt.
+	for i := 1; i < len(offlineBackoffSchedule); i++ {
+		s.nextProbeAt = time.Time{}
+		s.tryFetch()
+		if s.offlineBackoffIdx != i {
+			t.Fatalf("after probe %d, expected idx=%d got %d", i+1, i, s.offlineBackoffIdx)
+		}
+	}
+
+	// One more probe past the schedule end: index should clamp, not panic.
+	s.nextProbeAt = time.Time{}
+	s.tryFetch()
+	if s.offlineBackoffIdx != len(offlineBackoffSchedule)-1 {
+		t.Fatalf("expected idx clamped to %d, got %d", len(offlineBackoffSchedule)-1, s.offlineBackoffIdx)
+	}
+
+	// No spam during backoff transitions.
+	if got := drainEvents(s); len(got) != 0 {
+		t.Fatalf("expected silence during backoff escalation, got %d events", len(got))
+	}
+}
+
+func TestTryFetchRecoveryEmitsOnlineEvent(t *testing.T) {
+	s := newNetTestSupervisor()
+	s.fetchFn = func() error { return errors.New("network is unreachable") }
+
+	s.tryFetch()
+	if !s.offline {
+		t.Fatal("expected offline after failure")
+	}
+	_ = drainEvents(s)
+
+	// Flip to healthy and pretend the backoff window has elapsed.
+	s.nextProbeAt = time.Time{}
+	s.fetchFn = func() error { return nil }
+	s.tryFetch()
+
+	if s.offline {
+		t.Fatal("expected online after successful probe")
+	}
+	if s.offlineBackoffIdx != 0 {
+		t.Fatalf("expected backoff reset to 0, got %d", s.offlineBackoffIdx)
+	}
+	evt, ok := waitForEvent(s, 200*time.Millisecond)
+	if !ok || evt.Type != "info" {
+		t.Fatalf("expected info recovery event, got ok=%v evt=%+v", ok, evt)
+	}
+}
+
+func TestTryFetchNonNetworkErrorSurfaces(t *testing.T) {
+	s := newNetTestSupervisor()
+	s.fetchFn = func() error { return errors.New("fatal: bad object refs/heads/foo") }
+
+	s.tryFetch()
+	if s.offline {
+		t.Fatal("non-network errors must not flip to offline")
+	}
+	evt, ok := waitForEvent(s, 200*time.Millisecond)
+	if !ok || evt.Type != "warning" {
+		t.Fatalf("expected warning event for non-network error, got ok=%v evt=%+v", ok, evt)
+	}
+}
+
+func TestIsOnlineGatesCheckMergedPRs(t *testing.T) {
+	s := newNetTestSupervisor()
+	s.offline = true
+	if s.isOnline() {
+		t.Fatal("expected isOnline=false when offline")
+	}
+	s.offline = false
+	if !s.isOnline() {
+		t.Fatal("expected isOnline=true when online")
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -106,11 +106,16 @@ type Supervisor struct {
 	waitingHintEmitted bool
 	lastGHError        time.Time // throttle GitHub API error reporting
 	ghPollSucceeded    bool      // true after first successful poll
+	offline            bool
+	offlineSince       time.Time
+	offlineBackoffIdx  int
+	nextProbeAt        time.Time
 	events             chan Event
 	parentCtx          context.Context
 	cancel             context.CancelFunc
 	done               chan struct{}
 	ghClientFactory    func(token string) *ghpkg.Client
+	fetchFn            func() error // overridable for tests
 }
 
 // New creates a new Supervisor.
@@ -119,7 +124,7 @@ func New(store *db.Store, deploy *db.Deployment, repoDir, owner, repo, ghToken s
 	if maxAgents < 1 {
 		maxAgents = 3
 	}
-	return &Supervisor{
+	s := &Supervisor{
 		store:     store,
 		deploy:    deploy,
 		repoDir:   repoDir,
@@ -130,6 +135,8 @@ func New(store *db.Store, deploy *db.Deployment, repoDir, owner, repo, ghToken s
 		maxAgents: maxAgents,
 		events:    make(chan Event, 64),
 	}
+	s.fetchFn = func() error { return gitpkg.Fetch(s.repoDir) }
+	return s
 }
 
 func (s *Supervisor) newGHClient() *ghpkg.Client {
@@ -463,20 +470,11 @@ func (s *Supervisor) fillCapacity(ctx context.Context) {
 		}
 	}
 
-	// Fetch once before launching — retry on transient network errors.
+	// Fetch once before launching, with offline-aware backoff.
 	if len(s.running) < s.maxAgents {
 		s.mu.Unlock()
-		err := gitpkg.FetchWithRetry(s.repoDir, 3, func(attempt, max int, err error) {
-			s.emitEvent("warning", fmt.Sprintf("Git fetch failed (network error) — retrying (%d/%d)", attempt, max), 0)
-		})
+		s.tryFetch()
 		s.mu.Lock()
-		if err != nil {
-			if gitpkg.IsNetworkError(err) {
-				s.emitEvent("warning", "Git fetch failed after retries (network issue) — will try again next cycle", 0)
-			} else {
-				s.emitEvent("warning", fmt.Sprintf("Git fetch failed: %v", err), 0)
-			}
-		}
 	}
 
 	for len(s.running) < s.maxAgents {
@@ -486,6 +484,69 @@ func (s *Supervisor) fillCapacity(ctx context.Context) {
 		}
 		s.launchJob(ctx, jobs[0])
 	}
+}
+
+// offlineBackoffSchedule is the delay-until-next-probe sequence while offline.
+// Index advances on each consecutive failure and caps at the last entry.
+var offlineBackoffSchedule = []time.Duration{
+	30 * time.Second,
+	1 * time.Minute,
+	2 * time.Minute,
+	5 * time.Minute,
+	10 * time.Minute,
+	15 * time.Minute,
+}
+
+// tryFetch attempts a git fetch with offline-aware backoff.
+// While offline, it skips entirely until nextProbeAt; on the probe attempt
+// it does a single fetch. Logs only on offline↔online transitions or on
+// non-network errors.
+func (s *Supervisor) tryFetch() {
+	s.mu.Lock()
+	if s.offline && time.Now().Before(s.nextProbeAt) {
+		s.mu.Unlock()
+		return
+	}
+	s.mu.Unlock()
+
+	err := s.fetchFn()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err == nil {
+		if s.offline {
+			downFor := time.Since(s.offlineSince).Round(time.Second)
+			s.offline = false
+			s.offlineBackoffIdx = 0
+			s.nextProbeAt = time.Time{}
+			go s.emitEvent("info", fmt.Sprintf("Network online (offline for %s) — resuming", downFor), 0)
+		}
+		return
+	}
+
+	if !gitpkg.IsNetworkError(err) {
+		// Non-network error: surface immediately, don't enter offline state.
+		go s.emitEvent("warning", fmt.Sprintf("Git fetch failed: %v", err), 0)
+		return
+	}
+
+	if !s.offline {
+		s.offline = true
+		s.offlineSince = time.Now()
+		s.offlineBackoffIdx = 0
+		go s.emitEvent("warning", "Network offline (git fetch failed) — backing off, will retry quietly", 0)
+	} else if s.offlineBackoffIdx < len(offlineBackoffSchedule)-1 {
+		s.offlineBackoffIdx++
+	}
+	s.nextProbeAt = time.Now().Add(offlineBackoffSchedule[s.offlineBackoffIdx])
+}
+
+// isOnline reports whether the supervisor considers the network up.
+func (s *Supervisor) isOnline() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.offline
 }
 
 func (s *Supervisor) checkBudgetCeiling() bool {
@@ -569,7 +630,11 @@ func (s *Supervisor) runJobManager(ctx context.Context, job *db.Job) {
 }
 
 // checkMergedPRs checks if any review/reviewed jobs had their PRs merged.
+// Skipped while offline to avoid hammering the GitHub API during outages.
 func (s *Supervisor) checkMergedPRs(ctx context.Context) {
+	if !s.isOnline() {
+		return
+	}
 	jobs, err := s.store.GetJobs(s.deploy.ID)
 	if err != nil {
 		return

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -520,14 +520,14 @@ func (s *Supervisor) tryFetch() {
 			s.offline = false
 			s.offlineBackoffIdx = 0
 			s.nextProbeAt = time.Time{}
-			go s.emitEvent("info", fmt.Sprintf("Network online (offline for %s) — resuming", downFor), 0)
+			s.emitEvent("info", fmt.Sprintf("Network online (offline for %s) — resuming", downFor), 0)
 		}
 		return
 	}
 
 	if !gitpkg.IsNetworkError(err) {
 		// Non-network error: surface immediately, don't enter offline state.
-		go s.emitEvent("warning", fmt.Sprintf("Git fetch failed: %v", err), 0)
+		s.emitEvent("warning", fmt.Sprintf("Git fetch failed: %v", err), 0)
 		return
 	}
 
@@ -535,7 +535,7 @@ func (s *Supervisor) tryFetch() {
 		s.offline = true
 		s.offlineSince = time.Now()
 		s.offlineBackoffIdx = 0
-		go s.emitEvent("warning", "Network offline (git fetch failed) — backing off, will retry quietly", 0)
+		s.emitEvent("warning", "Network offline (git fetch failed) — backing off, will retry quietly", 0)
 	} else if s.offlineBackoffIdx < len(offlineBackoffSchedule)-1 {
 		s.offlineBackoffIdx++
 	}


### PR DESCRIPTION
## Summary
- Foreground `minder deploy` was spamming `Git fetch failed (network error) — retrying (2/3)` every poll cycle while the laptop was offline (closed lid, walking around), making it hard to tell whether anything was actually progressing.
- Replaces per-retry warnings with a supervisor-level offline state machine. First failure emits one warning; subsequent failures are silent and skip the fetch entirely until the backoff window elapses.
- Backoff: 30s → 1m → 2m → 5m → 10m → 15m cap. Recovery emits a single info event with the outage duration.
- `checkMergedPRs` is gated on `isOnline()` so we stop hitting the GitHub API during outages too.
- Non-network git errors still surface immediately — only transient connectivity failures get the quiet treatment.

## Test plan
- [x] `go test ./...` — all packages green
- [x] New `internal/supervisor/network_test.go` covers: success path, offline transition + silence, backoff escalation + clamp, recovery event, non-network error surfacing, isOnline gate
- [ ] Manual: run `minder deploy --foreground`, close laptop, reopen — confirm exactly one `Network offline` warning and one `Network online (offline for ...)` info, no spam in between

🤖 Generated with [Claude Code](https://claude.com/claude-code)