### PR TITLE
Surface and attach Claude skills during enroll + agents add

### DIFF
--- a/cmd/agents_add.go
+++ b/cmd/agents_add.go
@@ -129,17 +129,65 @@ Based on the description, determine:
 - For **reactive** agents: ask which GitHub label triggers it
 - For **proactive** agents: ask what schedule (suggest sensible defaults based on the task)
 
-### 4. Run a research sub-agent
+### 4. Skill survey (do this BEFORE the research sub-agent)
+
+Claude Code "skills" are reusable instruction packs the agent can invoke.
+
+**4a. Suggest high-value external skills.** Based on the agent's purpose and the
+repo's stack, propose up to 3 well-maintained, high-quality skills the user may
+want to install. Sourcing rules — MUST follow:
+- Only suggest skills from anthropic-official sources (github.com/anthropics/skills),
+  established marketplaces (Claude Code plugin marketplace), or repos with clear
+  signs of active maintenance.
+- Do NOT invent skill names. If you cannot verify a skill exists, don't suggest it.
+- Each suggestion: name, one-line purpose, source URL, one-line fit reason.
+- If nothing meets the bar, say "no external skills recommended" and move on.
+
+For each suggestion, ask install / skip / defer. On install, ask the user to
+confirm the exact install command before running it.
+
+**4b. Inventory locally-available skills.** List every SKILL.md under:
+- .claude/skills/*/SKILL.md
+- ~/.claude/skills/*/SKILL.md
+- .claude/plugins/*/skills/*/SKILL.md
+
+Capture name + description from each. If none are found and none were installed,
+record "no skills available" and continue.
+
+### 5. Run a research sub-agent
 Before writing the agent definition, run a research agent to analyze the codebase:
 
-  claude -p --model sonnet "Research this codebase for writing an optimized <agent-name> agent definition that <description>. Focus on: relevant code patterns, tools, commands, and conventions. Output ONLY the instruction body markdown — no frontmatter, no preamble."
+  claude -p --model sonnet "Research this codebase for writing an optimized <agent-name> agent definition that <description>. Focus on: relevant code patterns, tools, commands, and conventions. Available skills the agent can invoke: <skill-name>: <description>; ... (omit if none). Recommend which of these skills fit this agent's job. Output ONLY the instruction body markdown — no frontmatter, no preamble."
 
 Read the output and use it as the foundation for the instruction body.
 
-### 5. Create the agent definition
+### 6. Create the agent definition
 Write the file to .claude/agents/<name>.md with:
 - YAML frontmatter with the correct contract fields
+- Optionally a "skills:" list in the frontmatter (see skill attachment below)
 - Instruction body based on the research + user's requirements
+
+**Skill attachment (two layers, both required if any skills are attached):**
+
+Ask the user which skills from the step-4 inventory + research recommendation to
+attach to this agent (skip if no skills are available).
+
+Layer 1 — frontmatter. Add a "skills:" list at the end of the frontmatter:
+
+    skills:
+      - <skill-name>
+
+Layer 2 — body. For each attached skill, add a "[REQUIRED]" workflow step with
+MUST language and a mandatory line in a final-report section:
+
+    ## Workflow
+    - [REQUIRED] Invoke the the named skill with <args>. If it returns
+      zero findings, record "no findings" — do not omit the line.
+
+    ## Final report (every line required)
+    - <skill-name>: <N findings> | "no findings" | "skipped — <reason>"
+
+Descriptive phrasing gets silently skipped — use MUST / [REQUIRED] / numbered steps.
 
 Use existing agent templates as reference for the frontmatter structure:
 %s
@@ -153,7 +201,7 @@ Key frontmatter fields:
 - context (list of providers: issue, repo_info, file_list, recent_commits:<days>, lessons, sibling_jobs, dep_graph)
 - dedup (for proactive: branch_exists, open_pr_with_label:<label>, recent_run:<hours>)
 
-### 6. Update jobs.yaml
+### 7. Update jobs.yaml
 Read the existing .agent-minder/jobs.yaml (if it exists) and add an entry for the new agent.
 
 For reactive agents:
@@ -170,14 +218,14 @@ For proactive agents:
     description: "<description>"
     budget: 3.0
 
-### 7. Validate
+### 8. Validate
 - Run: minder agents list --repo .
 - Run: minder jobs list --repo .
   If minder is not on PATH, use go run ./cmd/minder.
   Do NOT use Python or Ruby YAML parsers.
 - If validation fails, fix and re-validate.
 
-### 8. Summary
+### 9. Summary
 Print a summary of what was created:
 - Agent definition file path
 - Mode and trigger/schedule

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -176,6 +176,40 @@ Languages: %v
 
 ## Your goals (in order)
 
+### 0. Skill survey + suggestions (do this FIRST, before anything else)
+
+Claude Code "skills" are reusable instruction packs that agents can invoke. Surfacing
+relevant skills before agent research means research can factor them in rather than
+duplicating their logic.
+
+**0a. Suggest high-value skills to install.** Based on the repo's languages and
+frameworks, propose a SHORT list (max 5) of well-maintained, high-quality skills
+the user may want to install. Sourcing rules — MUST follow:
+- Only suggest skills from anthropic-official sources (github.com/anthropics/skills),
+  established marketplaces (Claude Code plugin marketplace), or repos with clear
+  signs of active maintenance (recent commits, > a handful of stars, README).
+- Do NOT invent skill names. If you cannot verify a skill exists via WebFetch or
+  by checking a known directory, do not suggest it.
+- Each suggestion must include: name, one-line purpose, source URL, and a one-line
+  reason it fits THIS repo.
+- If nothing meets the bar, say "no external skills recommended" and move on.
+
+Present the list. For each, ask the user: install / skip / defer. For each "install",
+clone or copy the SKILL.md into .claude/skills/<name>/SKILL.md (ask the user to
+confirm the exact install command before running it).
+
+**0b. Inventory locally-available skills.** After install decisions, list every
+SKILL.md found under:
+- .claude/skills/*/SKILL.md (repo-level)
+- ~/.claude/skills/*/SKILL.md (user-level)
+- .claude/plugins/*/skills/*/SKILL.md (plugin-level)
+
+For each, read the frontmatter and capture: name, description. Keep this list
+in your working memory — you will use it in steps 3 and 4.
+
+If no skills are found locally and none are installed, record "no skills available"
+and continue. Skills are optional; never block onboarding on their absence.
+
 ### 1. Onboarding configuration
 - Ask about the test command (verify it works by running it)
 - Ask about the build command
@@ -205,7 +239,7 @@ Required agents (autopilot, reviewer) are always installed. Optional agents:
 For EACH agent the user wants installed (including required agents), spawn a research
 sub-agent using the Bash tool to run:
 
-  claude -p --model sonnet "Research this codebase for writing an optimized <agent-name> agent definition. Focus on: <focus areas>. Output ONLY the instruction body markdown — no frontmatter, no preamble."
+  claude -p --model sonnet "Research this codebase for writing an optimized <agent-name> agent definition. Focus on: <focus areas>. Available skills the agent can invoke: <skill-name>: <description>; ... (omit if none). The research should consider which of these skills naturally fit this agent's job and recommend which to attach. Output ONLY the instruction body markdown — no frontmatter, no preamble."
 
 Run ALL research sub-agents in parallel (use & and wait) to save time:
 
@@ -238,13 +272,44 @@ Agent definition files go in .claude/agents/<name>.md. Each file has YAML frontm
 between --- markers, followed by instruction text.
 
 CRITICAL RULES:
-- The YAML frontmatter (between the --- markers) must NOT be modified. It contains
-  contract fields that the orchestrator parses. Changing it will break the agent.
-- You may ONLY customize the instruction text BELOW the closing --- marker.
+- The YAML frontmatter (between the --- markers) must NOT be modified EXCEPT to
+  add a "skills:" list (see below). All other contract fields are orchestrator-parsed
+  — changing them will break the agent.
+- You may customize the instruction text BELOW the closing --- marker freely.
 - Use the research sub-agent output as the foundation for each instruction body.
   Refine it: ensure it references actual commands, directories, and conventions
   found in THIS repo. Remove any generic filler that doesn't add value.
 - Keep instructions concise and actionable.
+
+**Skills attachment (two layers, both required):**
+
+For each agent, look at the skill inventory from step 0 + research recommendations
+and ask the user which skills to attach (skip if no skills are available).
+
+Layer 1 — frontmatter. Add a "skills:" list under the closing of the existing
+frontmatter fields (before the closing ---):
+
+    skills:
+      - <skill-name-1>
+      - <skill-name-2>
+
+Without this, Claude Code's description-based skill discovery is unreliable in
+autonomous runs.
+
+Layer 2 — imperative invocation in the body. For each attached skill, add a
+"[REQUIRED]" step in the agent's workflow with explicit MUST language and a
+mandatory line in the final-report section so a skipped skill is visibly absent.
+Pattern:
+
+    ## Workflow
+    - [REQUIRED] Invoke the the named skill with <args>. If it returns
+      zero findings, record "no findings" — do not omit the line.
+
+    ## Final report (every line required)
+    - <skill-name>: <N findings> | "no findings" | "skipped — <reason>"
+
+Descriptive phrasing like "consider using the skill" gets silently skipped.
+Use MUST / [REQUIRED] / numbered steps.
 
 Reference frontmatter for each agent type (use these EXACTLY):
 %s

--- a/internal/supervisor/contract.go
+++ b/internal/supervisor/contract.go
@@ -28,6 +28,10 @@ type AgentContract struct {
 	// Available: issue, repo_info, recent_commits:<days>, file_list, lessons, sibling_jobs, dep_graph
 	Context []string `yaml:"context"`
 
+	// Skills to preload when Claude Code invokes this agent. Claude Code reads
+	// this frontmatter directly; agent-minder just round-trips it.
+	Skills []string `yaml:"skills"`
+
 	// Pipeline stages (optional — default is single-stage: just run the agent).
 	Stages []StageContract `yaml:"stages"`
 }


### PR DESCRIPTION
## Summary

The interactive onboarding (`minder enroll`) and `minder agents add` flows now
surface Claude Code skills and wire them into new agents reliably.

- `AgentContract` round-trips a `skills:` list in frontmatter.
- **enroll** gains a Step 0 that runs before everything else:
  - **0a — suggest external skills**: propose up to 5 high-quality,
    well-maintained skills based on the repo's stack. Strict sourcing rules:
    anthropic-official (github.com/anthropics/skills), established marketplaces,
    or repos with verifiable active maintenance. No inventing skill names. The
    agent presents install/skip/defer per suggestion.
  - **0b — inventory local skills**: catalog SKILL.md files under
    `.claude/skills/`, `~/.claude/skills/`, and `.claude/plugins/*/skills/`.
  - Research sub-agents now receive the skill list and recommend fits.
  - Agent definitions get both layers from the invocation-reliability guidance:
    `skills:` in frontmatter (so Claude Code preloads them) + `[REQUIRED]`
    workflow steps and mandatory final-report lines (so the agent actually
    invokes them).
- **agents add** mirrors the same flow, scoped to the single new agent,
  inserted before the research sub-agent.

Why both layers? `skills:` in frontmatter makes the skill *available*; the
imperative `[REQUIRED]` checklist + mandatory reporting makes the agent
*use* it. Either alone is unreliable in autonomous runs.

## Test plan

- [x] `go build ./...` clean (verified locally)
- [x] `go test ./internal/supervisor/... ./cmd/...` green (verified locally)
- [x] Run `minder enroll --force` against a repo with at least one local skill;
      confirm the agent inventories it and offers to attach
- [x] Run `minder agents add` and confirm the skill survey runs before research
- [x] Inspect a generated `.claude/agents/<name>.md`: frontmatter contains
      `skills:` and body contains `[REQUIRED]` invocation steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)