### PR TITLE
Make reaper sparing; add minder worktrees list/prune

### DIFF
--- a/cmd/worktrees.go
+++ b/cmd/worktrees.go
@@ -1,0 +1,374 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aptx-health/agent-minder/internal/db"
+	gitpkg "github.com/aptx-health/agent-minder/internal/git"
+	"github.com/aptx-health/agent-minder/internal/reaper"
+	"github.com/spf13/cobra"
+)
+
+var worktreesCmd = &cobra.Command{
+	Use:   "worktrees",
+	Short: "List agent worktrees with size, age, and reaper protection status",
+	Long: `Lists every worktree under ~/.agent-minder/worktrees/ with its job status,
+completion age, hold-file presence, and on-disk size.
+
+Worktrees with .minder-hold are protected from the periodic reaper.
+Recently-completed worktrees (< 1h) are also spared.`,
+	RunE: runWorktrees,
+}
+
+var (
+	pruneOlderThan string
+	pruneDryRun    bool
+	pruneStatuses  string
+	pruneYes       bool
+)
+
+var worktreesPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove worktrees for completed jobs older than a threshold",
+	Long: `Removes git worktrees + their on-disk directories for jobs in a terminal
+state older than --older-than. Held worktrees (.minder-hold) are always spared.
+
+Defaults: --older-than 7d --status done,reviewed,bailed`,
+	RunE: runWorktreesPrune,
+}
+
+func init() {
+	rootCmd.AddCommand(worktreesCmd)
+	worktreesCmd.AddCommand(worktreesPruneCmd)
+	worktreesPruneCmd.Flags().StringVar(&pruneOlderThan, "older-than", "7d", "Minimum completion age to prune (e.g. 7d, 48h)")
+	worktreesPruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be removed without removing")
+	worktreesPruneCmd.Flags().StringVar(&pruneStatuses, "status", "done,reviewed,bailed", "Comma-separated job statuses eligible for prune")
+	worktreesPruneCmd.Flags().BoolVarP(&pruneYes, "yes", "y", false, "Skip confirmation prompt")
+}
+
+func runWorktreesPrune(_ *cobra.Command, _ []string) error {
+	threshold, err := parseAgeFlag(pruneOlderThan)
+	if err != nil {
+		return fmt.Errorf("--older-than: %w", err)
+	}
+	statusSet := map[string]bool{}
+	for _, s := range strings.Split(pruneStatuses, ",") {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			statusSet[s] = true
+		}
+	}
+
+	conn, err := db.Open(db.DefaultDBPath())
+	if err != nil {
+		return err
+	}
+	store := db.NewStore(conn)
+	defer func() { _ = store.Close() }()
+
+	deploys, err := store.ListDeployments()
+	if err != nil {
+		return err
+	}
+	repoByDeploy := map[string]string{}
+	jobByPath := map[string]*db.Job{}
+	deployByJob := map[int64]string{}
+	for _, d := range deploys {
+		repoByDeploy[d.ID] = d.RepoDir
+		jobs, _ := store.GetJobs(d.ID)
+		for _, j := range jobs {
+			if j.WorktreePath.Valid && j.WorktreePath.String != "" {
+				jobByPath[j.WorktreePath.String] = j
+				deployByJob[j.ID] = d.ID
+			}
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	root := filepath.Join(home, ".agent-minder", "worktrees")
+	rows := collectWorktrees(root, jobByPath)
+
+	type candidate struct {
+		row     worktreeRow
+		job     *db.Job
+		repoDir string
+		ageStr  string
+	}
+	var candidates []candidate
+	var skippedHeld, skippedYoung, skippedStatus, skippedOrphan int
+	for _, r := range rows {
+		if r.Held {
+			skippedHeld++
+			continue
+		}
+		j, ok := jobByPath[r.Path]
+		if !ok {
+			skippedOrphan++
+			continue
+		}
+		if !statusSet[j.Status] {
+			skippedStatus++
+			continue
+		}
+		if !j.CompletedAt.Valid || time.Since(j.CompletedAt.Time) < threshold {
+			skippedYoung++
+			continue
+		}
+		repoDir := repoByDeploy[deployByJob[j.ID]]
+		if repoDir == "" {
+			skippedOrphan++
+			continue
+		}
+		candidates = append(candidates, candidate{
+			row:     r,
+			job:     j,
+			repoDir: repoDir,
+			ageStr:  humanAge(time.Since(j.CompletedAt.Time)),
+		})
+	}
+
+	if len(candidates) == 0 {
+		fmt.Printf("nothing to prune (held=%d young=%d wrong-status=%d orphan/no-repo=%d)\n",
+			skippedHeld, skippedYoung, skippedStatus, skippedOrphan)
+		return nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].row.SizeBytes > candidates[j].row.SizeBytes })
+
+	var totalBytes int64
+	fmt.Printf("%-7s  %-10s  %-10s  %-8s  %s\n", "ISSUE", "STATUS", "AGE", "SIZE", "PATH")
+	for _, c := range candidates {
+		totalBytes += c.row.SizeBytes
+		issue := "-"
+		if c.row.IssueNum > 0 {
+			issue = fmt.Sprintf("#%d", c.row.IssueNum)
+		}
+		fmt.Printf("%-7s  %-10s  %-10s  %-8s  %s\n",
+			issue, c.job.Status, c.ageStr, c.row.SizeHuman, c.row.Path)
+	}
+	fmt.Printf("\n%d worktree(s), %s reclaimable (held=%d young=%d wrong-status=%d orphan/no-repo=%d)\n",
+		len(candidates), humanBytes(totalBytes), skippedHeld, skippedYoung, skippedStatus, skippedOrphan)
+
+	if pruneDryRun {
+		fmt.Println("\n(dry-run; no changes made)")
+		return nil
+	}
+
+	if !pruneYes {
+		fmt.Print("\nProceed with removal? [y/N]: ")
+		var resp string
+		_, _ = fmt.Scanln(&resp)
+		if !strings.EqualFold(strings.TrimSpace(resp), "y") {
+			fmt.Println("aborted")
+			return nil
+		}
+	}
+
+	var removed, failed int
+	for _, c := range candidates {
+		if err := gitpkg.WorktreeRemove(c.repoDir, c.row.Path); err != nil {
+			fmt.Printf("FAIL  %s: %v\n", c.row.Path, err)
+			failed++
+			continue
+		}
+		// Clear stored worktree path so it doesn't show up next time.
+		_ = store.ClearJobWorktree(c.job.ID)
+		removed++
+	}
+	fmt.Printf("\nremoved %d, failed %d\n", removed, failed)
+	return nil
+}
+
+// parseAgeFlag accepts Go-duration syntax plus a "d" suffix for days (e.g. "7d").
+func parseAgeFlag(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "d") {
+		var days float64
+		if _, err := fmt.Sscanf(s, "%fd", &days); err != nil {
+			return 0, err
+		}
+		return time.Duration(days * 24 * float64(time.Hour)), nil
+	}
+	return time.ParseDuration(s)
+}
+
+type worktreeRow struct {
+	Path      string
+	DeployID  string
+	IssueNum  int
+	JobStatus string
+	Completed time.Time
+	HasJob    bool
+	Held      bool
+	SizeBytes int64
+	SizeHuman string
+}
+
+func runWorktrees(_ *cobra.Command, _ []string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	root := filepath.Join(home, ".agent-minder", "worktrees")
+
+	conn, err := db.Open(db.DefaultDBPath())
+	if err != nil {
+		return err
+	}
+	store := db.NewStore(conn)
+	defer func() { _ = store.Close() }()
+
+	// Index jobs by worktree path for lookup.
+	jobByPath := map[string]*db.Job{}
+	deploys, _ := store.ListDeployments()
+	for _, d := range deploys {
+		jobs, _ := store.GetJobs(d.ID)
+		for _, j := range jobs {
+			if j.WorktreePath.Valid && j.WorktreePath.String != "" {
+				jobByPath[j.WorktreePath.String] = j
+			}
+		}
+	}
+
+	rows := collectWorktrees(root, jobByPath)
+	if len(rows) == 0 {
+		fmt.Println("no worktrees found under", root)
+		return nil
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].SizeBytes > rows[j].SizeBytes })
+
+	var totalBytes, heldBytes int64
+	fmt.Printf("%-7s  %-10s  %-12s  %-8s  %-6s  %s\n", "ISSUE", "STATUS", "COMPLETED", "SIZE", "HOLD", "PATH")
+	for _, r := range rows {
+		totalBytes += r.SizeBytes
+		if r.Held {
+			heldBytes += r.SizeBytes
+		}
+		issue := "-"
+		if r.IssueNum > 0 {
+			issue = fmt.Sprintf("#%d", r.IssueNum)
+		}
+		status := r.JobStatus
+		if !r.HasJob {
+			status = "orphan"
+		}
+		completed := "-"
+		if !r.Completed.IsZero() {
+			completed = humanAge(time.Since(r.Completed)) + " ago"
+		}
+		hold := ""
+		if r.Held {
+			hold = "HOLD"
+		}
+		fmt.Printf("%-7s  %-10s  %-12s  %-8s  %-6s  %s\n",
+			issue, status, completed, r.SizeHuman, hold, r.Path)
+	}
+	fmt.Printf("\n%d worktrees, %s total (%s held)\n",
+		len(rows), humanBytes(totalBytes), humanBytes(heldBytes))
+	return nil
+}
+
+func collectWorktrees(root string, jobByPath map[string]*db.Job) []worktreeRow {
+	var rows []worktreeRow
+	deployDirs, err := os.ReadDir(root)
+	if err != nil {
+		return rows
+	}
+	for _, dd := range deployDirs {
+		if !dd.IsDir() {
+			continue
+		}
+		deployID := dd.Name()
+		deployPath := filepath.Join(root, deployID)
+		issueDirs, err := os.ReadDir(deployPath)
+		if err != nil {
+			continue
+		}
+		for _, id := range issueDirs {
+			if !id.IsDir() {
+				continue
+			}
+			path := filepath.Join(deployPath, id.Name())
+			row := worktreeRow{
+				Path:     path,
+				DeployID: deployID,
+				Held:     reaper.IsHeld(path),
+			}
+			if n, ok := parseIssueDir(id.Name()); ok {
+				row.IssueNum = n
+			}
+			if j, ok := jobByPath[path]; ok {
+				row.HasJob = true
+				row.JobStatus = j.Status
+				if j.CompletedAt.Valid {
+					row.Completed = j.CompletedAt.Time
+				}
+			}
+			row.SizeBytes = dirSize(path)
+			row.SizeHuman = humanBytes(row.SizeBytes)
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func parseIssueDir(name string) (int, bool) {
+	if !strings.HasPrefix(name, "issue-") {
+		return 0, false
+	}
+	var n int
+	_, err := fmt.Sscanf(name, "issue-%d", &n)
+	return n, err == nil
+}
+
+// dirSize shells out to `du -sk` for speed and accuracy (apparent-vs-real
+// disk usage, hard links, etc. handled correctly).
+func dirSize(path string) int64 {
+	out, err := exec.Command("du", "-sk", path).Output()
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 0
+	}
+	var kb int64
+	_, _ = fmt.Sscanf(fields[0], "%d", &kb)
+	return kb * 1024
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%cB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+func humanAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -5,6 +5,7 @@ package reaper
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -12,6 +13,20 @@ import (
 	"syscall"
 	"time"
 )
+
+// HoldFileName is the sentinel filename that, when present at the root of a
+// worktree, makes Sweep a no-op. Use `touch <worktree>/.minder-hold` before
+// manual testing to protect long-lived dev servers from the periodic reaper.
+const HoldFileName = ".minder-hold"
+
+// IsHeld reports whether worktreePath contains the hold sentinel file.
+func IsHeld(worktreePath string) bool {
+	if worktreePath == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(worktreePath, HoldFileName))
+	return err == nil
+}
 
 // Reaped describes a single process the reaper killed.
 type Reaped struct {
@@ -33,6 +48,9 @@ func (r Reaped) String() string {
 // Returns the list of processes that were reaped.
 func Sweep(worktreePath string) ([]Reaped, error) {
 	if worktreePath == "" {
+		return nil, nil
+	}
+	if IsHeld(worktreePath) {
 		return nil, nil
 	}
 	pids, err := findPIDsInPath(worktreePath)

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -120,6 +120,40 @@ func TestSweepIgnoresProcessOutsideWorktree(t *testing.T) {
 	}
 }
 
+// TestSweepRespectsHoldFile confirms a worktree with .minder-hold is spared.
+func TestSweepRespectsHoldFile(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
+	worktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(worktree, HoldFileName), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sleep", "30")
+	cmd.Dir = worktree
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	reaped, err := Sweep(worktree)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(reaped) != 0 {
+		t.Errorf("expected hold file to spare worktree, got %d reaps", len(reaped))
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Errorf("held pid %d unexpectedly dead: %v", pid, err)
+	}
+}
+
 // TestSweepEmptyPath returns no error and no reaps.
 func TestSweepEmptyPath(t *testing.T) {
 	r, err := Sweep("")

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -115,7 +115,8 @@ type Supervisor struct {
 	cancel             context.CancelFunc
 	done               chan struct{}
 	ghClientFactory    func(token string) *ghpkg.Client
-	fetchFn            func() error // overridable for tests
+	fetchFn            func() error        // overridable for tests
+	sparedLogAt        map[int64]time.Time // throttle "spared by reaper" events per job
 }
 
 // New creates a new Supervisor.
@@ -125,15 +126,16 @@ func New(store *db.Store, deploy *db.Deployment, repoDir, owner, repo, ghToken s
 		maxAgents = 3
 	}
 	s := &Supervisor{
-		store:     store,
-		deploy:    deploy,
-		repoDir:   repoDir,
-		owner:     owner,
-		repo:      repo,
-		ghToken:   ghToken,
-		running:   make(map[int64]*runState),
-		maxAgents: maxAgents,
-		events:    make(chan Event, 64),
+		store:       store,
+		deploy:      deploy,
+		repoDir:     repoDir,
+		owner:       owner,
+		repo:        repo,
+		ghToken:     ghToken,
+		running:     make(map[int64]*runState),
+		maxAgents:   maxAgents,
+		events:      make(chan Event, 64),
+		sparedLogAt: make(map[int64]time.Time),
 	}
 	s.fetchFn = func() error { return gitpkg.Fetch(s.repoDir) }
 	return s
@@ -763,6 +765,7 @@ func (s *Supervisor) sweepAllInactiveWorktrees() {
 	}
 	s.mu.Unlock()
 
+	const completionGrace = time.Hour
 	for _, j := range jobs {
 		if running[j.ID] {
 			continue // active agent; do not touch
@@ -773,12 +776,49 @@ func (s *Supervisor) sweepAllInactiveWorktrees() {
 		if !j.WorktreePath.Valid || j.WorktreePath.String == "" {
 			continue
 		}
+		// Spare recently-completed jobs so manual testing in the worktree
+		// (dev servers etc.) isn't nuked. Held worktrees are spared in Sweep itself.
+		var sparedReason string
+		switch {
+		case reaper.IsHeld(j.WorktreePath.String):
+			sparedReason = "hold-file"
+		case j.CompletedAt.Valid && time.Since(j.CompletedAt.Time) < completionGrace:
+			sparedReason = "grace"
+		}
+		if sparedReason != "" {
+			s.reportSpared(j, sparedReason)
+			continue
+		}
 		reaped, err := reaper.Sweep(j.WorktreePath.String)
 		if err != nil {
 			continue
 		}
 		s.reportReaped(reaped, j.ID, j.IssueNumber)
 	}
+}
+
+// reportSpared emits one event per ticker pass (throttled to once an hour
+// per job) when the reaper skips a worktree so users can see accumulating
+// held/recently-completed worktrees in the event stream.
+func (s *Supervisor) reportSpared(j *db.Job, reason string) {
+	s.mu.Lock()
+	last := s.sparedLogAt[j.ID]
+	if time.Since(last) < time.Hour {
+		s.mu.Unlock()
+		return
+	}
+	s.sparedLogAt[j.ID] = time.Now()
+	s.mu.Unlock()
+
+	age := ""
+	if j.CompletedAt.Valid {
+		age = fmt.Sprintf(" age=%s", time.Since(j.CompletedAt.Time).Truncate(time.Minute))
+	}
+	msg := fmt.Sprintf("[reaper] spared job#%d issue-%d reason=%s%s worktree=%s",
+		j.ID, j.IssueNumber, reason, age, j.WorktreePath.String)
+	s.emitEvent("spared", msg, j.ID)
+	debugLog("reaper spared", "job", j.ID, "issue", j.IssueNumber,
+		"reason", reason, "worktree", j.WorktreePath.String)
 }
 
 // reportReaped emits one event per killed process so the foreground CLI and


### PR DESCRIPTION
## Summary
- Reaper now respects a `.minder-hold` sentinel file and a 1h post-completion grace, so dev servers users start for manual testing of freshly-PR'd worktrees don't get nuked on the next 30s sweep tick.
- Supervisor emits a throttled `spared` event when the periodic sweep skips a worktree (held or within grace), so accumulating held/recent worktrees are visible in the event stream rather than silent.
- New `minder worktrees` lists every worktree under `~/.agent-minder/worktrees/` with status, completion age, on-disk size, and HOLD flag — sorted by size.
- New `minder worktrees prune --older-than 7d [--dry-run] [--status done,reviewed,bailed] [-y]` removes worktrees for completed jobs past the threshold, sparing held ones. On this machine the default surfaced ~32GB of reclaimable space across 43 worktrees.

The immediate post-agent sweep (`sweepJobWorktree`) is unchanged — it still cleans up stragglers right after the agent exits, only the periodic ticker sweep got the new safeguards.

## Test plan
- [x] `go test ./...` passes (new TestSweepRespectsHoldFile + existing reaper/supervisor suites)
- [x] `minder worktrees` shows live data on this machine (94.9GB / 101 worktrees)
- [x] `minder worktrees prune --older-than 7d --dry-run` previews removals with skip-reason summary
- [ ] After merge: `touch <worktree>/.minder-hold` on a freshly-PR'd job and confirm subsequent sweep emits a `spared` event instead of killing processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)