### PR TITLE
Define AgentRuntime contract for doer execution (#500)

### DIFF
--- a/design/agent-runtime.md
+++ b/design/agent-runtime.md
@@ -1,0 +1,74 @@
+# AgentRuntime contract
+
+Status: proposed. Lands with milestone 17. Codex is out of scope; gaps for Codex are tracked in milestone 18.
+
+## Purpose
+
+Extract the agent **doer** execution boundary so the supervisor stops knowing about Claude Code specifics (CLI flags, stream-json shape, `.claude/agents/` convention, `--resume`). After this lands, a second runtime can be added by implementing one interface in a sibling package.
+
+This is a refactor, not a feature. No user-visible behavior changes from #500 alone. The CLI flag (`--runtime claude-code`) ships in #504.
+
+## Non-goals
+
+- No Codex support. The contract is designed from current Claude Code usage. Gaps surfaced by milestone 18 are acceptable and will be addressed there.
+- No coverage of the "thinker" path (`internal/claudecli`). That package is used by depgraph and review-risk classification and is a separate, narrower boundary.
+- No changes to agent contracts (`.claude/agents/*.md` markdown format). Contracts remain Minder-defined; the runtime translates them at materialization time.
+- No anticipation of resume semantics for runtimes that lack sessions. The interface exposes `ErrNotSupported` and the caller falls back.
+
+## Interface
+
+See `internal/runtime/runtime.go` and `internal/runtime/types.go`. Summary:
+
+```go
+type AgentRuntime interface {
+    Name() string
+    PrepareAgentDef(ctx, ws, def) error
+    Run(ctx, inv, sink, logFile) (exitCode int, err error)
+    Resume(ctx, sessionID, sink, logFile) (exitCode int, err error)  // ErrNotSupported allowed
+    ParseResult(logPath) (*Result, error)
+    ClassifyOutcome(r, limits) Outcome
+    ExtractBailReport(r, logPath) *BailReport
+}
+```
+
+Supporting types: `Workspace`, `AgentDefinition`, `Invocation`, `Limits`, `Result`, `Outcome`, `BailReport`, `EventSink`.
+
+## Seam-by-seam mapping
+
+Each row maps an interface method to the current Claude-Code-shaped code it abstracts. The ClaudeRuntime implementation in #501 will move or wrap these.
+
+| Interface method | Current code | Notes |
+|---|---|---|
+| `PrepareAgentDef` | `ensureAgentDefByName` in `internal/supervisor/prompt.go:184` (called from `SlotContext.EnsureAgentDef` at `internal/supervisor/jobmanager.go:138`) | Writes `.claude/agents/<name>.md` into the worktree. Returns `AgentDefSource` today; the runtime swallows that. |
+| `Run` | `SlotContext.RunClaudeAgent` at `internal/supervisor/jobmanager.go:157` + `buildAgentArgs` at `internal/supervisor/prompt.go:324` + `scanStream` at `internal/supervisor/scanner.go:46` | The supervisor builds `[]string` Claude CLI args today; ClaudeRuntime owns that internally. Stream-json scanning becomes runtime-internal, with normalized events pushed to `EventSink`. |
+| `Resume` | Hard-coded `--resume <session_id>` at `internal/supervisor/jobmanager.go:527-531` | Currently always supported because we only have Claude. Becomes ClaudeRuntime-internal. |
+| `ParseResult` | `agentutil.ParseAgentLog` in `internal/agentutil/result.go:30` | The `AgentResult` struct is Claude's result-event shape. ClaudeRuntime adapts it to the normalized `Result`. |
+| `ClassifyOutcome` | `classifyOutcome` in `internal/supervisor/outcome.go:24` | Pure function over `(result, maxTurns, maxBudget)`. Largely lifts as-is, with the input switched to normalized `Result` + `Limits`. |
+| `ExtractBailReport` | `extractBailReport` and `extractBailReportFromLog` in `internal/supervisor/bail.go` | Knowledge of where the final text lives (Claude's `result.Result`) and the raw-log fallback are runtime-specific. The `<bail-report>` JSON parser inside is shared and stays in a common helper. |
+
+## Design decisions and rationale
+
+**EventSink instead of supervisor mutation.** Today `scanStream` directly writes to `supervisor.running[jobID].liveStatus`. That couples the runtime to supervisor internals. `EventSink` is a four-method interface the supervisor implements against its running-map. Runtime knows nothing about jobs, slots, or supervisors.
+
+**Resume is optional, not required.** Claude Code supports session resume; we don't know what Codex offers. The interface exposes `Resume`, and runtimes that lack it return `ErrNotSupported`. The supervisor's existing "re-run stage from scratch" fallback (already present in `jobmanager.go:532-536`) catches that case without losing function.
+
+**Bail-report extraction is runtime-shaped, not runtime-internal.** The `<bail-report>` JSON protocol is Minder-defined and the agent emits it on instruction from `prompt.go`. But *where* the final message lives, and what "scan the raw log" means, differ per runtime. `ExtractBailReport` is on the interface; the JSON parser (`bail.go`'s `unescapeJSONString` etc.) stays in a shared helper that runtimes call internally.
+
+**Tooling and system prompt as normalized strings.** `AllowedTools []string` and `SystemPrompt string` pass through as Minder's view; each runtime translates to its own gating and injection model. Claude maps `AllowedTools` to `--allowedTools`; Codex may map differently or ignore. Lossy translation is the runtime's problem.
+
+**`Result.Native` and `BailReport.Native` for forensics.** Both types include a raw `json.RawMessage` so the runtime-native data survives normalization. Used for debug logging and for diagnosing surprises in the wild.
+
+**`AgentDefinition.Body` is opaque bytes.** The runtime decides how to interpret the contract markdown. Today's `.claude/agents/<name>.md` form works because Claude Code reads frontmatter; Codex might extract a different subset. Keeping it opaque lets PrepareAgentDef do whatever materialization is right.
+
+## Deferred / open
+
+- **AgentDefinition source-of-truth.** Today contracts live in `.claude/agents/*.md` in the worktree and Minder's embedded defaults in `internal/supervisor/agents/`. The materialization step writes a worktree-local copy. This stays Claude-Code-shaped for now; Codex may want contracts in a different location (e.g., a temp file passed via env). PrepareAgentDef can do whatever it needs; no contract changes in #500.
+- **Timeout handling.** `Limits.Timeout` is on the interface but unused by the current supervisor (`internal/supervisor/jobmanager.go` does not currently set a deadline on the runtime call). ClaudeRuntime will ignore it. Wiring deferred until a real need surfaces.
+- **Cost reporting cadence.** `EventSink` currently fires only on assistant steps, tool boundaries, and usage limits. Cost is post-hoc via `ParseResult`. If we want live cost ticks for the TUI, add `OnCostUpdate(usd float64)` later. Out of scope for #500.
+
+## What's deliberately NOT in the contract
+
+- No method to list events from history. ParseResult is the only post-hoc accessor; if we need richer replay, add it when there's a caller.
+- No method for "is this runtime healthy" / preflight check. Add when needed.
+- No structured tool-use schema. `OnToolStart(name, inputSummary)` passes a displayable summary string; the supervisor doesn't need the parsed input. Structured tool data stays in the raw log via the `Native` field on `Result`.
+- No retry policy on the interface. Retry/backoff lives in the supervisor where it can coordinate across stages, not in the runtime.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// ErrNotSupported is returned by runtime methods for optional capabilities
+// (e.g., Resume) that a particular runtime does not implement. Callers must
+// handle this by falling back to a runtime-agnostic recovery path.
+var ErrNotSupported = errors.New("runtime: capability not supported")
+
+// AgentRuntime is the doer execution boundary. It abstracts the agent process,
+// its event stream, its result, and its outcome classification so the
+// supervisor can drive multiple runtimes through one contract.
+//
+// Lifecycle for a single stage:
+//
+//  1. PrepareAgentDef once per agent referenced by the stage pipeline.
+//  2. Run the invocation; events flow to sink, raw stream to logFile.
+//  3. ParseResult from logFile.
+//  4. ClassifyOutcome on the parsed result.
+//  5. If the outcome indicates the agent bailed, ExtractBailReport.
+//  6. On usage-limit recovery, Resume with the SessionID from step 3
+//     (or fall back to a fresh Run if the runtime returns ErrNotSupported).
+type AgentRuntime interface {
+	// Name identifies the runtime in logs, CLI flags, and stored metadata
+	// (e.g., "claude-code", "codex").
+	Name() string
+
+	// PrepareAgentDef materializes an agent definition into the workspace in
+	// whatever form this runtime expects (e.g., .claude/agents/<name>.md for
+	// Claude Code). Idempotent. Called once per agent before Run.
+	PrepareAgentDef(ctx context.Context, ws Workspace, def AgentDefinition) error
+
+	// Run executes the agent until exit. Normalized events are pushed to sink
+	// as they happen. The raw runtime-native stream is written to logFile for
+	// forensics and post-hoc parsing by ParseResult.
+	//
+	// exitCode is the underlying process exit code; err is non-nil only on
+	// failures to start, pipe, or wait on the process (not on agent-level
+	// errors, which are surfaced via ParseResult).
+	Run(ctx context.Context, inv Invocation, sink EventSink, logFile io.Writer) (exitCode int, err error)
+
+	// Resume restarts a prior session by ID, typically after a usage-limit
+	// wait. The runtime continues writing to logFile and pushing to sink as
+	// in Run.
+	//
+	// Runtimes that do not support session resume must return ErrNotSupported.
+	// The caller will fall back to a fresh Run.
+	Resume(ctx context.Context, sessionID string, sink EventSink, logFile io.Writer) (exitCode int, err error)
+
+	// ParseResult reads the raw log written by Run/Resume and extracts the
+	// normalized final result. Returns (nil, nil) if no result event is found
+	// (e.g., the agent crashed before emitting one).
+	ParseResult(logPath string) (*Result, error)
+
+	// ClassifyOutcome maps a Result against the run's Limits to a normalized
+	// Outcome. An empty Outcome.Status means no failure was detected and the
+	// caller should proceed (e.g., check for a PR).
+	ClassifyOutcome(r *Result, limits Limits) Outcome
+
+	// ExtractBailReport finds the <bail-report> JSON the agent embeds in its
+	// final message. The runtime knows where the final message lives (Claude's
+	// result.Result vs. the equivalent for other runtimes) and falls back to
+	// scanning the raw log. Returns nil if no report is present.
+	ExtractBailReport(r *Result, logPath string) *BailReport
+}

--- a/internal/runtime/types.go
+++ b/internal/runtime/types.go
@@ -1,0 +1,100 @@
+// Package runtime defines the doer execution boundary for agent-minder.
+//
+// An AgentRuntime adapts a concrete agent process (Claude Code, Codex, etc.)
+// to the contract the supervisor expects: prepare an agent definition,
+// run a single invocation, normalize the event stream, parse the result,
+// and classify the outcome.
+//
+// This package contains the interface and supporting types only. Concrete
+// runtimes live in sibling packages (e.g., internal/runtime/claudecode).
+package runtime
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Workspace is the directory the runtime executes in. For worktree-using
+// agents this is the worktree path; for non-worktree agents (output: issue
+// or comment) it is the repo root.
+type Workspace struct {
+	Dir string
+}
+
+// AgentDefinition is a runtime-agnostic agent contract that PrepareAgentDef
+// translates into the runtime's native on-disk form.
+type AgentDefinition struct {
+	Name   string // contract identifier, e.g. "autopilot"
+	Source string // origin path or label, for diagnostics
+	Body   []byte // raw contract body (frontmatter + markdown)
+}
+
+// Invocation is a fully-specified single run request.
+type Invocation struct {
+	Workspace    Workspace
+	AgentName    string   // must match a prior PrepareAgentDef
+	Prompt       string   // assembled user prompt / context
+	SystemPrompt string   // optional system-prompt append (e.g., lessons)
+	AllowedTools []string // runtime translates to its own gating; may ignore
+	Limits       Limits
+	Env          map[string]string // additional env vars (e.g., GITHUB_TOKEN)
+}
+
+// Limits caps a single run. A zero value means no cap (runtime default).
+type Limits struct {
+	MaxTurns     int
+	MaxBudgetUSD float64
+	Timeout      time.Duration
+}
+
+// Result is the normalized post-run summary parsed from the runtime log.
+type Result struct {
+	SessionID         string // for Resume; empty if runtime has no session concept
+	NumTurns          int
+	TotalCostUSD      float64
+	FinalText         string // last assistant message text (where bail-report lives)
+	IsError           bool
+	StopReason        string
+	PermissionDenials []string
+	Native            json.RawMessage // raw runtime-native result event, for debugging
+}
+
+// Outcome categorizes a Result against the run's Limits.
+//
+// Status values:
+//   - ""        no failure detected
+//   - "warning" non-fatal issue (e.g., permission denials); caller should still check for a PR
+//   - "failed"  fatal failure
+type Outcome struct {
+	Status        string
+	FailureReason string // "max_turns" | "max_budget" | "error" | "permissions" | ...
+	FailureDetail string
+}
+
+// BailReport is the Minder-defined <bail-report> JSON the agent emits when it
+// decides it cannot complete the work. The shape is runtime-agnostic; runtimes
+// know where to look for it (final message vs. raw log scan).
+type BailReport struct {
+	Reason string          // agent-supplied category
+	Detail string          // agent-supplied free text
+	Native json.RawMessage // raw JSON block, for forensics
+}
+
+// EventSink receives normalized events as the agent runs. Implementations
+// must be safe to call from the runtime's reader goroutine.
+type EventSink interface {
+	// OnAssistantStep is called once per assistant message.
+	OnAssistantStep()
+
+	// OnToolStart is called when the agent begins a tool call.
+	// inputSummary is a truncated, displayable summary of the tool input.
+	OnToolStart(name, inputSummary string)
+
+	// OnToolEnd is called when an assistant message has no further tool_use
+	// (the agent is idle or has finished).
+	OnToolEnd()
+
+	// OnUsageLimit is called when the runtime detects a rate limit, billing
+	// error, or other usage-limit signal mid-run.
+	OnUsageLimit()
+}


### PR DESCRIPTION
## Summary
- Adds `internal/runtime` package with the `AgentRuntime` interface and supporting types (`Workspace`, `AgentDefinition`, `Invocation`, `Limits`, `Result`, `Outcome`, `BailReport`, `EventSink`).
- Adds `design/agent-runtime.md` with seam-by-seam mapping to current Claude-Code-shaped code, design rationale, and deferred/non-goal items.
- No implementations and no call site changes. ClaudeRuntime lands in #501; supervisor wiring in #502; CLI runtime flag in #504.

Closes #500. Part of milestone 17.

## Design choices (see design doc for rationale)
- `EventSink` interface decouples runtime from supervisor internals.
- `Resume` is optional; runtimes without sessions return `ErrNotSupported` and the supervisor falls back to a fresh run.
- `ExtractBailReport` is on the runtime (knows where the final message lives); the JSON parser stays shared.
- `AllowedTools` and `SystemPrompt` pass through as normalized strings; each runtime translates.
- `Result.Native` and `BailReport.Native` preserve raw runtime data for forensics.

## Test plan
- [x] `go build ./internal/runtime/...` passes
- [x] `go vet ./internal/runtime/...` clean
- [x] `go test ./...` passes (interface-only addition, no existing code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)