### PR TITLE
Add ClaudeRuntime adapter for runtime.AgentRuntime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **ClaudeRuntime adapter**: New `internal/runtime/claudecode` package implements the `runtime.AgentRuntime` contract for the Claude Code CLI. Encapsulates command-arg construction (`--agent`, `-p`, `--output-format stream-json`, `--max-turns`, `--max-budget-usd`, `--allowedTools`, `--append-system-prompt`), `.claude/agents/<name>.md` materialization, stream-json scanning with normalized `EventSink` callbacks (tool start/end, assistant step, usage limit), result-event parsing into `runtime.Result`, outcome classification against `runtime.Limits`, and `<bail-report>` extraction from final text with raw-log fallback. Session resume via `--resume`. Not yet wired into the supervisor (see #502 / #504). (#501)
 - **PR build artifacts in CI**: CI workflow now builds the `minder` binary on `ubuntu-latest` and `macos-latest`, uploading per-OS artifacts on pull request builds via `actions/upload-artifact@v4` so reviewers can download a binary without compiling locally. Retention is 14 days. (#477)
 - **Weekly cron schedules for proactive agents**: Built-in agent definitions now include default cron schedules (weekly dependency checks, security scans, doc updates) (#431)
 - **Repo-level agent defs and overnight cron jobs**: Agent definitions can be stored in repos at `.claude/agents/` and discovered at deploy time; overnight cron scheduling for proactive agents (#375)

--- a/internal/runtime/claudecode/bail.go
+++ b/internal/runtime/claudecode/bail.go
@@ -1,0 +1,113 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+// bailAssessment is the wire shape the agent emits inside <bail-report> tags.
+// Mirrors `supervisor.BailAssessment`; kept private to the runtime to avoid a
+// supervisor dependency.
+type bailAssessment struct {
+	Reason        string   `json:"reason"`
+	FilesExamined []string `json:"files_examined"`
+	Plan          string   `json:"plan"`
+	SubIssues     []string `json:"sub_issues,omitempty"`
+	Complexity    string   `json:"complexity"`
+}
+
+// maxLogScanBytes caps the raw-log fallback scan to the tail of the log to
+// avoid quadratic strings.LastIndex work on multi-megabyte logs.
+const maxLogScanBytes = 200_000
+
+// extractBailReportFromText finds the last well-formed <bail-report>…</bail-report>
+// JSON block in text and returns it as a runtime.BailReport.
+//
+// Search proceeds from the end of the string so a backtick-quoted
+// `<bail-report>` mentioned earlier in the message doesn't shadow the real
+// final-message block.
+//
+// Handles up to three levels of JSON-string escaping — bail reports embedded in
+// stream-json `assistant.text` blocks can be escaped multiple times depending
+// on how the agent emitted them (direct text vs. tool-use argument).
+func extractBailReportFromText(text string) *runtime.BailReport {
+	const openTag = "<bail-report>"
+	const closeTag = "</bail-report>"
+
+	searchFrom := len(text)
+	for {
+		end := strings.LastIndex(text[:searchFrom], closeTag)
+		if end < 0 {
+			return nil
+		}
+		start := strings.LastIndex(text[:end], openTag)
+		if start < 0 {
+			return nil
+		}
+		body := strings.TrimSpace(text[start+len(openTag) : end])
+		if rep := tryParseBail(body); rep != nil {
+			return rep
+		}
+		searchFrom = end
+	}
+}
+
+// extractBailReportFromLog reads the tail of a stream-json log file and
+// searches for a <bail-report> block. Used as a fallback when the report did
+// not appear in the agent's final text (e.g., the agent piped the report into
+// `gh issue comment --body-file` via a tool call).
+//
+// Returns nil if the log can't be read or contains no valid report.
+func extractBailReportFromLog(logPath string) *runtime.BailReport {
+	if logPath == "" {
+		return nil
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return nil
+	}
+	content := string(data)
+	if len(content) > maxLogScanBytes {
+		content = content[len(content)-maxLogScanBytes:]
+	}
+	return extractBailReportFromText(content)
+}
+
+// tryParseBail attempts to parse a JSON bail report, unescaping up to three
+// levels of JSON-string encoding before giving up.
+func tryParseBail(s string) *runtime.BailReport {
+	current := s
+	for range 3 {
+		current = strings.TrimSpace(current)
+		var a bailAssessment
+		if err := json.Unmarshal([]byte(current), &a); err == nil {
+			raw := append(json.RawMessage(nil), []byte(current)...)
+			return &runtime.BailReport{
+				Reason: a.Reason,
+				Detail: a.Plan,
+				Native: raw,
+			}
+		}
+		unescaped := jsonUnescape(current)
+		if unescaped == current {
+			return nil
+		}
+		current = unescaped
+	}
+	return nil
+}
+
+// jsonUnescape applies one level of JSON-string unescaping by wrapping s in
+// quotes and asking encoding/json to parse it. Returns s unchanged if the
+// result isn't a valid quoted string.
+func jsonUnescape(s string) string {
+	quoted := `"` + s + `"`
+	var out string
+	if err := json.Unmarshal([]byte(quoted), &out); err == nil {
+		return out
+	}
+	return s
+}

--- a/internal/runtime/claudecode/claudecode.go
+++ b/internal/runtime/claudecode/claudecode.go
@@ -1,0 +1,273 @@
+// Package claudecode is the Claude Code implementation of runtime.AgentRuntime.
+//
+// It wraps the `claude` CLI (`claude --agent <name> -p --output-format stream-json`),
+// materializes agent definitions as `.claude/agents/<name>.md`, scans stream-json
+// for live tool/step events, parses the final result event, classifies the outcome
+// against the run's Limits, and extracts the Minder-defined <bail-report> JSON from
+// the final assistant message (with raw-log fallback).
+//
+// No supervisor types leak into this package — translation happens at the seam.
+package claudecode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+// Name is the canonical identifier for this runtime.
+const Name = "claude-code"
+
+// ClaudeRuntime implements runtime.AgentRuntime for the Claude Code CLI.
+//
+// All fields are optional. The zero value uses the `claude` binary on PATH and
+// the system environment.
+type ClaudeRuntime struct {
+	// Bin overrides the path to the claude binary (default: "claude").
+	Bin string
+}
+
+// New constructs a ClaudeRuntime with default settings.
+func New() *ClaudeRuntime { return &ClaudeRuntime{} }
+
+// Name returns the runtime identifier.
+func (c *ClaudeRuntime) Name() string { return Name }
+
+// binPath returns the configured binary path or the default.
+func (c *ClaudeRuntime) binPath() string {
+	if c.Bin != "" {
+		return c.Bin
+	}
+	return "claude"
+}
+
+// PrepareAgentDef writes the agent definition body to
+// `<workspace>/.claude/agents/<name>.md`. Idempotent: overwrites if the file
+// already exists so updates to the embedded contract are picked up.
+//
+// If the workspace directory is empty (non-worktree agents that run from the
+// repo root with no PrepareAgentDef step), this is a no-op.
+func (c *ClaudeRuntime) PrepareAgentDef(_ context.Context, ws runtime.Workspace, def runtime.AgentDefinition) error {
+	if ws.Dir == "" {
+		return nil
+	}
+	if def.Name == "" {
+		return fmt.Errorf("claudecode: PrepareAgentDef: empty agent name")
+	}
+	if len(def.Body) == 0 {
+		return fmt.Errorf("claudecode: PrepareAgentDef: empty body for %q", def.Name)
+	}
+	dir := filepath.Join(ws.Dir, ".claude", "agents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("claudecode: create agent dir: %w", err)
+	}
+	path := filepath.Join(dir, def.Name+".md")
+	if err := os.WriteFile(path, def.Body, 0o644); err != nil {
+		return fmt.Errorf("claudecode: write agent def: %w", err)
+	}
+	return nil
+}
+
+// Run executes `claude --agent <name> -p --output-format stream-json ...`,
+// streams stream-json lines to logFile, and forwards normalized events to sink.
+//
+// The process inherits the parent environment, then applies inv.Env on top.
+// GITHUB_TOKEN and similar credentials should be passed via inv.Env.
+func (c *ClaudeRuntime) Run(ctx context.Context, inv runtime.Invocation, sink runtime.EventSink, logFile io.Writer) (int, error) {
+	args := buildArgs(inv)
+	return c.exec(ctx, args, inv.Workspace.Dir, inv.Env, sink, logFile)
+}
+
+// Resume restarts a session by ID using `claude --resume <id> --output-format stream-json`.
+// Workspace, env, and event-sink semantics match Run.
+//
+// Resume does not re-apply the agent name, prompt, system prompt, allowed tools,
+// or limits — the resumed session already has them. Callers that need fresh
+// limits or a different prompt should use Run.
+func (c *ClaudeRuntime) Resume(ctx context.Context, sessionID string, sink runtime.EventSink, logFile io.Writer) (int, error) {
+	if sessionID == "" {
+		return 0, fmt.Errorf("claudecode: Resume: empty session id")
+	}
+	args := []string{"--resume", sessionID, "--output-format", "stream-json", "--verbose"}
+	// Workspace and env are unknown at Resume time; the caller's working dir is
+	// used. This matches today's supervisor behavior, which calls --resume from
+	// the same SlotContext that ran the original stage.
+	return c.exec(ctx, args, "", nil, sink, logFile)
+}
+
+// exec is the shared process-runner used by Run and Resume. It pipes stdout
+// through the stream scanner (which writes lossless lines to logFile and pushes
+// normalized events to sink) and waits for the process to exit.
+func (c *ClaudeRuntime) exec(ctx context.Context, args []string, workDir string, env map[string]string, sink runtime.EventSink, logFile io.Writer) (int, error) {
+	cmd := exec.CommandContext(ctx, c.binPath(), args...)
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+	cmd.Stderr = logFile
+
+	if len(env) > 0 {
+		cmd.Env = os.Environ()
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return 0, fmt.Errorf("claudecode: stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("claudecode: start: %w", err)
+	}
+
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+		scanStream(stdout, logFile, sink)
+	}()
+
+	waitErr := cmd.Wait()
+	<-scanDone
+
+	exitCode := 0
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return 0, fmt.Errorf("claudecode: wait: %w", waitErr)
+		}
+	}
+	return exitCode, nil
+}
+
+// buildArgs constructs the CLI argv for a fresh Run.
+//
+// Effective flags (matching the supervisor's current invocation in
+// `internal/supervisor/prompt.go:buildAgentArgs`):
+//
+//	--agent <name> -p --output-format stream-json --verbose
+//	--max-turns N --max-budget-usd F --allowedTools <csv>
+//	[--append-system-prompt <text>]
+//	-- <prompt>
+func buildArgs(inv runtime.Invocation) []string {
+	args := []string{
+		"--agent", inv.AgentName,
+		"-p",
+		"--output-format", "stream-json",
+		"--verbose",
+	}
+	if inv.Limits.MaxTurns > 0 {
+		args = append(args, "--max-turns", strconv.Itoa(inv.Limits.MaxTurns))
+	}
+	if inv.Limits.MaxBudgetUSD > 0 {
+		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", inv.Limits.MaxBudgetUSD))
+	}
+	if len(inv.AllowedTools) > 0 {
+		args = append(args, "--allowedTools", strings.Join(inv.AllowedTools, ","))
+	}
+	if inv.SystemPrompt != "" {
+		args = append(args, "--append-system-prompt", inv.SystemPrompt)
+	}
+	args = append(args, "--", inv.Prompt)
+	return args
+}
+
+// ParseResult reads a Claude Code stream-json log and extracts the result event,
+// returning a normalized runtime.Result.
+//
+// Returns (nil, nil) if logPath is empty or contains no result event (e.g., the
+// agent crashed before emitting one).
+func (c *ClaudeRuntime) ParseResult(logPath string) (*runtime.Result, error) {
+	evt, raw, err := readResultEvent(logPath)
+	if err != nil {
+		return nil, err
+	}
+	if evt == nil {
+		return nil, nil
+	}
+
+	denials := make([]string, 0, len(evt.PermissionDenials))
+	for _, d := range evt.PermissionDenials {
+		denials = append(denials, string(d))
+	}
+
+	return &runtime.Result{
+		SessionID:         evt.SessionID,
+		NumTurns:          evt.NumTurns,
+		TotalCostUSD:      evt.TotalCost,
+		FinalText:         evt.Result,
+		IsError:           evt.IsError,
+		StopReason:        string(evt.StopReason),
+		PermissionDenials: denials,
+		Native:            raw,
+	}, nil
+}
+
+// ClassifyOutcome maps a Result + Limits to a normalized Outcome.
+//
+// Lifts the existing logic from `internal/supervisor/outcome.go:classifyOutcome`:
+// turn-limit exhaustion, budget exhaustion (>=95%), explicit error flag, then
+// permission denials as a non-fatal warning.
+//
+// An empty Outcome.Status means no failure was detected and the caller should
+// proceed (e.g., check for a PR).
+func (c *ClaudeRuntime) ClassifyOutcome(r *runtime.Result, limits runtime.Limits) runtime.Outcome {
+	if r == nil {
+		return runtime.Outcome{}
+	}
+
+	if limits.MaxTurns > 0 && r.NumTurns >= limits.MaxTurns {
+		return runtime.Outcome{
+			Status:        "failed",
+			FailureReason: "max_turns",
+			FailureDetail: fmt.Sprintf("used %d of %d turns", r.NumTurns, limits.MaxTurns),
+		}
+	}
+
+	if limits.MaxBudgetUSD > 0 && r.TotalCostUSD >= limits.MaxBudgetUSD*0.95 {
+		return runtime.Outcome{
+			Status:        "failed",
+			FailureReason: "max_budget",
+			FailureDetail: fmt.Sprintf("spent $%.2f of $%.2f budget", r.TotalCostUSD, limits.MaxBudgetUSD),
+		}
+	}
+
+	if r.IsError {
+		detail := r.FinalText
+		if len(detail) > 500 {
+			detail = detail[:500] + "..."
+		}
+		return runtime.Outcome{Status: "failed", FailureReason: "error", FailureDetail: detail}
+	}
+
+	if len(r.PermissionDenials) > 0 {
+		detail, _ := json.Marshal(r.PermissionDenials)
+		return runtime.Outcome{Status: "warning", FailureReason: "permissions", FailureDetail: string(detail)}
+	}
+
+	return runtime.Outcome{}
+}
+
+// ExtractBailReport finds a <bail-report> JSON block, first in the result's
+// FinalText (where the agent is instructed to emit it) and then by scanning the
+// raw stream-json log (the agent may have embedded it in a tool call such as
+// `gh issue comment --body-file`).
+//
+// Returns nil if no valid report is present.
+func (c *ClaudeRuntime) ExtractBailReport(r *runtime.Result, logPath string) *runtime.BailReport {
+	if r != nil && r.FinalText != "" {
+		if rep := extractBailReportFromText(r.FinalText); rep != nil {
+			return rep
+		}
+	}
+	return extractBailReportFromLog(logPath)
+}

--- a/internal/runtime/claudecode/claudecode_test.go
+++ b/internal/runtime/claudecode/claudecode_test.go
@@ -1,0 +1,411 @@
+package claudecode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+func TestName(t *testing.T) {
+	if got := (&ClaudeRuntime{}).Name(); got != "claude-code" {
+		t.Errorf("Name() = %q, want %q", got, "claude-code")
+	}
+}
+
+func TestPrepareAgentDef_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+	r := New()
+	body := []byte("---\nname: autopilot\n---\nhello")
+	err := r.PrepareAgentDef(context.Background(), runtime.Workspace{Dir: dir}, runtime.AgentDefinition{
+		Name: "autopilot",
+		Body: body,
+	})
+	if err != nil {
+		t.Fatalf("PrepareAgentDef: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".claude", "agents", "autopilot.md"))
+	if err != nil {
+		t.Fatalf("read written def: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("written body = %q, want %q", got, body)
+	}
+}
+
+func TestPrepareAgentDef_NoWorkspace(t *testing.T) {
+	r := New()
+	err := r.PrepareAgentDef(context.Background(), runtime.Workspace{}, runtime.AgentDefinition{Name: "x", Body: []byte("y")})
+	if err != nil {
+		t.Errorf("expected nil for empty workspace, got %v", err)
+	}
+}
+
+func TestPrepareAgentDef_Errors(t *testing.T) {
+	r := New()
+	ctx := context.Background()
+	dir := t.TempDir()
+	if err := r.PrepareAgentDef(ctx, runtime.Workspace{Dir: dir}, runtime.AgentDefinition{Name: "", Body: []byte("x")}); err == nil {
+		t.Error("expected error for empty name")
+	}
+	if err := r.PrepareAgentDef(ctx, runtime.Workspace{Dir: dir}, runtime.AgentDefinition{Name: "x", Body: nil}); err == nil {
+		t.Error("expected error for empty body")
+	}
+}
+
+func TestBuildArgs(t *testing.T) {
+	args := buildArgs(runtime.Invocation{
+		AgentName:    "autopilot",
+		Prompt:       "do the thing",
+		SystemPrompt: "lessons here",
+		AllowedTools: []string{"Read", "Edit", "Bash(git:*)"},
+		Limits:       runtime.Limits{MaxTurns: 50, MaxBudgetUSD: 2.50},
+	})
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"--agent autopilot",
+		"-p",
+		"--output-format stream-json",
+		"--verbose",
+		"--max-turns 50",
+		"--max-budget-usd 2.50",
+		"--allowedTools Read,Edit,Bash(git:*)",
+		"--append-system-prompt lessons here",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q: %v", want, args)
+		}
+	}
+	// Prompt must come last after the `--` separator.
+	if args[len(args)-1] != "do the thing" || args[len(args)-2] != "--" {
+		t.Errorf("expected prompt to follow `--` at end: %v", args[len(args)-3:])
+	}
+}
+
+func TestBuildArgs_OmitsZeroLimits(t *testing.T) {
+	args := buildArgs(runtime.Invocation{AgentName: "x", Prompt: "p"})
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--max-turns") {
+		t.Errorf("zero MaxTurns should not emit flag: %v", args)
+	}
+	if strings.Contains(joined, "--max-budget-usd") {
+		t.Errorf("zero MaxBudgetUSD should not emit flag: %v", args)
+	}
+	if strings.Contains(joined, "--allowedTools") {
+		t.Errorf("empty AllowedTools should not emit flag: %v", args)
+	}
+	if strings.Contains(joined, "--append-system-prompt") {
+		t.Errorf("empty SystemPrompt should not emit flag: %v", args)
+	}
+}
+
+func TestClassifyOutcome(t *testing.T) {
+	r := New()
+
+	tests := []struct {
+		name   string
+		result *runtime.Result
+		limits runtime.Limits
+		want   runtime.Outcome
+	}{
+		{
+			name:   "nil result",
+			result: nil,
+			want:   runtime.Outcome{},
+		},
+		{
+			name:   "no failure",
+			result: &runtime.Result{NumTurns: 5, TotalCostUSD: 0.10},
+			limits: runtime.Limits{MaxTurns: 50, MaxBudgetUSD: 2.50},
+			want:   runtime.Outcome{},
+		},
+		{
+			name:   "turn limit hit",
+			result: &runtime.Result{NumTurns: 50},
+			limits: runtime.Limits{MaxTurns: 50},
+			want:   runtime.Outcome{Status: "failed", FailureReason: "max_turns", FailureDetail: "used 50 of 50 turns"},
+		},
+		{
+			name:   "budget hit at 95%",
+			result: &runtime.Result{TotalCostUSD: 2.40},
+			limits: runtime.Limits{MaxBudgetUSD: 2.50},
+			want:   runtime.Outcome{Status: "failed", FailureReason: "max_budget", FailureDetail: "spent $2.40 of $2.50 budget"},
+		},
+		{
+			name:   "error flag",
+			result: &runtime.Result{IsError: true, FinalText: "boom"},
+			want:   runtime.Outcome{Status: "failed", FailureReason: "error", FailureDetail: "boom"},
+		},
+		{
+			name:   "permission denials warning",
+			result: &runtime.Result{PermissionDenials: []string{`"tool":"X"`}},
+			want:   runtime.Outcome{Status: "warning", FailureReason: "permissions", FailureDetail: `["\"tool\":\"X\""]`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.ClassifyOutcome(tt.result, tt.limits)
+			if got != tt.want {
+				t.Errorf("got %+v\nwant %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseResult(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "log.jsonl")
+	// One assistant event, then a result.
+	lines := []string{
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`,
+		`{"type":"result","subtype":"success","is_error":false,"num_turns":3,"total_cost_usd":0.42,"session_id":"abc-123","result":"all done"}`,
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := New()
+	got, err := r.ParseResult(logPath)
+	if err != nil {
+		t.Fatalf("ParseResult: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if got.SessionID != "abc-123" {
+		t.Errorf("SessionID = %q, want abc-123", got.SessionID)
+	}
+	if got.NumTurns != 3 {
+		t.Errorf("NumTurns = %d, want 3", got.NumTurns)
+	}
+	if got.TotalCostUSD != 0.42 {
+		t.Errorf("TotalCostUSD = %v, want 0.42", got.TotalCostUSD)
+	}
+	if got.FinalText != "all done" {
+		t.Errorf("FinalText = %q", got.FinalText)
+	}
+	if len(got.Native) == 0 {
+		t.Error("Native raw is empty")
+	}
+}
+
+func TestParseResult_EmptyPathReturnsNil(t *testing.T) {
+	got, err := New().ParseResult("")
+	if err != nil || got != nil {
+		t.Errorf("ParseResult(\"\") = (%v, %v), want (nil, nil)", got, err)
+	}
+}
+
+// TestExtractBailReport_StreamJSONLog is the issue's required acceptance test:
+// bail-report extraction from a representative stream-json log fixture.
+//
+// The fixture mimics the real shape: a system init, an assistant tool call that
+// is unrelated, then a final assistant text block containing the bail-report
+// tags, and finally a result event whose `result` field also carries the bail
+// text. We assert extraction works both from the parsed Result and from the
+// raw-log fallback (after stripping result.result to force the fallback path).
+func TestExtractBailReport_StreamJSONLog(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.jsonl")
+
+	bailJSON := `{
+  "reason": "Issue requires design decisions not specified",
+  "files_examined": ["internal/auth/handler.go", "internal/auth/middleware.go"],
+  "plan": "1. Define new auth flow\n2. Update middleware\n3. Add tests",
+  "sub_issues": ["Refactor middleware", "Add JWT validation tests"],
+  "complexity": "large"
+}`
+	finalText := "I explored the codebase but cannot complete this.\n\n<bail-report>\n" + bailJSON + "\n</bail-report>"
+
+	// Write a stream-json log including a final assistant text block, then the
+	// result event with the bail report in `result`. We hand-build the lines
+	// with json.Marshal so escaping stays valid.
+	type contentBlock struct {
+		Type string `json:"type"`
+		Text string `json:"text,omitempty"`
+		Name string `json:"name,omitempty"`
+	}
+	type message struct {
+		Content []contentBlock `json:"content"`
+	}
+	type event struct {
+		Type     string  `json:"type"`
+		Subtype  string  `json:"subtype,omitempty"`
+		Message  message `json:"message,omitempty"`
+		IsError  bool    `json:"is_error,omitempty"`
+		NumTurns int     `json:"num_turns,omitempty"`
+		Cost     float64 `json:"total_cost_usd,omitempty"`
+		Result   string  `json:"result,omitempty"`
+		Session  string  `json:"session_id,omitempty"`
+	}
+
+	// Use a non-HTML-escaping encoder so `<bail-report>` survives literally in
+	// the raw log — matching real Claude CLI output.
+	encode := func(v any) string {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(v); err != nil {
+			t.Fatal(err)
+		}
+		return strings.TrimRight(buf.String(), "\n")
+	}
+	encodeString := func(s string) string {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(s); err != nil {
+			t.Fatal(err)
+		}
+		return strings.TrimRight(buf.String(), "\n")
+	}
+
+	lines := []string{
+		encode(event{Type: "system", Subtype: "init"}),
+		encode(event{Type: "assistant", Message: message{Content: []contentBlock{{Type: "text", Text: "thinking..."}}}}),
+		encode(event{Type: "assistant", Message: message{Content: []contentBlock{{Type: "text", Text: finalText}}}}),
+		// Result event carries the bail report in result, like Claude does.
+		`{"type":"result","subtype":"success","is_error":false,"num_turns":4,"total_cost_usd":0.31,"session_id":"sess-9","result":` + encodeString(finalText) + `}`,
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := New()
+
+	// Path 1: extract from parsed result FinalText.
+	parsed, err := r.ParseResult(logPath)
+	if err != nil {
+		t.Fatalf("ParseResult: %v", err)
+	}
+	if parsed == nil {
+		t.Fatal("expected parsed result")
+	}
+	rep := r.ExtractBailReport(parsed, logPath)
+	if rep == nil {
+		t.Fatal("expected bail report from FinalText, got nil")
+	}
+	if rep.Reason != "Issue requires design decisions not specified" {
+		t.Errorf("Reason = %q", rep.Reason)
+	}
+	if !strings.Contains(rep.Detail, "Update middleware") {
+		t.Errorf("Detail missing plan content: %q", rep.Detail)
+	}
+	if len(rep.Native) == 0 {
+		t.Error("Native raw bail JSON is empty")
+	}
+	// Native should round-trip back to a JSON object with reason set.
+	var probe map[string]any
+	if err := json.Unmarshal(rep.Native, &probe); err != nil {
+		t.Errorf("Native JSON invalid: %v", err)
+	} else if probe["reason"] != "Issue requires design decisions not specified" {
+		t.Errorf("Native reason mismatch: %v", probe["reason"])
+	}
+
+	// Path 2: force the raw-log fallback by clearing FinalText.
+	parsed.FinalText = ""
+	rep2 := r.ExtractBailReport(parsed, logPath)
+	if rep2 == nil {
+		t.Fatal("expected bail report via raw-log fallback, got nil")
+	}
+	if rep2.Reason != rep.Reason {
+		t.Errorf("fallback Reason = %q, want %q", rep2.Reason, rep.Reason)
+	}
+}
+
+func TestExtractBailReport_NoReport(t *testing.T) {
+	r := New()
+	if got := r.ExtractBailReport(&runtime.Result{FinalText: "no bail here"}, ""); got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+	if got := r.ExtractBailReport(nil, ""); got != nil {
+		t.Errorf("expected nil for nil result + empty path, got %+v", got)
+	}
+}
+
+func TestExtractBailReport_LastMatchedPairWins(t *testing.T) {
+	// A backtick-quoted mention of <bail-report> earlier in the message must
+	// not shadow a real, well-formed report at the end.
+	final := "Discussing the `<bail-report>` protocol earlier. " +
+		"<bail-report>not valid json</bail-report> " +
+		"\n\n<bail-report>\n" +
+		`{"reason":"real bail","files_examined":[],"plan":"do x","complexity":"small"}` +
+		"\n</bail-report>"
+	rep := extractBailReportFromText(final)
+	if rep == nil {
+		t.Fatal("expected report, got nil")
+	}
+	if rep.Reason != "real bail" {
+		t.Errorf("Reason = %q, want real bail", rep.Reason)
+	}
+}
+
+// stubSink records the calls made by scanStream so we can assert event
+// normalization end-to-end.
+type stubSink struct {
+	steps       int
+	toolStarts  []string
+	toolEnds    int
+	usageLimits int
+}
+
+func (s *stubSink) OnAssistantStep()           { s.steps++ }
+func (s *stubSink) OnToolStart(name, _ string) { s.toolStarts = append(s.toolStarts, name) }
+func (s *stubSink) OnToolEnd()                 { s.toolEnds++ }
+func (s *stubSink) OnUsageLimit()              { s.usageLimits++ }
+
+func TestScanStream_NormalizesEvents(t *testing.T) {
+	lines := []string{
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`,
+		`{"type":"system","subtype":"api_retry","error":"rate_limit","error_status":429}`,
+		`{"type":"result","subtype":"success","is_error":false,"num_turns":2}`,
+	}
+	input := strings.Join(lines, "\n") + "\n"
+
+	var logBuf bytes.Buffer
+	sink := &stubSink{}
+	scanStream(strings.NewReader(input), &logBuf, sink)
+
+	if sink.steps != 2 {
+		t.Errorf("assistant steps = %d, want 2", sink.steps)
+	}
+	if len(sink.toolStarts) != 1 || sink.toolStarts[0] != "Bash" {
+		t.Errorf("toolStarts = %v, want [Bash]", sink.toolStarts)
+	}
+	// One OnToolEnd for the no-tool assistant message, one for the result.
+	if sink.toolEnds != 2 {
+		t.Errorf("toolEnds = %d, want 2", sink.toolEnds)
+	}
+	if sink.usageLimits != 1 {
+		t.Errorf("usageLimits = %d, want 1", sink.usageLimits)
+	}
+	if logBuf.Len() != len(input) {
+		t.Errorf("log buffer len = %d, want %d (lossless mirror)", logBuf.Len(), len(input))
+	}
+}
+
+func TestScanStream_NilSink(t *testing.T) {
+	// nil sink must not panic; raw lines still mirror to logFile.
+	input := `{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n"
+	var buf bytes.Buffer
+	scanStream(strings.NewReader(input), &buf, nil)
+	if buf.String() != input {
+		t.Errorf("log buf = %q, want %q", buf.String(), input)
+	}
+}
+
+func TestResume_EmptySessionID(t *testing.T) {
+	_, err := New().Resume(context.Background(), "", nil, nil)
+	if err == nil {
+		t.Error("expected error for empty session id")
+	}
+}

--- a/internal/runtime/claudecode/scanner.go
+++ b/internal/runtime/claudecode/scanner.go
@@ -1,0 +1,185 @@
+package claudecode
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+// claudeResultEvent is the Claude Code stream-json result event shape.
+//
+// This mirrors `internal/agentutil.AgentResult` but stays internal to the
+// runtime so changes to Claude's wire format don't leak into supervisor code.
+type claudeResultEvent struct {
+	SubType           string            `json:"subtype"`
+	IsError           bool              `json:"is_error"`
+	NumTurns          int               `json:"num_turns"`
+	TotalCost         float64           `json:"total_cost_usd"`
+	StopReason        json.RawMessage   `json:"stop_reason"`
+	Result            string            `json:"result"`
+	PermissionDenials []json.RawMessage `json:"permission_denials"`
+	SessionID         string            `json:"session_id"`
+}
+
+// streamEvent is the envelope for any stream-json event.
+type streamEvent struct {
+	Type        string     `json:"type"`
+	Subtype     string     `json:"subtype,omitempty"`
+	Message     *streamMsg `json:"message,omitempty"`
+	NumTurns    int        `json:"num_turns,omitempty"`
+	TotalCost   float64    `json:"total_cost_usd,omitempty"`
+	IsError     bool       `json:"is_error,omitempty"`
+	Error       string     `json:"error,omitempty"`
+	ErrorStatus int        `json:"error_status,omitempty"`
+}
+
+type streamMsg struct {
+	Content []streamBlock `json:"content"`
+}
+
+type streamBlock struct {
+	Type  string          `json:"type"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	Text  string          `json:"text,omitempty"`
+}
+
+// scanStream reads stream-json lines from r, mirrors each line to logFile, and
+// pushes normalized events to sink.
+//
+// Sink semantics (matching the supervisor's existing LiveStatus updates in
+// `internal/supervisor/scanner.go:scanStream`):
+//
+//   - assistant message with at least one tool_use block → OnAssistantStep then
+//     OnToolStart(name, inputSummary) for the (last) tool_use.
+//   - assistant message with no tool_use blocks → OnAssistantStep then OnToolEnd.
+//   - result event → OnToolEnd (clears any in-flight tool display).
+//   - system api_retry with rate_limit / billing_error → OnUsageLimit.
+//
+// Returns when r reaches EOF.
+func scanStream(r io.Reader, logFile io.Writer, sink runtime.EventSink) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		if logFile != nil {
+			_, _ = logFile.Write(line)
+			_, _ = logFile.Write([]byte("\n"))
+		}
+
+		if sink == nil {
+			continue
+		}
+
+		var evt streamEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+
+		switch evt.Type {
+		case "assistant":
+			if evt.Message == nil {
+				continue
+			}
+			sink.OnAssistantStep()
+
+			var lastTool *streamBlock
+			for i := range evt.Message.Content {
+				if evt.Message.Content[i].Type == "tool_use" {
+					lastTool = &evt.Message.Content[i]
+				}
+			}
+			if lastTool != nil {
+				sink.OnToolStart(lastTool.Name, extractToolInput(lastTool.Input, 80))
+			} else {
+				sink.OnToolEnd()
+			}
+
+		case "result":
+			sink.OnToolEnd()
+
+		case "system":
+			if evt.Subtype == "api_retry" &&
+				(evt.Error == "rate_limit" || evt.Error == "billing_error") {
+				sink.OnUsageLimit()
+			}
+		}
+	}
+}
+
+// extractToolInput pulls a short, displayable summary from raw tool_use input
+// JSON. Prefers common human-meaningful keys; falls back to the raw JSON.
+func extractToolInput(raw json.RawMessage, maxLen int) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var obj map[string]any
+	if json.Unmarshal(raw, &obj) != nil {
+		return truncate(string(raw), maxLen)
+	}
+
+	for _, key := range []string{"command", "file_path", "pattern", "prompt", "query", "description"} {
+		if val, ok := obj[key].(string); ok && val != "" {
+			return truncate(val, maxLen)
+		}
+	}
+	return truncate(string(raw), maxLen)
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// readResultEvent walks a stream-json log line by line and returns the parsed
+// result event plus the raw JSON line (for Result.Native).
+//
+// Returns (nil, nil, nil) if logPath is empty or no result event is found.
+func readResultEvent(logPath string) (*claudeResultEvent, json.RawMessage, error) {
+	if logPath == "" {
+		return nil, nil, nil
+	}
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var env struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(line, &env); err != nil {
+			continue
+		}
+		if env.Type != "result" {
+			continue
+		}
+		var evt claudeResultEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		raw := make(json.RawMessage, len(line))
+		copy(raw, line)
+		return &evt, raw, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, nil, err
+	}
+	return nil, nil, nil
+}


### PR DESCRIPTION
## Summary
- Adds `internal/runtime/claudecode` implementing the `runtime.AgentRuntime` contract for the Claude Code CLI.
- Encapsulates command-arg construction, `.claude/agents/<name>.md` materialization, stream-json scanning + `EventSink` normalization (assistant step, tool start/end, usage limit), result-event parsing into `runtime.Result`, outcome classification, and `<bail-report>` extraction (final text + raw-log fallback). `Resume` shells out via `--resume`.
- Behavior preserves the supervisor's current effective flags (`-p --output-format stream-json --verbose --max-turns N --max-budget-usd F --allowedTools …` + optional `--append-system-prompt`).
- No supervisor wiring; that's #502 / #504.

## Test plan
- [x] `go test ./...` (all packages green, including new `internal/runtime/claudecode` suite)
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `golangci-lint run ./...` clean
- [x] New `TestExtractBailReport_StreamJSONLog` covers extraction from a representative stream-json log fixture, exercising both the `Result.FinalText` path and the raw-log fallback.

Fixes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)