### PR TITLE
docs: sync docs with AgentRuntime, schema v5, and CONTRIBUTING cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Go CLI coordination layer on top of [agent-msg](../agent-msg). Monitors git repo
 
 ## Architecture
 
-All LLM calls go through `internal/claudecli`, which wraps `claude -p` with `--output-format json` and `claude --agent` for agent execution.
+All LLM calls go through `internal/claudecli`, which wraps `claude -p` with `--output-format json` and `claude --agent` for agent execution. Doer (agent) execution flows through the `runtime.AgentRuntime` contract (`internal/runtime`), with `internal/runtime/claudecode` as the default (and currently only) implementation. The runtime is selected per deploy via `--runtime` (default `claude-code`) and injected into the supervisor via `Supervisor.SetRuntime`; `liveStatusSink` adapts `runtime.EventSink` so live tool/step status still surfaces through `minder status`, daemon `/jobs`, and the TUI.
 
 ### Supervisor (internal/supervisor)
 
@@ -65,6 +65,8 @@ Migrations: v1→v2 (tasks→jobs rename, add agent/name/stage columns), v2→v3
 | `internal/scheduler` | Job scheduler | Cron parser, `jobs.yaml` config, scheduled job firing |
 | `internal/db` | SQLite schema + CRUD | sqlx.DB wrapper, migrations in `schema.go` |
 | `internal/claudecli` | Claude Code CLI wrapper | `Completer` interface, `claude -p` invocation |
+| `internal/runtime` | Doer-runtime contract + registry | `AgentRuntime` interface, `EventSink`, `Validate`, `KnownNames`, `DefaultName` |
+| `internal/runtime/claudecode` | Default `AgentRuntime` impl | Wraps `claude --agent`, stream-json scanning, `<bail-report>` extraction, `--resume` |
 | `internal/git` | Git CLI wrappers | `LogSince()`, `Branches()`, `WorktreeList()` |
 | `internal/github` | GitHub API client | go-github wrapper, ETag transport, URL parsing |
 | `internal/lesson` | Learning system | Lesson selection, injection, grooming |
@@ -75,7 +77,7 @@ Migrations: v1→v2 (tasks→jobs rename, add agent/name/stage columns), v2→v3
 
 ## Commands
 
-- `deploy [issues...] [flags]` — Launch agents on issues or start daemon. Key flags: `--repo`, `--agent`, `--watch`, `--serve`, `--foreground`, `--max-agents`, `--auto-merge`, `--total-budget`.
+- `deploy [issues...] [flags]` — Launch agents on issues or start daemon. Key flags: `--repo`, `--agent`, `--runtime` (default `claude-code`, validated against `runtime` registry, propagated through daemon re-exec), `--watch`, `--serve`, `--foreground`, `--max-agents`, `--auto-merge`, `--total-budget`.
 - `status [deploy-id]` — Deployment status (`--json` for structured output, `--remote host:port` for remote daemon).
 - `stop [deploy-id]` — Stop a running deployment (local or `--remote`).
 - `enroll [repo-dir]` — Scan repo, generate `onboarding.yaml`, install agent definitions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ Thanks for your interest in contributing to agent-minder! This document covers e
 - **Go 1.25+** (required for bubbletea v2)
 - **golangci-lint** — install via `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest` or [other methods](https://golangci-lint.run/welcome/install/)
 - **lefthook** — git hook manager; install via `go install github.com/evilmartians/lefthook@latest` or [other methods](https://github.com/evilmartians/lefthook/blob/master/docs/install.md)
-- **An `ANTHROPIC_API_KEY`** environment variable (needed at runtime and for integration tests)
+- **[Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)** — agent execution (no Anthropic API key needed; the CLI handles auth)
+- **`GITHUB_TOKEN`** — GitHub API token (env var or `minder auth login`)
 
 ### Clone and build
 
@@ -42,11 +43,12 @@ go test ./...
 
 # Package-specific tests (verbose)
 go test ./internal/db/... -v
-go test ./internal/poller/... -v
-go test ./internal/msgbus/... -v
+go test ./internal/supervisor/... -v
+go test ./internal/scheduler/... -v
+go test ./internal/daemon/... -v
 
-# Integration test (requires ANTHROPIC_API_KEY + an existing agent-test project)
-go test -tags integration -run TestIntegrationTwoTierPipeline -v ./internal/poller/ -timeout 90s
+# Supervisor scenario integration suite (end-to-end pipeline scenarios)
+make integration
 ```
 
 ## Running a local dev instance
@@ -64,10 +66,11 @@ This auto-derives paths from the current branch name, copies the production DB o
 
 | Variable | Description |
 |----------|-------------|
-| `MINDER_DB` | Override database path (default: `~/.agent-minder/minder.db`) |
+| `MINDER_DB` | Override database path (default: `~/.agent-minder/v2.db`) |
 | `MINDER_LOG` | Override debug log path (default: `~/.agent-minder/debug.log`) |
 | `MINDER_DEBUG=1` | Enable structured JSON debug logging |
-| `ANTHROPIC_API_KEY` | Required for LLM calls |
+| `GITHUB_TOKEN` | GitHub API token (required for agent execution) |
+| `MINDER_API_KEY` | API key for remote daemon access |
 
 ## Code style and linting
 
@@ -83,12 +86,13 @@ The codebase is organized into focused internal packages. See the **Package map*
 
 High-level:
 
-- **`cmd/`** — Cobra CLI commands (`init`, `start`, `status`, `enroll`, etc.)
-- **`internal/poller`** — Two-tier LLM pipeline (Haiku summarizer → Sonnet analyzer)
-- **`internal/tui`** — Bubbletea v2 terminal dashboard
+- **`cmd/`** — Cobra CLI commands (`deploy`, `status`, `stop`, `enroll`, `lesson`, `jobs`, `agents`, `auth`, `tui`, etc.)
+- **`internal/supervisor`** — Job manager for concurrent Claude Code agents (contracts, context providers, dedup, review, dep graph, stage executor)
+- **`internal/runtime`** — `AgentRuntime` contract + registry; `claudecode/` is the default doer implementation
+- **`internal/daemon`** — PID/heartbeat lifecycle and HTTP API server + client
+- **`internal/scheduler`** — Cron parser, `jobs.yaml`, scheduled job firing
 - **`internal/db`** — SQLite schema, migrations, and CRUD operations
-- **`internal/autopilot`** — Supervisor for concurrent Claude Code agents
-- **`internal/msgbus`** — Integration with the agent-msg message bus
+- **`internal/claudecli`** — Claude Code CLI wrapper (`claude -p` / `claude --agent`)
 - **`internal/git`** — Git CLI wrappers
 
 ## Making changes
@@ -114,7 +118,7 @@ If your change modifies the SQLite schema:
 
 ### Agent definitions
 
-The repo-level `agents/autopilot.md` file and the `defaultAgentDef` constant in `internal/autopilot/prompt.go` must stay in sync. There is a drift-prevention test that enforces this.
+Built-in agent definitions live under `agents/` at the repo root and are also embedded into the binary via `internal/supervisor/templates.go` (`AgentTemplates()`). Both copies must stay in sync — drift-prevention tests in `internal/supervisor` enforce this.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ A macOS menu bar widget that shows agent status at a glance. Supports all job st
 |------|---------|-------------|
 | `--repo <dir>` | `.` | Repository directory |
 | `--agent <name>` | `autopilot` | Agent type to use |
+| `--runtime <name>` | `claude-code` | Doer runtime to execute agents (currently only `claude-code` is implemented) |
 | `--watch <filter>` | — | Watch for issues (`label:<name>` or `milestone:<name>`) |
 | `--serve <addr>` | — | Start HTTP API (e.g., `:7749`) |
 | `--foreground` | — | Don't daemonize |
@@ -335,8 +336,9 @@ internal/
   supervisor/                # Job manager, context providers, contracts, dedup, review, bail, templates
   scheduler/                 # Cron parser, jobs.yaml, scheduled job firing
   daemon/                    # PID files, heartbeat, HTTP API server + client
-  db/                        # SQLite schema (v4), models, queries, migrations
+  db/                        # SQLite schema (v5), models, queries, migrations
   claudecli/                 # Claude Code CLI wrapper
+  runtime/                   # AgentRuntime contract + registry; claudecode/ default impl
   github/                    # GitHub API client (go-github, ETag caching)
   git/                       # Git CLI wrappers
   auth/                      # OS keyring integration (macOS Keychain, Linux libsecret)
@@ -351,7 +353,7 @@ xbar/                        # macOS SwiftBar menu bar plugin
 
 ### Data storage
 
-SQLite at `~/.agent-minder/v2.db` (WAL mode, foreign keys, single-writer via `SetMaxOpenConns(1)`). Schema v4.
+SQLite at `~/.agent-minder/v2.db` (WAL mode, foreign keys, single-writer via `SetMaxOpenConns(1)`). Schema v5.
 
 | Table | Purpose |
 |-------|---------|


### PR DESCRIPTION
## Summary

Targeted documentation edits to reflect recent changes (AgentRuntime contract, --runtime flag, schema v5) and clean up stale v1 references in CONTRIBUTING.md.

### Files changed

- **CLAUDE.md** — Document the `runtime.AgentRuntime` contract, the `--runtime` deploy flag, and the supervisor injection seam (`Supervisor.SetRuntime`, `liveStatusSink`). Add `internal/runtime` and `internal/runtime/claudecode` rows to the package map.
- **README.md** — Add `--runtime <name>` to the Deploy flags table; bump schema reference from v4 to v5 (actual `schemaVersion` in `internal/db/schema.go`); add `runtime/` to the architecture tree.
- **CONTRIBUTING.md** — Replace `ANTHROPIC_API_KEY` prerequisite with Claude Code CLI + `GITHUB_TOKEN` (Claude Code CLI handles auth in v2). Swap stale `internal/poller` / `internal/msgbus` / `internal/autopilot` test and architecture references for the current `internal/supervisor`, `internal/runtime`, `internal/daemon`, `internal/scheduler` packages. Fix `MINDER_DB` default from v1 `minder.db` to `v2.db`. Add `make integration` to the test list. Update agent-definition drift note to point at `internal/supervisor/templates.go`.

CHANGELOG.md already covered the recent runtime/scenario-suite/bail-fix work (#500, #501, #502, #504, #517, #519), so no changes there.

## Test plan

- [x] `go build ./...`
- [x] `lefthook` pre-commit (build + lint) passes
- [ ] Reviewer skim of CLAUDE.md / CONTRIBUTING.md for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)