### PR TITLE
Add Codex doer runtime

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -19,6 +19,9 @@ import (
 	// Side-effect import: register the claude-code runtime factory in the
 	// runtime registry so runtime.Lookup("claude-code") resolves.
 	_ "github.com/aptx-health/agent-minder/internal/runtime/claudecode"
+	// Side-effect import: register the codex runtime factory in the runtime
+	// registry so runtime.Lookup("codex") resolves.
+	_ "github.com/aptx-health/agent-minder/internal/runtime/codex"
 	"github.com/aptx-health/agent-minder/internal/scheduler"
 	"github.com/aptx-health/agent-minder/internal/supervisor"
 	"github.com/google/uuid"
@@ -165,6 +168,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		MaxAgents:      flagMaxAgents,
 		MaxTurns:       flagMaxTurns,
 		MaxBudgetUSD:   flagBudget,
+		Runtime:        flagRuntime,
 		AnalyzerModel:  flagModel,
 		SkipLabel:      flagSkipLabel,
 		AutoMerge:      flagAutoMerge,
@@ -288,6 +292,14 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 // runForeground runs the supervisor in the current process.
 // Prepare() has already been called — jobs exist in the DB.
 func runForeground(deployID string) error {
+	if err := daemon.WritePID(deployID); err != nil {
+		return fmt.Errorf("write PID: %w", err)
+	}
+	stopHB := daemon.StartHeartbeat(deployID)
+	defer daemon.RemovePID(deployID)
+	defer daemon.RemoveHeartbeat(deployID)
+	defer stopHB()
+
 	conn, err := db.Open(db.DefaultDBPath())
 	if err != nil {
 		return err

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -267,6 +267,10 @@ func runLogsRemote(args []string) error {
 
 // streamLog reads stream-json from r and prints formatted output.
 func streamLog(r io.Reader, raw bool) error {
+	return streamLogTo(os.Stdout, r, raw)
+}
+
+func streamLogTo(out io.Writer, r io.Reader, raw bool) error {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
 
@@ -274,31 +278,15 @@ func streamLog(r io.Reader, raw bool) error {
 		line := scanner.Bytes()
 
 		if raw {
-			fmt.Println(string(line))
+			writeLogLine(out, string(line))
 			continue
 		}
 
-		var evt struct {
-			Type    string `json:"type"`
-			Subtype string `json:"subtype,omitempty"`
-			Message *struct {
-				Content []struct {
-					Type  string          `json:"type"`
-					Name  string          `json:"name,omitempty"`
-					Text  string          `json:"text,omitempty"`
-					Input json.RawMessage `json:"input,omitempty"`
-				} `json:"content"`
-			} `json:"message,omitempty"`
-			NumTurns  int     `json:"num_turns,omitempty"`
-			TotalCost float64 `json:"total_cost_usd,omitempty"`
-			IsError   bool    `json:"is_error,omitempty"`
-			Result    string  `json:"result,omitempty"`
-			Error     string  `json:"error,omitempty"`
-		}
+		var evt formattedLogEvent
 
 		if json.Unmarshal(line, &evt) != nil {
 			// Non-JSON line (e.g., "--- REVIEW AGENT ---").
-			fmt.Println(string(line))
+			writeLogLine(out, string(line))
 			continue
 		}
 
@@ -311,34 +299,73 @@ func streamLog(r io.Reader, raw bool) error {
 				switch block.Type {
 				case "tool_use":
 					input := truncateLogStr(string(block.Input), 120)
-					fmt.Printf("\033[36m> %s\033[0m %s\n", block.Name, input)
+					writeLogf(out, "\033[36m> %s\033[0m %s\n", block.Name, input)
 				case "text":
 					if block.Text != "" {
-						fmt.Printf("\033[33m%s\033[0m\n", block.Text)
+						writeLogf(out, "\033[33m%s\033[0m\n", block.Text)
 					}
 				}
 			}
 
 		case "result":
-			fmt.Println()
+			writeLogLine(out)
 			if evt.IsError {
-				fmt.Printf("\033[31m--- Result (error) ---\033[0m\n")
+				writeLogf(out, "\033[31m--- Result (error) ---\033[0m\n")
 			} else {
-				fmt.Printf("\033[32m--- Result ---\033[0m\n")
+				writeLogf(out, "\033[32m--- Result ---\033[0m\n")
 			}
 			if evt.Result != "" {
 				result := evt.Result
 				if len(result) > 500 {
 					result = result[:497] + "..."
 				}
-				fmt.Println(result)
+				writeLogLine(out, result)
 			}
-			fmt.Printf("Turns: %d  Cost: $%.2f\n", evt.NumTurns, evt.TotalCost)
+			writeLogf(out, "Turns: %d  Cost: $%.2f\n", evt.NumTurns, evt.TotalCost)
 
 		case "system":
 			if evt.Error != "" {
-				fmt.Printf("\033[31m[system] %s: %s\033[0m\n", evt.Subtype, evt.Error)
+				writeLogf(out, "\033[31m[system] %s: %s\033[0m\n", evt.Subtype, evt.Error)
 			}
+
+		case "thread.started":
+			if evt.ThreadID != "" {
+				writeLogf(out, "\033[90mSession: %s\033[0m\n", evt.ThreadID)
+			}
+
+		case "turn.started":
+			writeLogLine(out, "\033[90m--- Turn started ---\033[0m")
+
+		case "turn.completed":
+			writeLogLine(out)
+			writeLogLine(out, "\033[32m--- Turn complete ---\033[0m")
+			if evt.Usage != nil {
+				writeLogf(out, "Tokens: input=%d cached=%d output=%d reasoning=%d\n",
+					evt.Usage.InputTokens,
+					evt.Usage.CachedInputTokens,
+					evt.Usage.OutputTokens,
+					evt.Usage.ReasoningOutputTokens,
+				)
+			}
+
+		case "turn.failed", "error":
+			msg := evt.Error
+			if msg == "" {
+				msg = evt.Result
+			}
+			if msg == "" && evt.Item != nil {
+				msg = codexLogItemError(evt.Item.Error)
+			}
+			writeLogf(out, "\033[31m[%s] %s\033[0m\n", evt.Type, msg)
+
+		case "item.started":
+			formatCodexLogItem(out, "started", evt.Item)
+
+		case "item.completed":
+			formatCodexLogItem(out, "completed", evt.Item)
+
+		case "response_item":
+			formatCodexLogItem(out, "response", evt.Item)
 
 		default:
 			// Skip other event types (tool_result, etc.)
@@ -346,6 +373,167 @@ func streamLog(r io.Reader, raw bool) error {
 	}
 
 	return scanner.Err()
+}
+
+type formattedLogEvent struct {
+	Type      string         `json:"type"`
+	Subtype   string         `json:"subtype,omitempty"`
+	ThreadID  string         `json:"thread_id,omitempty"`
+	Message   *claudeLogMsg  `json:"message,omitempty"`
+	NumTurns  int            `json:"num_turns,omitempty"`
+	TotalCost float64        `json:"total_cost_usd,omitempty"`
+	IsError   bool           `json:"is_error,omitempty"`
+	Result    string         `json:"result,omitempty"`
+	Error     string         `json:"error,omitempty"`
+	Item      *codexLogItem  `json:"item,omitempty"`
+	Usage     *codexLogUsage `json:"usage,omitempty"`
+}
+
+type claudeLogMsg struct {
+	Content []claudeLogContent `json:"content"`
+}
+
+type claudeLogContent struct {
+	Type  string          `json:"type"`
+	Name  string          `json:"name,omitempty"`
+	Text  string          `json:"text,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+type codexLogUsage struct {
+	InputTokens           int `json:"input_tokens"`
+	CachedInputTokens     int `json:"cached_input_tokens"`
+	OutputTokens          int `json:"output_tokens"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens"`
+}
+
+func formatCodexLogItem(out io.Writer, eventStatus string, item *codexLogItem) {
+	if item == nil {
+		return
+	}
+	formatCodexLogItemValue(out, eventStatus, *item)
+}
+
+type codexLogItem struct {
+	Type             string           `json:"type"`
+	Name             string           `json:"name,omitempty"`
+	Text             string           `json:"text,omitempty"`
+	Command          string           `json:"command,omitempty"`
+	AggregatedOutput string           `json:"aggregated_output,omitempty"`
+	ExitCode         *int             `json:"exit_code,omitempty"`
+	Status           string           `json:"status,omitempty"`
+	Input            json.RawMessage  `json:"input,omitempty"`
+	Arguments        json.RawMessage  `json:"arguments,omitempty"`
+	Error            json.RawMessage  `json:"error,omitempty"`
+	Changes          []codexLogChange `json:"changes,omitempty"`
+}
+
+type codexLogChange struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+}
+
+func formatCodexLogItemValue(out io.Writer, eventStatus string, item codexLogItem) {
+	switch item.Type {
+	case "agent_message":
+		if item.Text != "" {
+			writeLogf(out, "\033[33m%s\033[0m\n", item.Text)
+		}
+
+	case "command_execution":
+		if eventStatus == "started" {
+			writeLogf(out, "\033[36m> %s\033[0m\n", item.Command)
+			return
+		}
+		if item.AggregatedOutput != "" {
+			writeLog(out, item.AggregatedOutput)
+			if !strings.HasSuffix(item.AggregatedOutput, "\n") {
+				writeLogLine(out)
+			}
+		}
+		if item.ExitCode != nil && *item.ExitCode != 0 {
+			writeLogf(out, "\033[31mexit code %d\033[0m\n", *item.ExitCode)
+		}
+
+	case "file_change":
+		if eventStatus == "started" {
+			writeLogLine(out, "\033[36m> file_change\033[0m")
+		}
+		if eventStatus == "completed" {
+			for _, change := range item.Changes {
+				writeLogf(out, "\033[36m%s\033[0m %s\n", change.Kind, change.Path)
+			}
+		}
+
+	case "function_call", "custom_tool_call", "mcp_tool_call":
+		name := item.Name
+		if name == "" {
+			name = item.Type
+		}
+		writeLogf(out, "\033[36m> %s\033[0m %s\n", name, codexLogInputSummary(item, 120))
+
+	case "function_call_output", "custom_tool_call_output":
+		if item.Text != "" {
+			writeLogLine(out, item.Text)
+		}
+
+	case "error":
+		msg := item.Text
+		if msg == "" {
+			msg = codexLogItemError(item.Error)
+		}
+		writeLogf(out, "\033[31m[error] %s\033[0m\n", msg)
+	}
+}
+
+func writeLog(out io.Writer, text string) {
+	_, _ = fmt.Fprint(out, text)
+}
+
+func writeLogLine(out io.Writer, args ...any) {
+	_, _ = fmt.Fprintln(out, args...)
+}
+
+func writeLogf(out io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(out, format, args...)
+}
+
+func codexLogInputSummary(item codexLogItem, maxLen int) string {
+	for _, raw := range []json.RawMessage{item.Input, item.Arguments} {
+		if len(raw) > 0 {
+			return truncateLogStr(string(raw), maxLen)
+		}
+	}
+	if item.Command != "" {
+		return truncateLogStr(item.Command, maxLen)
+	}
+	return ""
+}
+
+func codexLogItemError(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj struct {
+		Message string `json:"message"`
+		Code    string `json:"code"`
+		Type    string `json:"type"`
+	}
+	if json.Unmarshal(raw, &obj) == nil {
+		switch {
+		case obj.Message != "":
+			return obj.Message
+		case obj.Code != "":
+			return obj.Code
+		case obj.Type != "":
+			return obj.Type
+		}
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return string(raw)
 }
 
 func truncateLogStr(s string, max int) string {

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestStreamLogFormatsCodexEvents(t *testing.T) {
+	log := strings.Join([]string{
+		"Reading additional input from stdin...",
+		`{"type":"thread.started","thread_id":"session-123"}`,
+		`{"type":"turn.started"}`,
+		`{"type":"item.completed","item":{"type":"agent_message","text":"I am checking the repo."}}`,
+		`{"type":"item.started","item":{"type":"command_execution","command":"/bin/zsh -lc pwd","aggregated_output":"","exit_code":null,"status":"in_progress"}}`,
+		`{"type":"item.completed","item":{"type":"command_execution","command":"/bin/zsh -lc pwd","aggregated_output":"/tmp/worktree\n","exit_code":0,"status":"completed"}}`,
+		`{"type":"item.completed","item":{"type":"file_change","changes":[{"path":"/tmp/worktree/internal/model/article.go","kind":"add"}],"status":"completed"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":4,"output_tokens":3,"reasoning_output_tokens":2}}`,
+	}, "\n")
+
+	var out bytes.Buffer
+	if err := streamLogTo(&out, strings.NewReader(log), false); err != nil {
+		t.Fatalf("streamLogTo() error = %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"Reading additional input from stdin...",
+		"Session: session-123",
+		"--- Turn started ---",
+		"I am checking the repo.",
+		"> /bin/zsh -lc pwd",
+		"/tmp/worktree",
+		"add",
+		"/tmp/worktree/internal/model/article.go",
+		"Tokens: input=10 cached=4 output=3 reasoning=2",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted log missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
+func TestStreamLogStillFormatsClaudeEvents(t *testing.T) {
+	log := strings.Join([]string{
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Checking now."},{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}`,
+		`{"type":"result","result":"Done","num_turns":2,"total_cost_usd":0.25}`,
+	}, "\n")
+
+	var out bytes.Buffer
+	if err := streamLogTo(&out, strings.NewReader(log), false); err != nil {
+		t.Fatalf("streamLogTo() error = %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"Checking now.",
+		"> Bash",
+		"Done",
+		"Turns: 2  Cost: $0.25",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted log missing %q\noutput:\n%s", want, got)
+		}
+	}
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -51,6 +51,7 @@ type jobJSON struct {
 	IssueNumber int     `json:"issue_number,omitempty"`
 	Title       string  `json:"title"`
 	Agent       string  `json:"agent,omitempty"`
+	Runtime     string  `json:"runtime,omitempty"`
 	Status      string  `json:"status"`
 	PRNumber    int     `json:"pr_number,omitempty"`
 	CostUSD     float64 `json:"cost_usd,omitempty"`
@@ -83,6 +84,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 					IssueNumber: j.IssueNumber,
 					Title:       j.Title,
 					Agent:       j.Agent,
+					Runtime:     status.Config.Runtime,
 					Status:      j.Status,
 					PRNumber:    j.PRNumber,
 					CostUSD:     j.CostUSD,
@@ -98,6 +100,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		}
 
 		fmt.Printf("Deploy: %s (PID %d, up %ds)\n", status.DeployID, status.PID, status.UptimeSec)
+		if status.Config.Runtime != "" {
+			fmt.Printf("Runtime: %s\n", status.Config.Runtime)
+		}
 		fmt.Printf("Budget: $%.2f / $%.2f", status.TotalSpent, status.TotalBudget)
 		if status.BudgetPaused {
 			fmt.Print(" [PAUSED]")
@@ -149,6 +154,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 				IssueNumber: j.IssueNumber,
 				Title:       title,
 				Agent:       j.Agent,
+				Runtime:     deploy.Runtime,
 				Status:      j.Status,
 				PRNumber:    pr,
 				CostUSD:     j.CostUSD,
@@ -166,7 +172,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	fmt.Printf("Deploy: %s (%s/%s, %s mode)\n", deployID, deploy.Owner, deploy.Repo, deploy.Mode)
+	fmt.Printf("Deploy: %s (%s/%s, %s mode, runtime: %s)\n", deployID, deploy.Owner, deploy.Repo, deploy.Mode, deploy.Runtime)
 	if alive {
 		fmt.Printf("Status: running (PID %d)\n", pid)
 	} else {
@@ -190,13 +196,13 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			title = j.Name
 		}
 		if j.IssueNumber > 0 {
-			fmt.Printf("  #%-5d %-30s %-10s%s%s\n", j.IssueNumber, title, j.Status, pr, cost)
+			fmt.Printf("  #%-5d %-30s %-12s %-10s%s%s\n", j.IssueNumber, title, deploy.Runtime, j.Status, pr, cost)
 		} else {
 			agent := ""
 			if j.Agent != "autopilot" {
 				agent = fmt.Sprintf("[%s] ", j.Agent)
 			}
-			fmt.Printf("  %-6s %-30s %-10s%s%s\n", agent, title, j.Status, pr, cost)
+			fmt.Printf("  %-6s %-30s %-12s %-10s%s%s\n", agent, title, deploy.Runtime, j.Status, pr, cost)
 		}
 	}
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -137,6 +137,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 			MaxAgents:  deploy.MaxAgents,
 			MaxTurns:   deploy.MaxTurns,
 			MaxBudget:  deploy.MaxBudgetUSD,
+			Runtime:    deploy.Runtime,
 			Model:      deploy.AnalyzerModel,
 			SkipLabel:  deploy.SkipLabel,
 			AutoMerge:  deploy.AutoMerge,
@@ -314,6 +315,7 @@ type DeployConfig struct {
 	MaxAgents  int     `json:"max_agents"`
 	MaxTurns   int     `json:"max_turns"`
 	MaxBudget  float64 `json:"max_budget"`
+	Runtime    string  `json:"runtime"`
 	Model      string  `json:"model"`
 	SkipLabel  string  `json:"skip_label"`
 	AutoMerge  bool    `json:"auto_merge"`

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -67,6 +67,9 @@ func TestDeploymentCRUD(t *testing.T) {
 	if got.Owner != "aptx-health" || got.Repo != "agent-minder" {
 		t.Errorf("got %s/%s, want aptx-health/agent-minder", got.Owner, got.Repo)
 	}
+	if got.Runtime != "claude-code" {
+		t.Errorf("got runtime %q, want claude-code default", got.Runtime)
+	}
 
 	ds, err := s.ListDeployments()
 	if err != nil {
@@ -426,6 +429,13 @@ INSERT INTO tasks (deployment_id, issue_number, owner, repo, status) VALUES ('d1
 	}
 	if len(jobs) != 2 {
 		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+	deploy, err := store.GetDeployment("d1")
+	if err != nil {
+		t.Fatalf("GetDeployment after migration: %v", err)
+	}
+	if deploy.Runtime != "claude-code" {
+		t.Errorf("migrated runtime = %q, want claude-code", deploy.Runtime)
 	}
 
 	// Verify backfilled fields.

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -22,6 +22,7 @@ type Deployment struct {
 	MaxAgents       int             `db:"max_agents"`
 	MaxTurns        int             `db:"max_turns"`
 	MaxBudgetUSD    float64         `db:"max_budget_usd"`
+	Runtime         string          `db:"runtime"`
 	AnalyzerModel   string          `db:"analyzer_model"`
 	SkipLabel       string          `db:"skip_label"`
 	AutoMerge       bool            `db:"auto_merge"`
@@ -114,6 +115,7 @@ const (
 	StatusReviewing = "reviewing"
 	StatusReviewed  = "reviewed"
 	StatusDone      = "done"
+	StatusFailed    = "failed"
 	StatusBailed    = "bailed"
 	StatusManual    = "manual"
 	StatusStopped   = "stopped"

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -34,13 +34,17 @@ func (s *Store) DB() *sqlx.DB {
 
 // CreateDeployment inserts a new deployment.
 func (s *Store) CreateDeployment(d *Deployment) error {
+	runtimeName := d.Runtime
+	if runtimeName == "" {
+		runtimeName = "claude-code"
+	}
 	_, err := s.db.Exec(`INSERT INTO deployments
 		(id, repo_dir, owner, repo, mode, watch_filter, max_agents, max_turns,
-		 max_budget_usd, analyzer_model, skip_label, auto_merge, review_enabled,
+		 max_budget_usd, runtime, analyzer_model, skip_label, auto_merge, review_enabled,
 		 review_max_turns, review_max_budget, total_budget_usd, carried_cost_usd, base_branch)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		d.ID, d.RepoDir, d.Owner, d.Repo, d.Mode, d.WatchFilter,
-		d.MaxAgents, d.MaxTurns, d.MaxBudgetUSD, d.AnalyzerModel,
+		d.MaxAgents, d.MaxTurns, d.MaxBudgetUSD, runtimeName, d.AnalyzerModel,
 		d.SkipLabel, d.AutoMerge, d.ReviewEnabled,
 		d.ReviewMaxTurns, d.ReviewMaxBudget,
 		d.TotalBudgetUSD, d.CarriedCostUSD, d.BaseBranch)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -9,7 +9,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = 5
+const schemaVersion = 6
 
 const schema = `
 CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS deployments (
 	max_agents INTEGER DEFAULT 3,
 	max_turns INTEGER DEFAULT 50,
 	max_budget_usd REAL DEFAULT 5.0,
+	runtime TEXT DEFAULT 'claude-code',
 	analyzer_model TEXT DEFAULT 'sonnet',
 	skip_label TEXT DEFAULT 'no-agent',
 	auto_merge INTEGER DEFAULT 0,
@@ -258,6 +259,13 @@ ALTER TABLE lessons ADD COLUMN last_unhelpful_at DATETIME;
 UPDATE schema_version SET version = 5;
 `
 
+// migrateV5toV6 records the doer runtime selected for each deployment.
+const migrateV5toV6 = `
+ALTER TABLE deployments ADD COLUMN runtime TEXT DEFAULT 'claude-code';
+UPDATE deployments SET runtime = 'claude-code' WHERE runtime IS NULL OR runtime = '';
+UPDATE schema_version SET version = 6;
+`
+
 // DefaultDBPath returns the default database path for v2.
 func DefaultDBPath() string {
 	home, err := expandHome("~/.agent-minder")
@@ -309,6 +317,12 @@ func Open(dsn string) (*sqlx.DB, error) {
 			if _, err := db.Exec(migrateV4toV5); err != nil {
 				_ = db.Close()
 				return nil, fmt.Errorf("migrating v4→v5: %w", err)
+			}
+		}
+		if version < 6 {
+			if _, err := db.Exec(migrateV5toV6); err != nil {
+				_ = db.Close()
+				return nil, fmt.Errorf("migrating v5→v6: %w", err)
 			}
 		}
 	} else if !hasVersion {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -76,6 +76,12 @@ func CurrentBranch(dir string) (string, error) {
 	return run(dir, "rev-parse", "--abbrev-ref", "HEAD")
 }
 
+// UpstreamBranch returns the configured upstream branch for HEAD, e.g.
+// "origin/agent/issue-42". It returns an error if no upstream is configured.
+func UpstreamBranch(dir string) (string, error) {
+	return run(dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+}
+
 // parseLogOutput parses the pipe-delimited output from git log into LogEntry
 // slices. The expected format per line is "hash|subject|author|ISO-date".
 // If a date cannot be parsed, the current time is used as a fallback so that

--- a/internal/runtime/codex/bail.go
+++ b/internal/runtime/codex/bail.go
@@ -1,0 +1,83 @@
+package codex
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+type bailAssessment struct {
+	Reason        string   `json:"reason"`
+	FilesExamined []string `json:"files_examined"`
+	Plan          string   `json:"plan"`
+	SubIssues     []string `json:"sub_issues,omitempty"`
+	Complexity    string   `json:"complexity"`
+}
+
+const maxLogScanBytes = 200_000
+
+func extractBailReportFromText(text string) *runtime.BailReport {
+	const openTag = "<bail-report>"
+	const closeTag = "</bail-report>"
+
+	searchFrom := len(text)
+	for {
+		end := strings.LastIndex(text[:searchFrom], closeTag)
+		if end < 0 {
+			return nil
+		}
+		start := strings.LastIndex(text[:end], openTag)
+		if start < 0 {
+			return nil
+		}
+		body := strings.TrimSpace(text[start+len(openTag) : end])
+		if rep := tryParseBail(body); rep != nil {
+			return rep
+		}
+		searchFrom = end
+	}
+}
+
+func extractBailReportFromLog(logPath string) *runtime.BailReport {
+	if logPath == "" {
+		return nil
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return nil
+	}
+	content := string(data)
+	if len(content) > maxLogScanBytes {
+		content = content[len(content)-maxLogScanBytes:]
+	}
+	return extractBailReportFromText(content)
+}
+
+func tryParseBail(s string) *runtime.BailReport {
+	current := s
+	for range 3 {
+		current = strings.TrimSpace(current)
+		var a bailAssessment
+		if err := json.Unmarshal([]byte(current), &a); err == nil {
+			raw := append(json.RawMessage(nil), []byte(current)...)
+			return &runtime.BailReport{Reason: a.Reason, Detail: a.Plan, Native: raw}
+		}
+		unescaped := jsonUnescape(current)
+		if unescaped == current {
+			return nil
+		}
+		current = unescaped
+	}
+	return nil
+}
+
+func jsonUnescape(s string) string {
+	quoted := `"` + s + `"`
+	var out string
+	if err := json.Unmarshal([]byte(quoted), &out); err == nil {
+		return out
+	}
+	return s
+}

--- a/internal/runtime/codex/codex.go
+++ b/internal/runtime/codex/codex.go
@@ -1,0 +1,361 @@
+// Package codex is the Codex CLI implementation of runtime.AgentRuntime.
+//
+// It wraps `codex exec --json` for non-interactive doer runs in Minder-owned
+// worktrees. Codex owns authentication through its normal CLI login state; this
+// runtime only selects cwd, sandbox/approval policy, prompt, env, and logging.
+//
+// The runtime mirrors raw JSONL to the agent log, pushes normalized progress
+// events to the supervisor, and synthesizes Minder's runtime.Result from the
+// logged stream after the process exits.
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+// Name is the canonical identifier for this runtime.
+const Name = runtime.NameCodex
+
+// CodexRuntime implements runtime.AgentRuntime for the Codex CLI.
+//
+// All fields are optional. The zero value uses the `codex` binary on PATH and
+// the system environment.
+type CodexRuntime struct {
+	// Bin overrides the path to the codex binary (default: "codex").
+	Bin string
+
+	execFunc func(context.Context, []string, string, map[string]string, runtime.Limits, runtime.EventSink, io.Writer) (int, error)
+}
+
+// New constructs a CodexRuntime with default settings.
+func New() *CodexRuntime { return &CodexRuntime{} }
+
+func init() {
+	runtime.Register(Name, func() runtime.AgentRuntime { return New() })
+}
+
+// Name returns the runtime identifier.
+func (c *CodexRuntime) Name() string { return Name }
+
+// binPath returns the configured binary path or the default.
+func (c *CodexRuntime) binPath() string {
+	if c.Bin != "" {
+		return c.Bin
+	}
+	return "codex"
+}
+
+// PrepareAgentDef writes the selected Minder agent contract to
+// `<workspace>/AGENTS.md`, which Codex auto-loads from the project root down to
+// cwd. Worktrees are ephemeral per job, so overwriting an existing file here is
+// safe and keeps the contract scoped to the run.
+func (c *CodexRuntime) PrepareAgentDef(_ context.Context, ws runtime.Workspace, def runtime.AgentDefinition) error {
+	if ws.Dir == "" {
+		return nil
+	}
+	if def.Name == "" {
+		return fmt.Errorf("codex: PrepareAgentDef: empty agent name")
+	}
+	if len(def.Body) == 0 {
+		return fmt.Errorf("codex: PrepareAgentDef: empty body for %q", def.Name)
+	}
+	path := filepath.Join(ws.Dir, "AGENTS.md")
+	if err := os.WriteFile(path, def.Body, 0o644); err != nil {
+		return fmt.Errorf("codex: write AGENTS.md: %w", err)
+	}
+	return nil
+}
+
+// Run executes `codex exec --json ...`, streaming JSONL stdout and stderr to
+// logFile. Codex has no Claude-style allowed-tools flag; the runtime relies on
+// workspace-write sandboxing so it can edit only the provided worktree.
+func (c *CodexRuntime) Run(ctx context.Context, inv runtime.Invocation, sink runtime.EventSink, logFile io.Writer) (int, error) {
+	args := buildArgs(inv)
+	return c.exec(ctx, args, inv.Workspace.Dir, inv.Env, inv.Limits, sink, logFile)
+}
+
+// Resume restarts a prior Codex session using the documented non-interactive
+// resume form: `codex exec resume <session_id> --json`.
+func (c *CodexRuntime) Resume(ctx context.Context, sessionID string, sink runtime.EventSink, logFile io.Writer) (int, error) {
+	if sessionID == "" {
+		return 0, fmt.Errorf("codex: Resume: empty session id")
+	}
+	args := []string{"exec", "resume", sessionID, "--json"}
+	return c.exec(ctx, args, "", nil, runtime.Limits{}, sink, logFile)
+}
+
+func (c *CodexRuntime) exec(ctx context.Context, args []string, workDir string, env map[string]string, limits runtime.Limits, sink runtime.EventSink, logFile io.Writer) (int, error) {
+	if c.execFunc != nil {
+		return c.execFunc(ctx, args, workDir, env, limits, sink, logFile)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, c.binPath(), args...)
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+	logWriter := logFile
+	if logFile != nil {
+		logWriter = &safeWriter{w: logFile}
+	}
+	cmd.Stderr = logWriter
+
+	if len(env) > 0 {
+		cmd.Env = os.Environ()
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return 0, fmt.Errorf("codex: stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("codex: start: %w", err)
+	}
+
+	var scanState codexRunState
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+		scanStream(stdout, logWriter, sink, &scanState, limits, cancel)
+	}()
+
+	waitErr := cmd.Wait()
+	<-scanDone
+
+	exitCode := 0
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return 0, fmt.Errorf("codex: wait: %w", waitErr)
+		}
+	}
+	return exitCode, nil
+}
+
+// safeWriter serializes stdout/stderr writes into the shared agent log.
+type safeWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (w *safeWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.w.Write(p)
+}
+
+// buildArgs constructs the CLI argv for a fresh Run.
+//
+// Effective flags:
+//
+//	codex --ask-for-approval never exec --json --cd <worktree>
+//	  --sandbox workspace-write -c sandbox_workspace_write.network_access=true
+//	  [--add-dir <git-metadata-dir> ...] [--config key=value] <prompt>
+//
+// `workspace-write` gives Codex enough access to edit Minder's worktree while
+// respecting the execution plane boundary. `--ask-for-approval never` must be
+// a top-level Codex flag before `exec`; non-interactive exec cannot service
+// approval prompts.
+func buildArgs(inv runtime.Invocation) []string {
+	args := []string{
+		"--ask-for-approval", "never",
+		"exec",
+		"--json",
+	}
+	if inv.Workspace.Dir != "" {
+		args = append(args, "--cd", inv.Workspace.Dir)
+	}
+	args = append(args,
+		"--sandbox", "workspace-write",
+		"-c", "sandbox_workspace_write.network_access=true",
+	)
+	for _, dir := range gitMetadataDirs(inv.Workspace.Dir) {
+		args = append(args, "--add-dir", dir)
+	}
+	if inv.SystemPrompt != "" {
+		args = append(args, "-c", "developer_instructions="+strconv.Quote(inv.SystemPrompt))
+	}
+	args = append(args, inv.Prompt)
+	return args
+}
+
+func gitMetadataDirs(worktree string) []string {
+	if worktree == "" {
+		return nil
+	}
+
+	gitPath := filepath.Join(worktree, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return nil
+	}
+	if info.IsDir() {
+		return []string{gitPath}
+	}
+
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return nil
+	}
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir:")
+	if !ok {
+		return nil
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktree, gitDir)
+	}
+	gitDir = filepath.Clean(gitDir)
+
+	dirs := []string{gitDir}
+	commonDir := resolveCommonGitDir(gitDir)
+	if commonDir != "" && commonDir != gitDir {
+		dirs = append(dirs, commonDir)
+	}
+	return dirs
+}
+
+func resolveCommonGitDir(gitDir string) string {
+	data, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	if err != nil {
+		return ""
+	}
+	commonDir := strings.TrimSpace(string(data))
+	if commonDir == "" {
+		return ""
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(gitDir, commonDir)
+	}
+	return filepath.Clean(commonDir)
+}
+
+// ParseResult reads a Codex JSONL log and synthesizes the normalized Result.
+// Codex does not emit a single final result event, so this aggregates thread,
+// assistant-message, turn, usage, and terminal error events.
+func (c *CodexRuntime) ParseResult(logPath string) (*runtime.Result, error) {
+	state, err := readLogState(logPath)
+	if err != nil {
+		return nil, err
+	}
+	if state == nil {
+		return nil, nil
+	}
+
+	return &runtime.Result{
+		SessionID:         state.SessionID,
+		NumTurns:          state.NumTurns,
+		TotalCostUSD:      estimateCostUSD(state.Model, state.InputTok, state.CachedTok, state.OutputTok),
+		FinalText:         state.FinalText,
+		IsError:           state.IsError,
+		StopReason:        state.StopText,
+		PermissionDenials: nil,
+		Native:            state.Native,
+	}, nil
+}
+
+// ClassifyOutcome maps a Codex Result + Limits to a normalized Outcome.
+func (c *CodexRuntime) ClassifyOutcome(r *runtime.Result, limits runtime.Limits) runtime.Outcome {
+	if r == nil {
+		return runtime.Outcome{}
+	}
+
+	if limits.MaxTurns > 0 && r.NumTurns >= limits.MaxTurns {
+		return runtime.Outcome{
+			Status:        "failed",
+			FailureReason: "max_turns",
+			FailureDetail: fmt.Sprintf("used %d of %d turns", r.NumTurns, limits.MaxTurns),
+		}
+	}
+
+	if limits.MaxBudgetUSD > 0 && r.TotalCostUSD >= limits.MaxBudgetUSD*0.95 {
+		return runtime.Outcome{
+			Status:        "failed",
+			FailureReason: "max_budget",
+			FailureDetail: fmt.Sprintf("spent $%.2f of $%.2f budget", r.TotalCostUSD, limits.MaxBudgetUSD),
+		}
+	}
+
+	if r.IsError {
+		detail := r.FinalText
+		if detail == "" {
+			detail = r.StopReason
+		}
+		if len(detail) > 500 {
+			detail = detail[:500] + "..."
+		}
+		reason := "error"
+		if looksLikeUsageLimit(detail) {
+			reason = "usage_limit"
+		}
+		return runtime.Outcome{Status: "failed", FailureReason: reason, FailureDetail: detail}
+	}
+
+	return runtime.Outcome{}
+}
+
+// ExtractBailReport finds a <bail-report> JSON block in the final assistant
+// text, then falls back to scanning the raw JSONL log tail.
+func (c *CodexRuntime) ExtractBailReport(r *runtime.Result, logPath string) *runtime.BailReport {
+	if r != nil && r.FinalText != "" {
+		if rep := extractBailReportFromText(r.FinalText); rep != nil {
+			return rep
+		}
+	}
+	return extractBailReportFromLog(logPath)
+}
+
+func readLogState(logPath string) (*codexRunState, error) {
+	if logPath == "" {
+		return nil, nil
+	}
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	var state codexRunState
+	seen := false
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var evt codexEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		if evt.Type == "" {
+			continue
+		}
+		seen = true
+		state.apply(evt, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if !seen {
+		return nil, nil
+	}
+	return &state, nil
+}

--- a/internal/runtime/codex/codex_test.go
+++ b/internal/runtime/codex/codex_test.go
@@ -1,0 +1,380 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+func TestName(t *testing.T) {
+	if got := New().Name(); got != "codex" {
+		t.Errorf("Name() = %q, want %q", got, "codex")
+	}
+}
+
+func TestPrepareAgentDefWritesAgentsMD(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("---\nname: autopilot\n---\nship carefully")
+
+	err := New().PrepareAgentDef(context.Background(), runtime.Workspace{Dir: dir}, runtime.AgentDefinition{
+		Name: "autopilot",
+		Body: body,
+	})
+	if err != nil {
+		t.Fatalf("PrepareAgentDef: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("AGENTS.md = %q, want %q", got, body)
+	}
+}
+
+func TestPrepareAgentDefOverwritesExistingAgentsMD(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte("new contract")
+	if err := New().PrepareAgentDef(context.Background(), runtime.Workspace{Dir: dir}, runtime.AgentDefinition{Name: "reviewer", Body: body}); err != nil {
+		t.Fatalf("PrepareAgentDef: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("AGENTS.md = %q, want %q", got, body)
+	}
+}
+
+func TestPrepareAgentDefNoWorkspace(t *testing.T) {
+	err := New().PrepareAgentDef(context.Background(), runtime.Workspace{}, runtime.AgentDefinition{Name: "x", Body: []byte("y")})
+	if err != nil {
+		t.Errorf("expected nil for empty workspace, got %v", err)
+	}
+}
+
+func TestPrepareAgentDefErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := New().PrepareAgentDef(context.Background(), runtime.Workspace{Dir: dir}, runtime.AgentDefinition{Name: "", Body: []byte("x")}); err == nil {
+		t.Error("expected error for empty name")
+	}
+	if err := New().PrepareAgentDef(context.Background(), runtime.Workspace{Dir: dir}, runtime.AgentDefinition{Name: "x"}); err == nil {
+		t.Error("expected error for empty body")
+	}
+}
+
+func TestBuildArgs(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	args := buildArgs(runtime.Invocation{
+		Workspace:    runtime.Workspace{Dir: dir},
+		AgentName:    "autopilot",
+		Prompt:       "do the thing",
+		SystemPrompt: "lessons here",
+		AllowedTools: []string{"Read", "Edit"},
+		Limits:       runtime.Limits{MaxTurns: 50, MaxBudgetUSD: 2.50},
+	})
+
+	want := []string{
+		"--ask-for-approval", "never",
+		"exec",
+		"--json",
+		"--cd", dir,
+		"--sandbox", "workspace-write",
+		"-c", "sandbox_workspace_write.network_access=true",
+		"--add-dir", gitDir,
+		"-c", `developer_instructions="lessons here"`,
+		"do the thing",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("buildArgs() = %#v\nwant %#v", args, want)
+	}
+}
+
+func TestBuildArgsAddsLinkedWorktreeGitDirs(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, "..", "repo", ".git", "worktrees", "issue-2")
+	commonDir := filepath.Join(dir, "..", "repo", ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(commonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: "+gitDir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	args := buildArgs(runtime.Invocation{Workspace: runtime.Workspace{Dir: dir}, Prompt: "p"})
+	got := strings.Join(args, "\x00")
+	for _, want := range []string{filepath.Clean(gitDir), filepath.Clean(commonDir)} {
+		if !strings.Contains(got, "--add-dir\x00"+want) {
+			t.Errorf("args missing --add-dir %q: %#v", want, args)
+		}
+	}
+}
+
+func TestBuildArgs_OmitsWorkspaceAndSystemPrompt(t *testing.T) {
+	args := buildArgs(runtime.Invocation{Prompt: "p"})
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--cd") {
+		t.Errorf("empty workspace should not emit --cd: %v", args)
+	}
+	if strings.Contains(joined, "developer_instructions") {
+		t.Errorf("empty SystemPrompt should not emit config: %v", args)
+	}
+	if args[len(args)-1] != "p" {
+		t.Errorf("prompt should be last: %v", args)
+	}
+}
+
+func TestRunUsesExecCommandShape(t *testing.T) {
+	var gotArgs []string
+	var gotWorkDir string
+	var gotEnv map[string]string
+	var gotLog string
+
+	r := New()
+	r.execFunc = func(_ context.Context, args []string, workDir string, env map[string]string, _ runtime.Limits, _ runtime.EventSink, logFile io.Writer) (int, error) {
+		gotArgs = append([]string(nil), args...)
+		gotWorkDir = workDir
+		gotEnv = env
+		_, _ = logFile.Write([]byte(`{"type":"thread.started"}` + "\n"))
+		return 0, nil
+	}
+
+	var log bytes.Buffer
+	exitCode, err := r.Run(context.Background(), runtime.Invocation{
+		Workspace: runtime.Workspace{Dir: "/tmp/worktree"},
+		Prompt:    "ship it",
+		Env:       map[string]string{"GITHUB_TOKEN": "token"},
+	}, nil, &log)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0", exitCode)
+	}
+	if gotWorkDir != "/tmp/worktree" {
+		t.Errorf("workDir = %q, want /tmp/worktree", gotWorkDir)
+	}
+	if gotEnv["GITHUB_TOKEN"] != "token" {
+		t.Errorf("env not passed through: %v", gotEnv)
+	}
+	if gotLog = log.String(); gotLog == "" {
+		t.Error("expected fake exec to write log output")
+	}
+
+	joined := strings.Join(gotArgs, " ")
+	for _, want := range []string{"--ask-for-approval never", "exec", "--json", "--cd /tmp/worktree", "--sandbox workspace-write", "sandbox_workspace_write.network_access=true", "ship it"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q: %v", want, gotArgs)
+		}
+	}
+}
+
+func TestResumeUsesExecResume(t *testing.T) {
+	var gotArgs []string
+	r := New()
+	r.execFunc = func(_ context.Context, args []string, _ string, _ map[string]string, _ runtime.Limits, _ runtime.EventSink, _ io.Writer) (int, error) {
+		gotArgs = append([]string(nil), args...)
+		return 0, nil
+	}
+
+	if _, err := r.Resume(context.Background(), "thread-123", nil, nil); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	want := []string{"exec", "resume", "thread-123", "--json"}
+	if !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("Resume args = %#v, want %#v", gotArgs, want)
+	}
+}
+
+func TestResumeEmptySessionID(t *testing.T) {
+	if _, err := New().Resume(context.Background(), "", nil, nil); err == nil {
+		t.Fatal("expected error for empty session id")
+	}
+}
+
+func TestParseResultSuccess(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "codex.jsonl")
+	lines := []string{
+		`{"type":"thread.started","thread_id":"thread-1","model":"gpt-5.4-mini"}`,
+		`{"type":"item.completed","item":{"type":"agent_message","text":"all done"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":1000000,"cached_input_tokens":100000,"output_tokens":100000}}`,
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := New().ParseResult(logPath)
+	if err != nil {
+		t.Fatalf("ParseResult: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if got.SessionID != "thread-1" {
+		t.Errorf("SessionID = %q, want thread-1", got.SessionID)
+	}
+	if got.NumTurns != 1 {
+		t.Errorf("NumTurns = %d, want 1", got.NumTurns)
+	}
+	if got.FinalText != "all done" {
+		t.Errorf("FinalText = %q, want all done", got.FinalText)
+	}
+	if got.IsError {
+		t.Error("IsError = true, want false")
+	}
+	if got.TotalCostUSD != 1.1325 {
+		t.Errorf("TotalCostUSD = %.4f, want 1.1325", got.TotalCostUSD)
+	}
+	if len(got.Native) == 0 {
+		t.Error("Native raw is empty")
+	}
+}
+
+func TestParseResultErrorEvent(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "codex.jsonl")
+	if err := os.WriteFile(logPath, []byte(`{"type":"turn.failed","error":{"message":"boom"}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := New().ParseResult(logPath)
+	if err != nil {
+		t.Fatalf("ParseResult: %v", err)
+	}
+	if got == nil || !got.IsError {
+		t.Fatalf("expected error result, got %+v", got)
+	}
+	if !strings.Contains(got.StopReason, "boom") {
+		t.Errorf("StopReason = %q, want boom", got.StopReason)
+	}
+}
+
+func TestParseResultEmptyPathReturnsNil(t *testing.T) {
+	got, err := New().ParseResult("")
+	if err != nil || got != nil {
+		t.Errorf("ParseResult(\"\") = (%v, %v), want (nil, nil)", got, err)
+	}
+}
+
+func TestClassifyOutcome(t *testing.T) {
+	r := New()
+	tests := []struct {
+		name   string
+		result *runtime.Result
+		limits runtime.Limits
+		want   runtime.Outcome
+	}{
+		{
+			name:   "nil",
+			result: nil,
+			want:   runtime.Outcome{},
+		},
+		{
+			name:   "ok",
+			result: &runtime.Result{NumTurns: 1, TotalCostUSD: 0.01},
+			limits: runtime.Limits{MaxTurns: 10, MaxBudgetUSD: 1},
+			want:   runtime.Outcome{},
+		},
+		{
+			name:   "max turns",
+			result: &runtime.Result{NumTurns: 10},
+			limits: runtime.Limits{MaxTurns: 10},
+			want:   runtime.Outcome{Status: "failed", FailureReason: "max_turns", FailureDetail: "used 10 of 10 turns"},
+		},
+		{
+			name:   "max budget",
+			result: &runtime.Result{TotalCostUSD: 0.95},
+			limits: runtime.Limits{MaxBudgetUSD: 1},
+			want:   runtime.Outcome{Status: "failed", FailureReason: "max_budget", FailureDetail: "spent $0.95 of $1.00 budget"},
+		},
+		{
+			name:   "error",
+			result: &runtime.Result{IsError: true, StopReason: "turn.failed: boom"},
+			want:   runtime.Outcome{Status: "failed", FailureReason: "error", FailureDetail: "turn.failed: boom"},
+		},
+		{
+			name:   "usage limit",
+			result: &runtime.Result{IsError: true, StopReason: "turn.failed: rate limit exceeded"},
+			want:   runtime.Outcome{Status: "failed", FailureReason: "usage_limit", FailureDetail: "turn.failed: rate limit exceeded"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.ClassifyOutcome(tt.result, tt.limits)
+			if got != tt.want {
+				t.Errorf("got %+v\nwant %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractBailReport(t *testing.T) {
+	bailJSON := `{"reason":"too large","files_examined":["a.go"],"plan":"split into smaller issues","complexity":"large"}`
+	finalText := "cannot finish\n<bail-report>\n" + bailJSON + "\n</bail-report>"
+
+	rep := New().ExtractBailReport(&runtime.Result{FinalText: finalText}, "")
+	if rep == nil {
+		t.Fatal("expected report")
+	}
+	if rep.Reason != "too large" {
+		t.Errorf("Reason = %q, want too large", rep.Reason)
+	}
+	if rep.Detail != "split into smaller issues" {
+		t.Errorf("Detail = %q", rep.Detail)
+	}
+}
+
+func TestExtractBailReportLogFallback(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "codex.jsonl")
+	finalText := `<bail-report>{"reason":"blocked","files_examined":[],"plan":"ask human","complexity":"small"}</bail-report>`
+	line := `{"type":"item.completed","item":{"type":"agent_message","text":` + encodeJSONString(t, finalText) + `}}`
+	if err := os.WriteFile(logPath, []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rep := New().ExtractBailReport(&runtime.Result{}, logPath)
+	if rep == nil {
+		t.Fatal("expected fallback report")
+	}
+	if rep.Reason != "blocked" {
+		t.Errorf("Reason = %q, want blocked", rep.Reason)
+	}
+}
+
+func encodeJSONString(t *testing.T, s string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(buf.String())
+}

--- a/internal/runtime/codex/pricing.go
+++ b/internal/runtime/codex/pricing.go
@@ -1,0 +1,52 @@
+package codex
+
+import "strings"
+
+// ModelPricing records approximate per-token model rates.
+//
+// Pricing must be updated manually when OpenAI changes published rates. Last
+// verified: 2026-06-23.
+//
+// Sources:
+//   - https://openai.com/api/pricing/
+//   - https://developers.openai.com/codex/pricing/
+//
+// OpenAI's Codex pricing page says API-key Codex usage is charged based on API
+// pricing, while Codex plan credits use the same per-token rates. Unknown models
+// conservatively use the highest known rate in this table.
+type ModelPricing struct {
+	InputPerMTok       float64
+	CachedInputPerMTok float64
+	OutputPerMTok      float64
+}
+
+var modelPricing = map[string]ModelPricing{
+	// GPT-5.5: input $5.00 / 1M, cached input $0.50 / 1M, output $30.00 / 1M.
+	"gpt-5.5": {InputPerMTok: 5.00, CachedInputPerMTok: 0.50, OutputPerMTok: 30.00},
+	// GPT-5.4: input $2.50 / 1M, cached input $0.25 / 1M, output $15.00 / 1M.
+	"gpt-5.4": {InputPerMTok: 2.50, CachedInputPerMTok: 0.25, OutputPerMTok: 15.00},
+	// GPT-5.4 mini: input $0.75 / 1M, cached input $0.075 / 1M, output $4.50 / 1M.
+	"gpt-5.4-mini": {InputPerMTok: 0.75, CachedInputPerMTok: 0.075, OutputPerMTok: 4.50},
+	"gpt-5.4 mini": {InputPerMTok: 0.75, CachedInputPerMTok: 0.075, OutputPerMTok: 4.50},
+}
+
+var unknownModelPricing = ModelPricing{InputPerMTok: 5.00, CachedInputPerMTok: 0.50, OutputPerMTok: 30.00}
+
+func pricingForModel(model string) ModelPricing {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if p, ok := modelPricing[model]; ok {
+		return p
+	}
+	return unknownModelPricing
+}
+
+func estimateCostUSD(model string, inputTokens, cachedInputTokens, outputTokens int) float64 {
+	if cachedInputTokens > inputTokens {
+		cachedInputTokens = inputTokens
+	}
+	uncachedInput := inputTokens - cachedInputTokens
+	p := pricingForModel(model)
+	return (float64(uncachedInput)*p.InputPerMTok +
+		float64(cachedInputTokens)*p.CachedInputPerMTok +
+		float64(outputTokens)*p.OutputPerMTok) / 1_000_000
+}

--- a/internal/runtime/codex/scanner.go
+++ b/internal/runtime/codex/scanner.go
@@ -1,0 +1,310 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+type codexRunState struct {
+	SessionID string
+	Model     string
+	NumTurns  int
+	FinalText string
+	InputTok  int
+	CachedTok int
+	OutputTok int
+	IsError   bool
+	ErrorText string
+	StopText  string
+	Native    json.RawMessage
+	Unknown   []string
+}
+
+type codexEvent struct {
+	Type     string          `json:"type"`
+	ThreadID string          `json:"thread_id,omitempty"`
+	Model    string          `json:"model,omitempty"`
+	Item     *codexItem      `json:"item,omitempty"`
+	Usage    *codexUsage     `json:"usage,omitempty"`
+	Error    json.RawMessage `json:"error,omitempty"`
+	Message  string          `json:"message,omitempty"`
+	Payload  json.RawMessage `json:"payload,omitempty"`
+	Seq      any             `json:"seq,omitempty"`
+}
+
+type codexItem struct {
+	Type      string          `json:"type"`
+	Name      string          `json:"name,omitempty"`
+	Text      string          `json:"text,omitempty"`
+	CallID    string          `json:"call_id,omitempty"`
+	Command   string          `json:"command,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+	Error     json.RawMessage `json:"error,omitempty"`
+}
+
+type codexUsage struct {
+	InputTokens           int `json:"input_tokens"`
+	CachedInputTokens     int `json:"cached_input_tokens"`
+	OutputTokens          int `json:"output_tokens"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens"`
+}
+
+// scanStream reads Codex JSONL lines from r, mirrors each line to logFile, and
+// pushes normalized events to sink. It also accumulates the lightweight state
+// needed for later Result synthesis.
+func scanStream(r io.Reader, logFile io.Writer, sink runtime.EventSink, state *codexRunState, limits runtime.Limits, cancel context.CancelFunc) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		mirrorLine(logFile, line)
+
+		var evt codexEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		if state != nil {
+			state.apply(evt, line)
+		}
+		emitEvent(sink, evt)
+
+		if evt.Type == "turn.completed" && state != nil && limits.MaxTurns > 0 && state.NumTurns >= limits.MaxTurns && cancel != nil {
+			cancel()
+		}
+	}
+}
+
+func mirrorLine(logFile io.Writer, line []byte) {
+	if logFile == nil {
+		return
+	}
+	_, _ = logFile.Write(line)
+	_, _ = logFile.Write([]byte("\n"))
+}
+
+func (s *codexRunState) apply(evt codexEvent, raw []byte) {
+	switch evt.Type {
+	case "thread.started":
+		if evt.ThreadID != "" {
+			s.SessionID = evt.ThreadID
+		}
+		if evt.Model != "" {
+			s.Model = evt.Model
+		}
+	case "session_meta", "turn_context":
+		if evt.ThreadID != "" {
+			s.SessionID = evt.ThreadID
+		}
+		if evt.Model != "" {
+			s.Model = evt.Model
+		}
+	case "turn.completed":
+		s.NumTurns++
+		s.StopText = "turn.completed"
+		s.Native = append(s.Native[:0], raw...)
+		if evt.Usage != nil {
+			s.InputTok += evt.Usage.InputTokens
+			s.CachedTok += evt.Usage.CachedInputTokens
+			s.OutputTok += evt.Usage.OutputTokens
+		}
+	case "turn.failed":
+		s.IsError = true
+		s.ErrorText = eventErrorText(evt)
+		s.StopText = "turn.failed: " + s.ErrorText
+		s.Native = append(s.Native[:0], raw...)
+	case "item.completed":
+		if evt.Item == nil {
+			return
+		}
+		switch evt.Item.Type {
+		case "agent_message":
+			if evt.Item.Text != "" {
+				s.FinalText = evt.Item.Text
+			}
+		case "error":
+			s.IsError = true
+			s.ErrorText = itemErrorText(evt.Item)
+		}
+	case "error":
+		s.IsError = true
+		s.ErrorText = eventErrorText(evt)
+		s.StopText = "error: " + s.ErrorText
+		s.Native = append(s.Native[:0], raw...)
+	case "event_msg":
+		if usage := usageFromPayload(evt.Payload); usage != nil {
+			s.InputTok += usage.InputTokens
+			s.CachedTok += usage.CachedInputTokens
+			s.OutputTok += usage.OutputTokens
+		}
+	default:
+		if evt.Type != "" {
+			s.Unknown = append(s.Unknown, fmt.Sprintf("%s seq=%v", evt.Type, evt.Seq))
+		}
+	}
+}
+
+func emitEvent(sink runtime.EventSink, evt codexEvent) {
+	if sink == nil {
+		return
+	}
+
+	switch evt.Type {
+	case "turn.completed":
+		sink.OnAssistantStep()
+	case "turn.failed", "error":
+		if looksLikeUsageLimit(eventErrorText(evt)) {
+			sink.OnUsageLimit()
+		}
+	case "item.started":
+		if evt.Item == nil {
+			return
+		}
+		switch evt.Item.Type {
+		case "command_execution", "file_change", "mcp_tool_call":
+			sink.OnToolStart(toolName(evt.Item), toolInputSummary(evt.Item, 80))
+		}
+	case "item.completed":
+		if evt.Item == nil {
+			return
+		}
+		switch evt.Item.Type {
+		case "agent_message":
+			sink.OnToolEnd()
+		case "error":
+			if looksLikeUsageLimit(itemErrorText(evt.Item)) {
+				sink.OnUsageLimit()
+			}
+		}
+	case "response_item":
+		if evt.Item == nil {
+			return
+		}
+		switch evt.Item.Type {
+		case "function_call", "custom_tool_call":
+			sink.OnToolStart(toolName(evt.Item), toolInputSummary(evt.Item, 80))
+		case "function_call_output", "custom_tool_call_output":
+			sink.OnToolEnd()
+		}
+	}
+}
+
+func usageFromPayload(raw json.RawMessage) *codexUsage {
+	if len(raw) == 0 {
+		return nil
+	}
+	var payload struct {
+		Type  string      `json:"type"`
+		Usage *codexUsage `json:"usage"`
+	}
+	if json.Unmarshal(raw, &payload) != nil {
+		return nil
+	}
+	if payload.Type != "token_count" {
+		return nil
+	}
+	return payload.Usage
+}
+
+func toolName(item *codexItem) string {
+	if item.Name != "" {
+		return item.Name
+	}
+	return item.Type
+}
+
+func toolInputSummary(item *codexItem, maxLen int) string {
+	for _, raw := range []json.RawMessage{item.Input, item.Arguments} {
+		if summary := rawInputSummary(raw, maxLen); summary != "" {
+			return summary
+		}
+	}
+	if item.Command != "" {
+		return truncate(item.Command, maxLen)
+	}
+	if item.CallID != "" {
+		return truncate(item.CallID, maxLen)
+	}
+	return ""
+}
+
+func rawInputSummary(raw json.RawMessage, maxLen int) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj map[string]any
+	if json.Unmarshal(raw, &obj) == nil {
+		for _, key := range []string{"command", "file_path", "pattern", "prompt", "query", "description"} {
+			if val, ok := obj[key].(string); ok && val != "" {
+				return truncate(val, maxLen)
+			}
+		}
+	}
+	return truncate(string(raw), maxLen)
+}
+
+func eventErrorText(evt codexEvent) string {
+	if evt.Message != "" {
+		return evt.Message
+	}
+	if len(evt.Error) == 0 {
+		return ""
+	}
+	var obj struct {
+		Message string `json:"message"`
+		Code    string `json:"code"`
+		Type    string `json:"type"`
+	}
+	if json.Unmarshal(evt.Error, &obj) == nil {
+		switch {
+		case obj.Message != "":
+			return obj.Message
+		case obj.Code != "":
+			return obj.Code
+		case obj.Type != "":
+			return obj.Type
+		}
+	}
+	var s string
+	if json.Unmarshal(evt.Error, &s) == nil {
+		return s
+	}
+	return string(evt.Error)
+}
+
+func itemErrorText(item *codexItem) string {
+	if item.Text != "" {
+		return item.Text
+	}
+	if len(item.Error) == 0 {
+		return ""
+	}
+	return string(item.Error)
+}
+
+func looksLikeUsageLimit(s string) bool {
+	s = strings.ToLower(s)
+	for _, marker := range []string{"rate limit", "rate_limit", "quota", "billing", "usage limit", "usage_limit", "too many requests"} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/runtime/codex/scanner_test.go
+++ b/internal/runtime/codex/scanner_test.go
@@ -1,0 +1,141 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aptx-health/agent-minder/internal/runtime"
+)
+
+type stubSink struct {
+	steps       int
+	toolStarts  []string
+	toolInputs  []string
+	toolEnds    int
+	usageLimits int
+}
+
+func (s *stubSink) OnAssistantStep() { s.steps++ }
+func (s *stubSink) OnToolStart(name, inputSummary string) {
+	s.toolStarts = append(s.toolStarts, name)
+	s.toolInputs = append(s.toolInputs, inputSummary)
+}
+func (s *stubSink) OnToolEnd()    { s.toolEnds++ }
+func (s *stubSink) OnUsageLimit() { s.usageLimits++ }
+
+func TestScanStream_NormalizesCodexEvents(t *testing.T) {
+	lines := []string{
+		`{"type":"thread.started","thread_id":"thread-1"}`,
+		`{"type":"item.started","item":{"type":"command_execution","name":"shell","input":{"command":"go test ./..."}}}`,
+		`{"type":"item.completed","item":{"type":"agent_message","text":"done"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":25}}`,
+	}
+	input := strings.Join(lines, "\n") + "\n"
+
+	var logBuf bytes.Buffer
+	sink := &stubSink{}
+	var state codexRunState
+	scanStream(strings.NewReader(input), &logBuf, sink, &state, runtime.Limits{}, nil)
+
+	if logBuf.String() != input {
+		t.Errorf("log mirror = %q, want %q", logBuf.String(), input)
+	}
+	if state.SessionID != "thread-1" {
+		t.Errorf("SessionID = %q, want thread-1", state.SessionID)
+	}
+	if state.FinalText != "done" {
+		t.Errorf("FinalText = %q, want done", state.FinalText)
+	}
+	if state.NumTurns != 1 {
+		t.Errorf("NumTurns = %d, want 1", state.NumTurns)
+	}
+	if state.InputTok != 100 || state.OutputTok != 25 {
+		t.Errorf("usage = (%d,%d), want (100,25)", state.InputTok, state.OutputTok)
+	}
+	if len(sink.toolStarts) != 1 || sink.toolStarts[0] != "shell" {
+		t.Errorf("toolStarts = %v, want [shell]", sink.toolStarts)
+	}
+	if len(sink.toolInputs) != 1 || sink.toolInputs[0] != "go test ./..." {
+		t.Errorf("toolInputs = %v, want [go test ./...]", sink.toolInputs)
+	}
+	if sink.toolEnds != 1 {
+		t.Errorf("toolEnds = %d, want 1", sink.toolEnds)
+	}
+	if sink.steps != 1 {
+		t.Errorf("steps = %d, want 1", sink.steps)
+	}
+}
+
+func TestScanStream_RecordsErrorsAndUsageLimit(t *testing.T) {
+	input := strings.Join([]string{
+		`{"type":"turn.failed","error":{"message":"rate limit exceeded"}}`,
+		`{"type":"item.completed","item":{"type":"error","text":"billing quota reached"}}`,
+	}, "\n") + "\n"
+
+	var state codexRunState
+	sink := &stubSink{}
+	scanStream(strings.NewReader(input), nil, sink, &state, runtime.Limits{}, nil)
+
+	if !state.IsError {
+		t.Fatal("expected IsError")
+	}
+	if !strings.Contains(state.ErrorText, "billing") {
+		t.Errorf("ErrorText = %q, want latest billing error", state.ErrorText)
+	}
+	if sink.usageLimits != 2 {
+		t.Errorf("usageLimits = %d, want 2", sink.usageLimits)
+	}
+}
+
+func TestScanStream_UnknownEventsArePreserved(t *testing.T) {
+	var state codexRunState
+	scanStream(strings.NewReader(`{"type":"future.event","seq":7}`+"\n"), nil, nil, &state, runtime.Limits{}, nil)
+	if len(state.Unknown) != 1 || !strings.Contains(state.Unknown[0], "future.event") {
+		t.Errorf("Unknown = %v, want future.event entry", state.Unknown)
+	}
+}
+
+func TestScanStream_CurrentCodexAliases(t *testing.T) {
+	input := strings.Join([]string{
+		`{"type":"session_meta","thread_id":"thread-2","model":"gpt-5.4"}`,
+		`{"type":"response_item","item":{"type":"custom_tool_call","name":"apply_patch","input":{"description":"edit file"}}}`,
+		`{"type":"response_item","item":{"type":"custom_tool_call_output","call_id":"call-1"}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}`,
+	}, "\n") + "\n"
+
+	var state codexRunState
+	sink := &stubSink{}
+	scanStream(strings.NewReader(input), nil, sink, &state, runtime.Limits{}, nil)
+
+	if state.SessionID != "thread-2" || state.Model != "gpt-5.4" {
+		t.Errorf("state meta = (%q,%q), want (thread-2,gpt-5.4)", state.SessionID, state.Model)
+	}
+	if state.InputTok != 10 || state.CachedTok != 2 || state.OutputTok != 3 {
+		t.Errorf("usage = (%d,%d,%d), want (10,2,3)", state.InputTok, state.CachedTok, state.OutputTok)
+	}
+	if len(sink.toolStarts) != 1 || sink.toolStarts[0] != "apply_patch" {
+		t.Errorf("toolStarts = %v, want [apply_patch]", sink.toolStarts)
+	}
+	if sink.toolEnds != 1 {
+		t.Errorf("toolEnds = %d, want 1", sink.toolEnds)
+	}
+}
+
+func TestScanStream_MaxTurnsCancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var state codexRunState
+	scanStream(strings.NewReader(`{"type":"turn.completed"}`+"\n"), nil, nil, &state, runtime.Limits{MaxTurns: 1}, cancel)
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected context to be cancelled after max turns")
+	}
+	if state.NumTurns != 1 {
+		t.Errorf("NumTurns = %d, want 1", state.NumTurns)
+	}
+}

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -11,6 +11,7 @@ import (
 // added as their adapters land.
 const (
 	NameClaudeCode = "claude-code"
+	NameCodex      = "codex"
 )
 
 // DefaultName is the runtime selected when the operator does not pass

--- a/internal/supervisor/jobmanager.go
+++ b/internal/supervisor/jobmanager.go
@@ -37,9 +37,13 @@ type JobResult struct {
 type stageResult struct {
 	success    bool              // true if stage completed successfully
 	bailed     bool              // true if agent deliberately bailed
+	manual     bool              // true if work is ready but needs human follow-up
+	failed     bool              // true if runtime/process/classifier failed
 	exhausted  bool              // true if turn/budget limit hit
 	usageLimit bool              // true if Claude Code usage/rate limit hit
 	sessionID  string            // session ID for --resume on recovery
+	reason     string            // failure reason for failed stages
+	detail     string            // failure detail for failed stages
 	prDetected int               // PR number if one was opened during this stage
 	assessment *ReviewAssessment // review assessment if this was a review stage
 }
@@ -57,6 +61,7 @@ type TestHooks struct {
 	SetupWorktreeFn           func() error
 	EnsureAgentDefFn          func(name AgentName) (AgentDefSource, error)
 	ExtractReviewAssessmentFn func(ctx context.Context, logPath string, job *db.Job) ReviewAssessment
+	CreateReviewCommentFn     func(ctx context.Context, prNumber int, body string) (int64, error)
 }
 
 // SlotContext provides primitives that job managers use to interact
@@ -143,7 +148,20 @@ func (sc *SlotContext) EnsureAgentDef(name AgentName) (AgentDefSource, error) {
 	if sc.Hooks != nil && sc.Hooks.EnsureAgentDefFn != nil {
 		return sc.Hooks.EnsureAgentDefFn(name)
 	}
-	return ensureAgentDefByName(sc.WorktreePath, name)
+	source, body, err := resolveAgentDefByName(sc.WorktreePath, name)
+	if err != nil {
+		return "", err
+	}
+	if rt := sc.sup.Runtime(); rt != nil {
+		if err := rt.PrepareAgentDef(context.Background(), runtimepkg.Workspace{Dir: sc.WorktreePath}, runtimepkg.AgentDefinition{
+			Name:   string(name),
+			Source: source.Description(),
+			Body:   body,
+		}); err != nil {
+			return "", err
+		}
+	}
+	return source, nil
 }
 
 // OpenLogFile opens (or creates) the agent log file.
@@ -514,14 +532,22 @@ func (m *DefaultJobManager) Run(ctx context.Context) error {
 
 			// Exhausted retries — still hitting limit.
 			if result.usageLimit {
-				sc.EmitEvent("error", fmt.Sprintf("Usage limit: exhausted %d retries on %s, bailing",
+				sc.EmitEvent("error", fmt.Sprintf("Usage limit: exhausted %d retries on %s, failing",
 					maxUsageLimitRetries, sc.JobLabel()))
-				return m.finalizeBail(ctx)
+				return m.finalizeFailure(ctx, "usage_limit", fmt.Sprintf("exhausted %d usage-limit retries", maxUsageLimitRetries))
 			}
 		}
 
 		if result.success {
 			continue // next stage
+		}
+
+		if result.manual {
+			return m.finalizeManual(ctx, result.reason, result.detail)
+		}
+
+		if result.failed {
+			return m.finalizeFailure(ctx, result.reason, result.detail)
 		}
 
 		// Stage failed — handle on_failure.
@@ -597,12 +623,21 @@ func (m *DefaultJobManager) executeCodeStage(ctx context.Context, stage StageCon
 	}
 
 	inv := runtimeInvocationFor(sc, agentName, prompt, lessonsPrompt)
-	exitCode, runResult, sink, _ := sc.runStageThroughRuntime(ctx, inv, logFile)
+	exitCode, runResult, sink, runErr := sc.runStageThroughRuntime(ctx, inv, logFile)
 	result := adaptRuntimeResult(runResult)
 	usageLimit := sink.usageLimit || sc.HitUsageLimit() || isUsageLimitError(result)
 	sessionID := ""
 	if runResult != nil {
 		sessionID = runResult.SessionID
+	}
+
+	if runErr != nil {
+		return stageResult{
+			success: false,
+			failed:  true,
+			reason:  "runtime_error",
+			detail:  runErr.Error(),
+		}
 	}
 
 	if usageLimit {
@@ -630,13 +665,74 @@ func (m *DefaultJobManager) executeCodeStage(ctx context.Context, stage StageCon
 		outcome = rt.ClassifyOutcome(runResult, runtimepkg.Limits{MaxTurns: maxTurns, MaxBudgetUSD: maxBudget})
 		bailReport = rt.ExtractBailReport(runResult, sc.LogPath)
 	}
-	m.handleBailReport(ctx, bailReport)
-
-	return stageResult{
-		success:   false,
-		bailed:    outcome.Status == "failed" || bailReport != nil,
-		exhausted: outcome.Status == "failed" && result != nil && (result.NumTurns >= maxTurns || result.TotalCost >= maxBudget*0.95),
+	if bailReport != nil {
+		m.handleBailReport(ctx, bailReport)
+		return stageResult{
+			success: false,
+			bailed:  true,
+		}
 	}
+
+	if outcome.Status == "failed" {
+		return stageResult{
+			success:   false,
+			failed:    true,
+			exhausted: outcome.FailureReason == "max_turns" || outcome.FailureReason == "max_budget",
+			reason:    outcome.FailureReason,
+			detail:    outcome.FailureDetail,
+		}
+	}
+
+	if exitCode != 0 {
+		return stageResult{
+			success: false,
+			failed:  true,
+			reason:  "process_exit",
+			detail:  fmt.Sprintf("agent process exited with code %d before producing a successful result", exitCode),
+		}
+	}
+
+	detail := "agent exited successfully but did not open a PR"
+	if runResult != nil && strings.TrimSpace(runResult.FinalText) != "" {
+		detail = truncateFailureDetail(runResult.FinalText, 2000)
+	}
+	if branchPushed(sc.WorktreePath) {
+		return stageResult{
+			success: false,
+			manual:  true,
+			reason:  "pr_required",
+			detail:  detail,
+		}
+	}
+	return stageResult{
+		success: false,
+		failed:  true,
+		reason:  "no_pr",
+		detail:  detail,
+	}
+}
+
+func branchPushed(worktreePath string) bool {
+	current, err := gitpkg.CurrentBranch(worktreePath)
+	if err != nil || current == "" || current == "HEAD" {
+		return false
+	}
+	upstream, err := gitpkg.UpstreamBranch(worktreePath)
+	if err != nil {
+		return false
+	}
+	return upstream == "origin/"+current || strings.HasSuffix(upstream, "/"+current)
+}
+
+func truncateFailureDetail(s string, maxLen int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
 }
 
 // usageLimitWaitDuration is how long to sleep before retrying after a usage
@@ -744,7 +840,23 @@ func (m *DefaultJobManager) executeReviewStage(ctx context.Context, stage StageC
 		risk = "needs-testing"
 	}
 
-	_ = sc.Store.UpdateJobReview(job.ID, risk, 0)
+	reviewCommentID := int64(0)
+	commentBody := formatReviewComment(assessment)
+	var commentID int64
+	var err error
+	if sc.Hooks != nil && sc.Hooks.CreateReviewCommentFn != nil {
+		commentID, err = sc.Hooks.CreateReviewCommentFn(ctx, int(job.PRNumber.Int64), commentBody)
+	} else {
+		ghClient := sc.NewGHClient()
+		commentID, err = ghClient.CreateComment(ctx, sc.Owner, sc.Repo, int(job.PRNumber.Int64), commentBody)
+	}
+	if err != nil {
+		sc.EmitEvent("warning", fmt.Sprintf("Review comment failed for %s PR #%d: %v", sc.JobLabel(), job.PRNumber.Int64, err))
+	} else {
+		reviewCommentID = commentID
+	}
+
+	_ = sc.Store.UpdateJobReview(job.ID, risk, reviewCommentID)
 
 	sc.EmitEvent("info", fmt.Sprintf("Review of %s complete (risk: %s)", sc.JobLabel(), risk))
 	if assessment.Summary != "" {
@@ -846,6 +958,58 @@ func (m *DefaultJobManager) finalizeBail(ctx context.Context) error {
 		_ = sc.Store.CompleteJob(job.ID, db.StatusBailed)
 	}
 	sc.EmitEvent("bailed", fmt.Sprintf("Agent bailed on %s", sc.JobLabel()))
+	sc.RecordLessonOutcome(false)
+
+	return nil
+}
+
+// finalizeFailure handles runtime/process failures that are not deliberate
+// structured agent bails.
+func (m *DefaultJobManager) finalizeFailure(ctx context.Context, reason, detail string) error {
+	sc := m.sc
+	job := sc.Job
+	ghClient := sc.NewGHClient()
+
+	if job.IssueNumber > 0 {
+		ghClient.RemoveLabel(ctx, sc.Owner, sc.Repo, job.IssueNumber, "in-progress")
+	}
+
+	if reason == "" {
+		reason = "failed"
+	}
+	if detail == "" {
+		detail = "agent failed without additional detail"
+	}
+
+	_ = sc.Store.UpdateJobFailure(job.ID, reason, detail)
+	_ = sc.Store.CompleteJob(job.ID, db.StatusFailed)
+	sc.EmitEvent("error", fmt.Sprintf("Agent failed on %s: %s", sc.JobLabel(), detail))
+	sc.RecordLessonOutcome(false)
+
+	return nil
+}
+
+// finalizeManual handles runs where the agent completed local work and pushed a
+// branch, but a human/token action is required to finish publication.
+func (m *DefaultJobManager) finalizeManual(ctx context.Context, reason, detail string) error {
+	sc := m.sc
+	job := sc.Job
+	ghClient := sc.NewGHClient()
+
+	if job.IssueNumber > 0 {
+		ghClient.RemoveLabel(ctx, sc.Owner, sc.Repo, job.IssueNumber, "in-progress")
+	}
+
+	if reason == "" {
+		reason = "manual"
+	}
+	if detail == "" {
+		detail = "agent completed work but manual follow-up is required"
+	}
+
+	_ = sc.Store.UpdateJobFailure(job.ID, reason, detail)
+	_ = sc.Store.CompleteJob(job.ID, db.StatusManual)
+	sc.EmitEvent("manual", fmt.Sprintf("Agent needs manual follow-up on %s: %s", sc.JobLabel(), detail))
 	sc.RecordLessonOutcome(false)
 
 	return nil

--- a/internal/supervisor/pipeline_test.go
+++ b/internal/supervisor/pipeline_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -131,6 +132,9 @@ func newHarness(t *testing.T, opts ...func(*db.Deployment)) *pipelineHarness {
 		ExtractReviewAssessmentFn: func(ctx context.Context, logPath string, job *db.Job) ReviewAssessment {
 			return ReviewAssessment{Risk: "low-risk", Summary: "All good"}
 		},
+		CreateReviewCommentFn: func(ctx context.Context, prNumber int, body string) (int64, error) {
+			return 9001, nil
+		},
 	}
 
 	return h
@@ -215,7 +219,14 @@ func TestPipeline_CodeThenReview(t *testing.T) {
 
 	// Mock: review returns low-risk.
 	h.hooks.ExtractReviewAssessmentFn = func(ctx context.Context, logPath string, job *db.Job) ReviewAssessment {
-		return ReviewAssessment{Risk: "low-risk", Summary: "Clean PR"}
+		return ReviewAssessment{Risk: "low-risk", Summary: "Clean PR", Lessons: []string{"Keep tests focused"}}
+	}
+	var reviewCommentPR int
+	var reviewCommentBody string
+	h.hooks.CreateReviewCommentFn = func(ctx context.Context, prNumber int, body string) (int64, error) {
+		reviewCommentPR = prNumber
+		reviewCommentBody = body
+		return 12345, nil
 	}
 
 	job := testJob(t, h.store, h.deploy)
@@ -249,9 +260,18 @@ func TestPipeline_CodeThenReview(t *testing.T) {
 	if !updated.ReviewRisk.Valid || updated.ReviewRisk.String != "low-risk" {
 		t.Errorf("expected review_risk 'low-risk', got %v", updated.ReviewRisk)
 	}
+	if !updated.ReviewCommentID.Valid || updated.ReviewCommentID.Int64 != 12345 {
+		t.Errorf("expected review_comment_id 12345, got %v", updated.ReviewCommentID)
+	}
 	// Status should be "reviewed" (pipeline finalized with PR).
 	if updated.Status != db.StatusReviewed {
 		t.Errorf("expected status %q, got %q", db.StatusReviewed, updated.Status)
+	}
+	if reviewCommentPR != 100 {
+		t.Errorf("review comment PR = %d, want 100", reviewCommentPR)
+	}
+	if !strContains(reviewCommentBody, "**Risk:** `low-risk`") || !strContains(reviewCommentBody, "Clean PR") || !strContains(reviewCommentBody, "Keep tests focused") {
+		t.Errorf("review comment body missing expected content: %s", reviewCommentBody)
 	}
 
 	// Verify events include review stage starting.
@@ -330,6 +350,90 @@ func TestPipeline_CodeBailsNoReview(t *testing.T) {
 		// finalizeBail sets failure; if log is empty classifyOutcome returns empty strings,
 		// but the DB update still happens.
 		t.Logf("Note: failure_reason not set (expected when log is empty)")
+	}
+}
+
+func TestPipeline_PushedBranchWithoutPRNeedsManualFollowUp(t *testing.T) {
+	repo := initPushedBranchRepo(t, "agent/issue-2")
+	h := newHarness(t, func(d *db.Deployment) {
+		d.RepoDir = repo
+		d.ReviewEnabled = false
+	})
+
+	h.hooks.RunStageFn = func(ctx context.Context, inv runtimepkg.Invocation, logFile *os.File) (int, *runtimepkg.Result, bool, error) {
+		h.mu.Lock()
+		h.stageLog = append(h.stageLog, stageCall{Agent: inv.AgentName, Inv: inv})
+		h.mu.Unlock()
+		return 0, &runtimepkg.Result{FinalText: "Implemented and pushed. PR creation requires token permissions."}, false, nil
+	}
+	h.hooks.DetectPRFn = func(ctx context.Context) int { return 0 }
+
+	job := testJob(t, h.store, h.deploy, func(j *db.Job) {
+		j.IssueNumber = 2
+		j.Name = "issue-2"
+	})
+	contract := &AgentContract{
+		Name:   "autopilot",
+		Output: "pr",
+		Stages: []StageContract{{Name: "run", Agent: "autopilot"}},
+	}
+
+	if err := h.run(context.Background(), job, contract); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	updated, err := h.store.GetJob(job.ID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if updated.Status != db.StatusManual {
+		t.Fatalf("status = %q, want %q", updated.Status, db.StatusManual)
+	}
+	if !updated.FailureReason.Valid || updated.FailureReason.String != "pr_required" {
+		t.Errorf("failure_reason = %+v, want pr_required", updated.FailureReason)
+	}
+	if !updated.FailureDetail.Valid || !strContains(updated.FailureDetail.String, "token permissions") {
+		t.Errorf("failure_detail = %+v, want final message", updated.FailureDetail)
+	}
+	if !hasEvent(h.events(), "manual", "manual follow-up") {
+		t.Errorf("expected manual event, got %+v", h.events())
+	}
+}
+
+func initPushedBranchRepo(t *testing.T, branch string) string {
+	t.Helper()
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	repo := filepath.Join(root, "repo")
+	runGitCmd(t, root, "init", "--bare", origin)
+	runGitCmd(t, root, "init", repo)
+	runGitCmd(t, repo, "config", "user.email", "test@example.com")
+	runGitCmd(t, repo, "config", "user.name", "Test User")
+	runGitCmd(t, repo, "remote", "add", "origin", origin)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitCmd(t, repo, "add", "README.md")
+	runGitCmd(t, repo, "commit", "-m", "initial")
+	runGitCmd(t, repo, "branch", "-M", "main")
+	runGitCmd(t, repo, "push", "-u", "origin", "main")
+	runGitCmd(t, repo, "switch", "-c", branch)
+	if err := os.WriteFile(filepath.Join(repo, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitCmd(t, repo, "add", "feature.txt")
+	runGitCmd(t, repo, "commit", "-m", "feature")
+	runGitCmd(t, repo, "push", "-u", "origin", branch)
+	return repo
+}
+
+func runGitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
 }
 

--- a/internal/supervisor/prompt.go
+++ b/internal/supervisor/prompt.go
@@ -180,29 +180,46 @@ func ensureAgentDef(worktreePath string) (AgentDefSource, error) {
 }
 
 func ensureAgentDefByName(worktreePath string, name AgentName) (AgentDefSource, error) {
+	source, _, err := resolveAgentDefByName(worktreePath, name)
+	return source, err
+}
+
+func resolveAgentDefByName(worktreePath string, name AgentName) (AgentDefSource, []byte, error) {
 	filename := string(name) + ".md"
 
 	// Check repo-level.
 	repoPath := filepath.Join(worktreePath, ".claude", "agents", filename)
 	if _, err := os.Stat(repoPath); err == nil {
-		return AgentDefRepo, nil
+		body, err := os.ReadFile(repoPath)
+		if err != nil {
+			return "", nil, err
+		}
+		return AgentDefRepo, body, nil
 	}
 
 	// Check user-level.
 	home, _ := os.UserHomeDir()
 	userPath := filepath.Join(home, ".claude", "agents", filename)
 	if _, err := os.Stat(userPath); err == nil {
-		return AgentDefUser, nil
+		body, err := os.ReadFile(userPath)
+		if err != nil {
+			return "", nil, err
+		}
+		return AgentDefUser, body, nil
 	}
 
 	// Install from template registry, falling back to built-in constants.
 	for _, tmpl := range AgentTemplates() {
 		if tmpl.Name == string(name) {
-			_, err := InstallAgentDef(worktreePath, tmpl)
+			path, err := InstallAgentDef(worktreePath, tmpl)
 			if err != nil {
-				return "", err
+				return "", nil, err
 			}
-			return AgentDefBuiltIn, nil
+			body, err := os.ReadFile(path)
+			if err != nil {
+				return "", nil, err
+			}
+			return AgentDefBuiltIn, body, nil
 		}
 	}
 
@@ -213,12 +230,13 @@ func ensureAgentDefByName(worktreePath string, name AgentName) (AgentDefSource, 
 	}
 	dir := filepath.Join(worktreePath, ".claude", "agents")
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", fmt.Errorf("create agent dir: %w", err)
+		return "", nil, fmt.Errorf("create agent dir: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, filename), []byte(def), 0644); err != nil {
-		return "", fmt.Errorf("write agent def: %w", err)
+	body := []byte(def)
+	if err := os.WriteFile(filepath.Join(dir, filename), body, 0644); err != nil {
+		return "", nil, fmt.Errorf("write agent def: %w", err)
 	}
-	return AgentDefBuiltIn, nil
+	return AgentDefBuiltIn, body, nil
 }
 
 // resolveBaseBranch determines the base branch from onboarding.yaml, deploy config, or git default.

--- a/internal/supervisor/resume_test.go
+++ b/internal/supervisor/resume_test.go
@@ -109,8 +109,8 @@ func TestResume_ResumedSessionAlsoHitsLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetJob: %v", err)
 	}
-	if updated.Status != db.StatusBailed {
-		t.Errorf("status = %q, want %q after exhausting usage-limit retries", updated.Status, db.StatusBailed)
+	if updated.Status != db.StatusFailed {
+		t.Errorf("status = %q, want %q after exhausting usage-limit retries", updated.Status, db.StatusFailed)
 	}
 
 	// Supervisor should have emitted the "exhausted N retries" error event.

--- a/internal/supervisor/review.go
+++ b/internal/supervisor/review.go
@@ -29,6 +29,42 @@ type LessonFeedback struct {
 	Reason  string `json:"reason"`  // Brief explanation
 }
 
+func formatReviewComment(assessment ReviewAssessment) string {
+	var b strings.Builder
+	risk := assessment.Risk
+	if risk == "" {
+		risk = "needs-testing"
+	}
+	summary := assessment.Summary
+	if summary == "" {
+		summary = "Review completed."
+	}
+
+	fmt.Fprintf(&b, "## Agent Review\n\n")
+	fmt.Fprintf(&b, "**Risk:** `%s`\n\n", risk)
+	fmt.Fprintf(&b, "%s\n", summary)
+
+	if len(assessment.Issues) > 0 {
+		fmt.Fprintf(&b, "\n### Issues\n")
+		for _, issue := range assessment.Issues {
+			if strings.TrimSpace(issue) != "" {
+				fmt.Fprintf(&b, "- %s\n", issue)
+			}
+		}
+	}
+
+	if len(assessment.Lessons) > 0 {
+		fmt.Fprintf(&b, "\n### Lessons Captured\n")
+		for _, lesson := range assessment.Lessons {
+			if strings.TrimSpace(lesson) != "" {
+				fmt.Fprintf(&b, "- %s\n", lesson)
+			}
+		}
+	}
+
+	return b.String()
+}
+
 var reviewAssessmentSchema = `{
 	"type": "object",
 	"properties": {

--- a/internal/supervisor/runtime_test.go
+++ b/internal/supervisor/runtime_test.go
@@ -15,13 +15,19 @@ import (
 // DefaultJobManager drives stages through the runtime contract and that
 // EventSink events surface as live status updates.
 type fakeRuntime struct {
-	runCalled int
-	lastInv   runtimepkg.Invocation
+	runCalled     int
+	prepareCalled int
+	lastInv       runtimepkg.Invocation
+	lastDef       runtimepkg.AgentDefinition
+	lastWorkspace runtimepkg.Workspace
 }
 
 func (f *fakeRuntime) Name() string { return "fake" }
 
-func (f *fakeRuntime) PrepareAgentDef(_ context.Context, _ runtimepkg.Workspace, _ runtimepkg.AgentDefinition) error {
+func (f *fakeRuntime) PrepareAgentDef(_ context.Context, ws runtimepkg.Workspace, def runtimepkg.AgentDefinition) error {
+	f.prepareCalled++
+	f.lastWorkspace = ws
+	f.lastDef = def
 	return nil
 }
 
@@ -58,6 +64,49 @@ func (f *fakeRuntime) ClassifyOutcome(_ *runtimepkg.Result, _ runtimepkg.Limits)
 
 func (f *fakeRuntime) ExtractBailReport(_ *runtimepkg.Result, _ string) *runtimepkg.BailReport {
 	return nil
+}
+
+func TestEnsureAgentDefPreparesRuntimeDefinition(t *testing.T) {
+	store := testStore(t)
+	deploy := testDeployment(t, store)
+	job := testJob(t, store, deploy)
+
+	sup := NewTestSupervisor(store, deploy, deploy.RepoDir)
+	rt := &fakeRuntime{}
+	sup.SetRuntime(rt)
+
+	worktree := t.TempDir()
+	agentsDir := filepath.Join(worktree, ".claude", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("---\nname: autopilot\n---\nrepo contract")
+	if err := os.WriteFile(filepath.Join(agentsDir, "autopilot.md"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sc := sup.newSlotContext(job.ID, job)
+	sc.WorktreePath = worktree
+
+	source, err := sc.EnsureAgentDef(AgentAutopilot)
+	if err != nil {
+		t.Fatalf("EnsureAgentDef: %v", err)
+	}
+	if source != AgentDefRepo {
+		t.Errorf("source = %q, want %q", source, AgentDefRepo)
+	}
+	if rt.prepareCalled != 1 {
+		t.Fatalf("PrepareAgentDef calls = %d, want 1", rt.prepareCalled)
+	}
+	if rt.lastWorkspace.Dir != worktree {
+		t.Errorf("workspace = %q, want %q", rt.lastWorkspace.Dir, worktree)
+	}
+	if rt.lastDef.Name != "autopilot" {
+		t.Errorf("def name = %q, want autopilot", rt.lastDef.Name)
+	}
+	if string(rt.lastDef.Body) != string(body) {
+		t.Errorf("def body = %q, want %q", rt.lastDef.Body, body)
+	}
 }
 
 // TestExecuteCodeStage_RuntimeLiveStatus exercises executeCodeStage through a

--- a/internal/supervisor/scenario_test.go
+++ b/internal/supervisor/scenario_test.go
@@ -329,7 +329,7 @@ func TestScenarios(t *testing.T) {
 			TotalCostUSD:        0.20,
 			DetectedPR:          0,
 			FinalText:           "Out of turns.",
-			WantStatus:          db.StatusBailed,
+			WantStatus:          db.StatusFailed,
 			WantFailureReason:   "max_turns",
 			WantFailureDetailIn: "50",
 		},


### PR DESCRIPTION
## Summary
- add a Codex-backed doer runtime and wire it into deploy/runtime selection
- persist deployment runtime and surface per-job runtime in status output
- improve supervisor handling for Codex outcomes, manual PR follow-up, and review comments
- render Codex JSONL logs in checkout/log views

## Verification
- GOCACHE=/private/tmp/agent-minder-go-cache go test ./...
- pre-push: go test ./internal/supervisor/... -run TestScenarios -count=1 -timeout 2m

## Manual Testing
- ran Codex against news-aggregator issue #2 through deploy, PR creation, review, status, checkout, and logs
- confirmed review comments post with a suitable GitHub token
- confirmed checkout log view now shows full Codex execution details